### PR TITLE
Log search type and expose type stats

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -62,6 +62,7 @@ class DatabaseManager {
           user_id INT,
           username VARCHAR(255),
           search_term TEXT,
+          search_type VARCHAR(50),
           tables_searched TEXT,
           results_count INT DEFAULT 0,
           execution_time_ms INT DEFAULT 0,

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -19,7 +19,7 @@ router.post('/', authenticate, searchLimiter, async (req, res) => {
     console.log('🔍 POST /api/search - Nouvelle recherche');
     console.log('📥 Body reçu:', req.body);
     
-    const { query, filters = {}, page = 1, limit = 20 } = req.body;
+    const { query, filters = {}, page = 1, limit = 20, search_type = 'global' } = req.body;
 
     if (!query || query.trim().length === 0) {
       return res.status(400).json({ 
@@ -45,7 +45,8 @@ router.post('/', authenticate, searchLimiter, async (req, res) => {
       filters,
       parseInt(page),
       parseInt(limit),
-      req.user
+      req.user,
+      search_type
     );
 
     console.log('✅ Recherche terminée, envoi des résultats');

--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -6,7 +6,14 @@ class SearchService {
     this.catalog = tablesCatalog;
   }
 
-  async search(query, filters = {}, page = 1, limit = 20, user = null) {
+  async search(
+    query,
+    filters = {},
+    page = 1,
+    limit = 20,
+    user = null,
+    searchType = 'global'
+  ) {
     const startTime = Date.now();
     const results = [];
     const tablesSearched = [];
@@ -51,6 +58,7 @@ class SearchService {
         user_id: user.id,
         username: user.login,
         search_term: query,
+        search_type: searchType,
         filters: JSON.stringify(filters),
         tables_searched: JSON.stringify(tablesSearched),
         results_count: totalResults,
@@ -348,13 +356,14 @@ class SearchService {
     try {
       await database.query(`
         INSERT INTO autres.search_logs (
-          user_id, username, search_term, tables_searched, 
+          user_id, username, search_term, search_type, tables_searched,
           results_count, execution_time_ms, ip_address, user_agent
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `, [
         logData.user_id,
         logData.username,
         logData.search_term,
+        logData.search_type,
         logData.tables_searched,
         logData.results_count,
         logData.execution_time_ms,

--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -39,12 +39,20 @@ class StatsService {
         LIMIT 10
       `);
 
+      const searchesByType = await database.query(`
+        SELECT COALESCE(search_type, 'unknown') as search_type, COUNT(*) as search_count
+        FROM autres.search_logs
+        GROUP BY search_type
+        ORDER BY search_count DESC
+      `);
+
       return {
         total_searches: totalSearches?.count || 0,
         avg_execution_time: Math.round(avgExecutionTime?.avg_time || 0),
         today_searches: todaySearches?.count || 0,
         active_users: activeUsers?.count || 0,
-        top_search_terms: topSearchTerms || []
+        top_search_terms: topSearchTerms || [],
+        searches_by_type: searchesByType || []
       };
     } catch (error) {
       console.error('Erreur statistiques overview:', error);


### PR DESCRIPTION
## Summary
- track search_type in `search_logs` table
- capture search_type from request and log it during searches
- expose per-type search counts in stats overview

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68ac2e10e8e0832695e8ac5436f9b9e7