### PR TITLE
feat: enable admin data uploads and password resets

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -11,6 +11,7 @@ import authRoutes from './routes/auth.js';
 import searchRoutes from './routes/search.js';
 import usersRoutes from './routes/users.js';
 import statsRoutes from './routes/stats.js';
+import uploadRoutes from './routes/upload.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -47,6 +48,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/search', searchRoutes);
 app.use('/api/users', usersRoutes);
 app.use('/api/stats', statsRoutes);
+app.use('/api/upload', uploadRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {


### PR DESCRIPTION
## Summary
- allow admins to reset user passwords and skip current password check
- add "Charger des données" page for uploading CSV/SQL files into the `autres` database
- load uploaded tables into search catalog automatically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68ac40a573b88326bffc233e10f0338a