### PR TITLE
Style gendarmerie directory headers without phone numbers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1282,13 +1282,22 @@ const App: React.FC = () => {
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
-                    {paginatedGendarmerie.map((entry) => (
-                      <tr key={entry.id}>
-                        <td className="px-6 py-4 whitespace-nowrap">{entry.id}</td>
-                        <td className="px-6 py-4 whitespace-nowrap">{entry.Libelle}</td>
-                        <td className="px-6 py-4 whitespace-nowrap">{entry.Telephone}</td>
-                      </tr>
-                    ))}
+                    {paginatedGendarmerie.map((entry) => {
+                      const isTitle = !entry.Telephone || entry.Telephone.trim() === '';
+                      return isTitle ? (
+                        <tr key={entry.id} className="bg-gray-100">
+                          <td colSpan={3} className="px-6 py-4 font-semibold">
+                            {entry.Libelle}
+                          </td>
+                        </tr>
+                      ) : (
+                        <tr key={entry.id}>
+                          <td className="px-6 py-4 whitespace-nowrap">{entry.id}</td>
+                          <td className="px-6 py-4 whitespace-nowrap">{entry.Libelle}</td>
+                          <td className="px-6 py-4 whitespace-nowrap">{entry.Telephone}</td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
                 <div className="px-6 py-3 flex items-center justify-between border-t border-gray-200">


### PR DESCRIPTION
## Summary
- Render directory rows without phone numbers as section headers spanning the table and with distinct background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7afbeb8c8326aeb10289df0a8556