### PR TITLE
feat: add PDF export

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^6.10.0",
     "jsonwebtoken": "^9.0.2",
+    "jspdf": "^2.5.1",
     "lucide-react": "^0.263.1",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.6.0",


### PR DESCRIPTION
## Summary
- allow exporting search results as PDF in the UI
- install jsPDF dependency for PDF generation
- provide separate buttons for CSV and PDF exports

## Testing
- `npm install` (failed: 403 Forbidden - GET https://registry.npmjs.org/jspdf)
- `npm test` (failed: Missing script: "test")
- `npm run lint` (failed: Invalid option '--ext' with eslint.config.js)
- `npm run build` (failed: Rollup failed to resolve import "jspdf")


------
https://chatgpt.com/codex/tasks/task_e_68ac3c65dc948326a84360fe16d49d73