### PR TITLE
feat: add entreprises page with searchable table

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -13,6 +13,7 @@ import usersRoutes from './routes/users.js';
 import statsRoutes from './routes/stats.js';
 import uploadRoutes from './routes/upload.js';
 import annuaireRoutes from './routes/annuaire.js';
+import entreprisesRoutes from './routes/entreprises.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -51,6 +52,7 @@ app.use('/api/users', usersRoutes);
 app.use('/api/stats', statsRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/annuaire-gendarmerie', annuaireRoutes);
+app.use('/api/entreprises', entreprisesRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/routes/entreprises.js
+++ b/server/routes/entreprises.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import database from '../config/database.js';
+import { authenticate } from '../middleware/auth.js';
+
+const router = express.Router();
+
+router.get('/', authenticate, async (req, res) => {
+  try {
+    const rows = await database.query(`SELECT 
+      ninea_ninet, cuci, raison_social, ensemble_sigle, numrc,
+      syscoa1, syscoa2, syscoa3, naemas, naemas_rev1, citi_rev4,
+      adresse, telephone, telephone1, numero_telecopie, email,
+      bp, region, departement, ville, commune, quartier,
+      personne_contact, adresse_personne_contact, qualite_personne_contact,
+      premiere_annee_exercice, forme_juridique, regime_fiscal,
+      pays_du_siege_de_lentreprise, nombre_etablissement, controle,
+      date_reception, libelle_activite_principale, observations, systeme
+    FROM entreprises`);
+    res.json({ entries: rows });
+  } catch (error) {
+    console.error('Erreur entreprises:', error);
+    res.status(500).json({ error: "Erreur lors de la récupération des entreprises" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add entreprises API and wire it into server
- create front-end navigation and page to list entreprises with search & pagination

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ad8045aa1c83268330be2646a3bd65