### PR TITLE
Fix search logging and add user filter for stats

### DIFF
--- a/server/routes/stats.cjs
+++ b/server/routes/stats.cjs
@@ -42,8 +42,9 @@ router.get('/time-series', authenticate, authorize(['ADMIN', 'ANALYSTE']), async
 // Logs de recherche récents
 router.get('/search-logs', authenticate, authorize(['ADMIN', 'ANALYSTE']), async (req, res) => {
   try {
-    const limit = parseInt(req.query.limit) || 20;
-    const logs = await statsService.getSearchLogs(limit);
+    const limit = req.query.limit ? parseInt(req.query.limit) : null;
+    const username = req.query.username || '';
+    const logs = await statsService.getSearchLogs(limit, username);
     res.json({ logs });
   } catch (error) {
     console.error('Erreur logs de recherche:', error);

--- a/server/services/SearchService.cjs
+++ b/server/services/SearchService.cjs
@@ -42,17 +42,21 @@ class SearchService {
 
     // Journalisation
     if (user) {
-      SearchLog.create({
-        user_id: user.id,
-        username: user.username,
-        search_term: query,
-        filters: filters,
-        tables_searched: tablesSearched,
-        results_count: totalResults,
-        execution_time_ms: executionTime,
-        ip_address: user.ip_address,
-        user_agent: user.user_agent
-      });
+      try {
+        await SearchLog.create({
+          user_id: user.id,
+          username: user.username,
+          search_term: query,
+          filters: filters,
+          tables_searched: tablesSearched,
+          results_count: totalResults,
+          execution_time_ms: executionTime,
+          ip_address: user.ip_address,
+          user_agent: user.user_agent
+        });
+      } catch (err) {
+        console.error('Erreur journalisation recherche:', err);
+      }
     }
 
     return {

--- a/server/services/StatsService.cjs
+++ b/server/services/StatsService.cjs
@@ -175,16 +175,28 @@ class StatsService {
     }
   }
 
-  async getSearchLogs(limit = 20) {
+  async getSearchLogs(limit = null, username = '') {
     try {
-      const logs = await database.query(`
+      let sql = `
         SELECT
           sl.*, u.username
         FROM search_logs sl
-        LEFT JOIN users u ON sl.user_id = u.id
-        ORDER BY sl.search_date DESC
-        LIMIT ?
-      `, [limit]);
+        LEFT JOIN users u ON sl.user_id = u.id`;
+      const params = [];
+
+      if (username) {
+        sql += ' WHERE u.username LIKE ?';
+        params.push(`%${username}%`);
+      }
+
+      sql += ' ORDER BY sl.search_date DESC';
+
+      if (limit) {
+        sql += ' LIMIT ?';
+        params.push(limit);
+      }
+
+      const logs = await database.query(sql, params);
 
       return logs || [];
     } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,7 @@ const App: React.FC = () => {
   // États des statistiques
   const [statsData, setStatsData] = useState(null);
   const [searchLogs, setSearchLogs] = useState([]);
+  const [logUserFilter, setLogUserFilter] = useState('');
   const [loadingStats, setLoadingStats] = useState(false);
   const [timeSeries, setTimeSeries] = useState<any[]>([]);
   const [tableDistribution, setTableDistribution] = useState<any[]>([]);
@@ -294,9 +295,11 @@ const App: React.FC = () => {
       setLoadingStats(true);
       const headers = { 'Authorization': `Bearer ${localStorage.getItem('token')}` };
 
+      const logQuery = logUserFilter ? `?username=${encodeURIComponent(logUserFilter)}` : '';
+
       const [statsResponse, logsResponse, timeResponse, distResponse] = await Promise.all([
         fetch('/api/stats/overview', { headers }),
-        fetch('/api/stats/search-logs?limit=10', { headers }),
+        fetch(`/api/stats/search-logs${logQuery}`, { headers }),
         fetch('/api/stats/time-series?days=7', { headers }),
         fetch('/api/stats/data-distribution', { headers })
       ]);
@@ -1250,11 +1253,26 @@ const App: React.FC = () => {
                       <div className="bg-white rounded-2xl shadow-xl p-6">
                         <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-center">
                           <FileText className="h-6 w-6 mr-2 text-indigo-600" />
-                          Recherches récentes
+                          Logs de recherche
                         </h3>
+                        <div className="mb-4 flex">
+                          <input
+                            type="text"
+                            value={logUserFilter}
+                            onChange={(e) => setLogUserFilter(e.target.value)}
+                            placeholder="Filtrer par utilisateur"
+                            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          />
+                          <button
+                            onClick={loadStatistics}
+                            className="ml-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                          >
+                            Rechercher
+                          </button>
+                        </div>
                         <div className="max-h-80 overflow-y-auto">
                           <div className="space-y-3">
-                            {searchLogs.length > 0 ? searchLogs.slice(0, 10).map((log, index) => (
+                            {searchLogs.length > 0 ? searchLogs.map((log, index) => (
                               <div key={index} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
                                 <div className="flex-1">
                                   <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- Ensure search logs are saved with awaited DB writes
- Allow filtering search logs by username via API and UI
- Add user-based log filter and display full logs in statistics page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68ac348f5ae0832697e9033e8ac49d5e