### PR TITLE
feat: interactive statistics dashboard

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import authRoutes from './routes/auth.js';
 import searchRoutes from './routes/search.js';
 import usersRoutes from './routes/users.js';
+import statsRoutes from './routes/stats.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -45,6 +46,7 @@ app.set('trust proxy', 1);
 app.use('/api/auth', authRoutes);
 app.use('/api/search', searchRoutes);
 app.use('/api/users', usersRoutes);
+app.use('/api/stats', statsRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {


### PR DESCRIPTION
## Summary
- expose statistics API on the backend
- implement chart-based admin dashboard with search logs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68ac25c60f148326a776c126776a4dc8