### PR TITLE
style: modernize search results design

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -969,37 +969,35 @@ const App: React.FC = () => {
 
               {/* Résultats */}
               {searchResults && (
-                <div className="bg-white shadow-xl rounded-2xl overflow-hidden">
-                  <div className="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-blue-50 to-indigo-50">
+                <div className="bg-white/70 backdrop-blur-lg shadow-2xl rounded-3xl border border-gray-200 overflow-hidden">
+                  <div className="px-8 py-6 border-b border-gray-200 bg-gradient-to-r from-indigo-600 to-blue-600 text-white">
                     <div className="flex justify-between items-center">
                       <div>
-                        <h2 className="text-xl font-bold text-gray-900">
-                          Résultats de recherche
-                        </h2>
+                        <h2 className="text-xl font-bold">Résultats de recherche</h2>
                         <div className="flex items-center mt-2 space-x-4">
-                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
+                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-white/20">
                             <Activity className="w-4 h-4 mr-1" />
                             {searchResults.total} résultat(s)
                           </span>
-                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">
+                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-white/20">
                             <Clock className="w-4 h-4 mr-1" />
                             {searchResults.elapsed_ms}ms
                           </span>
                         </div>
                       </div>
-                      
+
                       {searchResults.hits.length > 0 && (
                         <div className="flex space-x-2">
                           <button
                             onClick={exportToCSV}
-                            className="flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+                            className="flex items-center px-4 py-2 bg-white/20 text-white rounded-lg hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 transition-colors"
                           >
                             <Download className="w-4 h-4 mr-2" />
                             Export CSV
                           </button>
                           <button
                             onClick={exportToPDF}
-                            className="flex items-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+                            className="flex items-center px-4 py-2 bg-white/20 text-white rounded-lg hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 transition-colors"
                           >
                             <FileText className="w-4 h-4 mr-2" />
                             Export PDF
@@ -1018,15 +1016,18 @@ const App: React.FC = () => {
                         </p>
                       </div>
                     ) : (
-                      <div className="p-6">
-                        <div className="grid gap-6">
+                      <div className="p-8 bg-gradient-to-br from-white to-gray-50">
+                        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
                           {searchResults.hits.map((result, index) => (
-                            <div key={index} className="bg-gradient-to-r from-white to-gray-50 border border-gray-200 rounded-xl p-6 hover:shadow-lg transition-all duration-300 hover:border-blue-300">
+                            <div
+                              key={index}
+                              className="group relative bg-white/80 backdrop-blur-sm border border-gray-200 rounded-2xl p-6 hover:shadow-xl hover:border-indigo-300 transform transition-all duration-300 hover:-translate-y-1"
+                            >
                               {/* Header de la carte */}
                               <div className="flex justify-between items-start mb-4">
                                 <div className="flex items-center space-x-3">
-                                  <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-500 to-indigo-500 rounded-lg">
-                                    <Database className="w-5 h-5 text-white" />
+                                  <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-indigo-500 to-blue-500 rounded-xl text-white shadow-md">
+                                    <Database className="w-5 h-5" />
                                   </div>
                                   <div>
                                     <h3 className="text-lg font-semibold text-gray-900">{result.table}</h3>
@@ -1034,7 +1035,7 @@ const App: React.FC = () => {
                                   </div>
                                 </div>
                                 <div className="flex items-center space-x-2">
-                                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700">
                                     <Activity className="w-3 h-3 mr-1" />
                                     Score: {result.score.toFixed(1)}
                                   </span>
@@ -1045,9 +1046,12 @@ const App: React.FC = () => {
                               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                                 {Object.entries(result.preview).map(([key, value]) => {
                                   if (!value || value === '' || value === null || value === undefined) return null;
-                                  
+
                                   return (
-                                    <div key={key} className="bg-white rounded-lg p-3 border border-gray-100 hover:border-blue-200 transition-colors">
+                                    <div
+                                      key={key}
+                                      className="bg-white/60 backdrop-blur-sm rounded-lg p-3 border border-transparent group-hover:border-indigo-200 transition-colors"
+                                    >
                                       <div className="flex flex-col">
                                         <span className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-1">
                                           {key.replace(/_/g, ' ')}
@@ -1064,10 +1068,15 @@ const App: React.FC = () => {
                               {/* Footer avec actions */}
                               <div className="mt-4 pt-4 border-t border-gray-100 flex justify-between items-center">
                                 <div className="text-xs text-gray-500">
-                                  {Object.keys(result.preview).filter(key => 
-                                    result.preview[key] && result.preview[key] !== '' && 
-                                    result.preview[key] !== null && result.preview[key] !== undefined
-                                  ).length} champs disponibles
+                                  {Object.keys(result.preview)
+                                    .filter(
+                                      key =>
+                                        result.preview[key] &&
+                                        result.preview[key] !== '' &&
+                                        result.preview[key] !== null &&
+                                        result.preview[key] !== undefined
+                                    ).length}{' '}
+                                  champs disponibles
                                 </div>
                                 <button
                                   onClick={() => {
@@ -1079,7 +1088,7 @@ const App: React.FC = () => {
                                     navigator.clipboard.writeText(dataText);
                                     alert('Données copiées dans le presse-papier !');
                                   }}
-                                  className="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-600 bg-blue-50 rounded-md hover:bg-blue-100 transition-colors"
+                                  className="inline-flex items-center px-3 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                 >
                                   <User className="w-3 h-3 mr-1" />
                                   Copier


### PR DESCRIPTION
## Summary
- modernize search results section with glass-like cards and gradient header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jspdf)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7903c4f88326bfee3cffa85e9169