### PR TITLE
feat: export statistics and improve search log filtering

### DIFF
--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -54,7 +54,8 @@ router.get('/user-activity', authenticate, async (req, res) => {
 router.get('/search-logs', authenticate, async (req, res) => {
   try {
     const limit = parseInt(req.query.limit) || 20;
-    const logs = await statsService.getSearchLogs(limit);
+    const username = req.query.username || '';
+    const logs = await statsService.getSearchLogs(limit, username);
     res.json({ logs });
   } catch (error) {
     console.error('Erreur logs de recherche:', error);

--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -165,18 +165,28 @@ class StatsService {
 
   /**
    * Récupère les logs de recherche récents avec l'utilisateur associé.
+   * Permet de filtrer par nom d'utilisateur.
    */
-  async getSearchLogs(limit = 20) {
+  async getSearchLogs(limit = 20, username = '') {
     try {
-      const logs = await database.query(`
+      let sql = `
         SELECT
           sl.*, u.login as username
         FROM autres.search_logs sl
         LEFT JOIN autres.users u ON sl.user_id = u.id
-        ORDER BY sl.search_date DESC
-        LIMIT ?
-      `, [limit]);
+      `;
 
+      const params = [];
+
+      if (username) {
+        sql += ' WHERE u.login LIKE ?';
+        params.push(`%${username}%`);
+      }
+
+      sql += ' ORDER BY sl.search_date DESC LIMIT ?';
+      params.push(limit);
+
+      const logs = await database.query(sql, params);
       return logs || [];
     } catch (error) {
       console.error('Erreur logs de recherche:', error);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -336,6 +336,27 @@ const App: React.FC = () => {
     }
   };
 
+  const exportStats = () => {
+    const data = {
+      overview: statsData,
+      time_series: timeSeries,
+      data_distribution: tableDistribution,
+      search_logs: searchLogs
+    };
+
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json'
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'statistics.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   const handleCreateUser = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -1039,6 +1060,15 @@ const App: React.FC = () => {
                 </p>
               </div>
 
+              <div className="flex justify-end">
+                <button
+                  onClick={exportStats}
+                  className="flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+                >
+                  <Download className="h-4 w-4 mr-2" /> Exporter
+                </button>
+              </div>
+
               {loadingStats ? (
                 <div className="flex items-center justify-center py-16">
                   <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
@@ -1244,6 +1274,14 @@ const App: React.FC = () => {
                               }
                             }}
                           />
+                        </div>
+                        <div className="mt-6 max-h-48 overflow-y-auto space-y-1">
+                          {tableDistribution.map((d, idx) => (
+                            <div key={idx} className="flex justify-between text-sm">
+                              <span className="text-gray-700">{d.table}</span>
+                              <span className="font-medium text-gray-900">{d.count}</span>
+                            </div>
+                          ))}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- allow filtering search logs by username
- add export button to download dashboard stats
- show complete list of data sources

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac3a7ac09483268c9179dc7c77f218