### PR TITLE
Fix admin password change and improve data upload UI

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -142,7 +142,8 @@ router.post('/:id/change-password', authenticate, async (req, res) => {
     }
 
     // Vérifier les permissions (admin ou propriétaire du compte)
-    if (req.user.admin !== 1 && req.user.id !== userId) {
+    const isAdmin = req.user.admin === 1 || req.user.admin === '1' || req.user.admin === true;
+    if (!isAdmin && req.user.id !== userId) {
       return res.status(403).json({ error: 'Permissions insuffisantes' });
     }
 
@@ -156,7 +157,7 @@ router.post('/:id/change-password', authenticate, async (req, res) => {
     }
 
     // Si ce n'est pas un admin, vérifier le mot de passe actuel
-    if (req.user.admin !== 1) {
+    if (!isAdmin) {
       if (!currentPassword) {
         return res.status(400).json({ error: 'Mot de passe actuel requis' });
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,8 @@ import {
   TrendingUp,
   BarChart3,
   FileText,
-  Upload
+  Upload,
+  UploadCloud
 } from 'lucide-react';
 import { Line, Bar, Doughnut } from 'react-chartjs-2';
 import {
@@ -1516,37 +1517,43 @@ const App: React.FC = () => {
       </div>
 
       {currentPage === 'upload' && isAdmin && (
-        <div className="max-w-xl mx-auto">
-          <h1 className="text-2xl font-bold mb-6">Charger des données</h1>
-          <form onSubmit={handleUploadData} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Nom de la table</label>
-              <input
-                type="text"
-                required
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                value={uploadTable}
-                onChange={(e) => setUploadTable(e.target.value)}
-              />
+        <div className="max-w-2xl mx-auto">
+          <div className="bg-white rounded-2xl shadow-xl p-8">
+            <div className="text-center mb-8">
+              <UploadCloud className="h-12 w-12 mx-auto text-blue-600" />
+              <h1 className="mt-4 text-3xl font-bold text-gray-900">Charger des données</h1>
+              <p className="mt-2 text-gray-600">Importez un fichier CSV ou SQL dans la table de votre choix.</p>
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Fichier (CSV ou SQL)</label>
-              <input
-                type="file"
-                accept=".csv,.sql"
-                required
-                onChange={(e) => setUploadFile(e.target.files?.[0] || null)}
-                className="w-full"
-              />
-            </div>
-            <button
-              type="submit"
-              disabled={loading}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 transition-colors"
-            >
-              {loading ? 'Chargement...' : 'Charger'}
-            </button>
-          </form>
+            <form onSubmit={handleUploadData} className="space-y-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Nom de la table</label>
+                <input
+                  type="text"
+                  required
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  value={uploadTable}
+                  onChange={(e) => setUploadTable(e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Fichier à importer</label>
+                <input
+                  type="file"
+                  accept=".csv,.sql"
+                  required
+                  onChange={(e) => setUploadFile(e.target.files?.[0] || null)}
+                  className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full px-4 py-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 transition-colors"
+              >
+                {loading ? 'Chargement...' : 'Importer'}
+              </button>
+            </form>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- allow admins to change any user's password
- restyle the data upload page with a card layout and enhanced file input

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68ac44bf77a083269178532f32817fe5