### PR TITLE
fix: improve dark mode readability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -772,11 +772,7 @@ const App: React.FC = () => {
 
   return (
     <div
-      className={`min-h-screen flex ${
-        theme === 'dark'
-          ? 'bg-gray-900 text-gray-100'
-          : 'bg-gray-50 text-gray-900'
-      }`}
+      className="min-h-screen flex bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100"
     >
       {/* Sidebar */}
       <div

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .dark .text-gray-900 { @apply text-gray-100; }
+  .dark .text-gray-600 { @apply text-gray-300; }
+  .dark .text-gray-500 { @apply text-gray-400; }
+  .dark .hover\:text-gray-900:hover { @apply text-gray-100; }
+  .dark .bg-gray-50 { @apply bg-gray-800; }
+  .dark .hover\:bg-gray-100:hover { @apply bg-gray-700; }
+  .dark .hover\:bg-gray-50:hover { @apply bg-gray-700; }
+}


### PR DESCRIPTION
## Summary
- tweak root container to use Tailwind dark variants
- override light theme utilities for dark mode readability

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jspdf)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7dd820548326831e7c6d9c1d94aa