### PR TITLE
Fix catalog merge to include all databases

### DIFF
--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -2,6 +2,7 @@ import database from '../config/database.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import baseCatalog from '../config/tables-catalog.js';
 
 class SearchService {
   constructor() {
@@ -11,20 +12,21 @@ class SearchService {
   }
 
   loadCatalog() {
+    let catalog = { ...baseCatalog };
     try {
-      const raw = fs.readFileSync(this.catalogPath, 'utf-8');
-      const json = JSON.parse(raw);
-      const catalog = {};
-      for (const [key, value] of Object.entries(json)) {
-        const [db, ...tableParts] = key.split('_');
-        const tableName = `${db}.${tableParts.join('_')}`;
-        catalog[tableName] = value;
+      if (fs.existsSync(this.catalogPath)) {
+        const raw = fs.readFileSync(this.catalogPath, 'utf-8');
+        const json = JSON.parse(raw);
+        for (const [key, value] of Object.entries(json)) {
+          const [db, ...tableParts] = key.split('_');
+          const tableName = `${db}.${tableParts.join('_')}`;
+          catalog[tableName] = value;
+        }
       }
-      return catalog;
     } catch (error) {
       console.error('❌ Erreur chargement catalogue:', error);
-      return {};
     }
+    return catalog;
   }
 
   async search(

--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -2,6 +2,7 @@ import database from '../config/database.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import baseCatalog from '../config/tables-catalog.js';
 
 /**
  * Service de génération de statistiques basées sur les journaux de recherche
@@ -15,20 +16,21 @@ class StatsService {
   }
 
   loadCatalog() {
+    let catalog = { ...baseCatalog };
     try {
-      const raw = fs.readFileSync(this.catalogPath, 'utf-8');
-      const json = JSON.parse(raw);
-      const catalog = {};
-      for (const [key, value] of Object.entries(json)) {
-        const [db, ...tableParts] = key.split('_');
-        const tableName = `${db}.${tableParts.join('_')}`;
-        catalog[tableName] = value;
+      if (fs.existsSync(this.catalogPath)) {
+        const raw = fs.readFileSync(this.catalogPath, 'utf-8');
+        const json = JSON.parse(raw);
+        for (const [key, value] of Object.entries(json)) {
+          const [db, ...tableParts] = key.split('_');
+          const tableName = `${db}.${tableParts.join('_')}`;
+          catalog[tableName] = value;
+        }
       }
-      return catalog;
     } catch (error) {
       console.error('❌ Erreur chargement catalogue:', error);
-      return {};
     }
+    return catalog;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Merge static table catalog with dynamic entries for searches and stats
- Ensure catalog loading covers all configured databases

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68ac5d5a7b1483269bbf7f2dde9c9b9c