### PR TITLE
Optimize table data loading with server-side pagination

### DIFF
--- a/server/routes/entreprises.js
+++ b/server/routes/entreprises.js
@@ -6,17 +6,48 @@ const router = express.Router();
 
 router.get('/', authenticate, async (req, res) => {
   try {
-    const rows = await database.query(`SELECT 
-      ninea_ninet, cuci, raison_social, ensemble_sigle, numrc,
-      syscoa1, syscoa2, syscoa3, naemas, naemas_rev1, citi_rev4,
-      adresse, telephone, telephone1, numero_telecopie, email,
-      bp, region, departement, ville, commune, quartier,
-      personne_contact, adresse_personne_contact, qualite_personne_contact,
-      premiere_annee_exercice, forme_juridique, regime_fiscal,
-      pays_du_siege_de_lentreprise, nombre_etablissement, controle,
-      date_reception, libelle_activite_principale, observations, systeme
-    FROM entreprises`);
-    res.json({ entries: rows });
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 12;
+    const search = (req.query.search || '').trim();
+    const offset = (page - 1) * limit;
+
+    let whereClause = '';
+    const params = [];
+
+    if (search) {
+      whereClause = `WHERE CONCAT_WS(' ',
+        ninea_ninet, cuci, raison_social, ensemble_sigle, numrc,
+        syscoa1, syscoa2, syscoa3, naemas, naemas_rev1, citi_rev4,
+        adresse, telephone, telephone1, numero_telecopie, email,
+        bp, region, departement, ville, commune, quartier,
+        personne_contact, adresse_personne_contact, qualite_personne_contact,
+        premiere_annee_exercice, forme_juridique, regime_fiscal,
+        pays_du_siege_de_lentreprise, nombre_etablissement, controle,
+        date_reception, libelle_activite_principale, observations, systeme
+      ) LIKE ?`;
+      params.push(`%${search}%`);
+    }
+
+    const totalResult = await database.queryOne(
+      `SELECT COUNT(*) AS count FROM entreprises ${whereClause}`,
+      params
+    );
+
+    const rows = await database.query(
+      `SELECT
+        ninea_ninet, cuci, raison_social, ensemble_sigle, numrc,
+        syscoa1, syscoa2, syscoa3, naemas, naemas_rev1, citi_rev4,
+        adresse, telephone, telephone1, numero_telecopie, email,
+        bp, region, departement, ville, commune, quartier,
+        personne_contact, adresse_personne_contact, qualite_personne_contact,
+        premiere_annee_exercice, forme_juridique, regime_fiscal,
+        pays_du_siege_de_lentreprise, nombre_etablissement, controle,
+        date_reception, libelle_activite_principale, observations, systeme
+      FROM entreprises ${whereClause} LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
+    );
+
+    res.json({ entries: rows, total: totalResult.count });
   } catch (error) {
     console.error('Erreur entreprises:', error);
     res.status(500).json({ error: "Erreur lors de la récupération des entreprises" });

--- a/server/routes/vehicules.js
+++ b/server/routes/vehicules.js
@@ -6,14 +6,42 @@ const router = express.Router();
 
 router.get('/', authenticate, async (req, res) => {
   try {
-    const rows = await database.query(`SELECT 
-      ID, Numero_Immatriculation, Code_Type, Numero_Serie, Date_Immatriculation, Serie_Immatriculation,
-      Categorie, Marque, Appelation_Com, Genre, Carrosserie, Etat_Initial, Immat_Etrangere, Date_Etrangere,
-      Date_Mise_Circulation, Date_Premiere_Immat, Energie, Puissance_Adm, Cylindre, Places_Assises,
-      PTR, PTAC_Code, Poids_Vide, CU, Prenoms, Nom, Date_Naissance, Exact, Lieu_Naissance,
-      Adresse_Vehicule, Code_Localite, Tel_Fixe, Tel_Portable, PrecImmat, Date_PrecImmat
-      FROM vehicules`);
-    res.json({ entries: rows });
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 12;
+    const search = (req.query.search || '').trim();
+    const offset = (page - 1) * limit;
+
+    let whereClause = '';
+    const params = [];
+
+    if (search) {
+      whereClause = `WHERE CONCAT_WS(' ',
+        Numero_Immatriculation, Code_Type, Numero_Serie, Date_Immatriculation, Serie_Immatriculation,
+        Categorie, Marque, Appelation_Com, Genre, Carrosserie, Etat_Initial, Immat_Etrangere, Date_Etrangere,
+        Date_Mise_Circulation, Date_Premiere_Immat, Energie, Puissance_Adm, Cylindre, Places_Assises,
+        PTR, PTAC_Code, Poids_Vide, CU, Prenoms, Nom, Date_Naissance, Exact, Lieu_Naissance,
+        Adresse_Vehicule, Code_Localite, Tel_Fixe, Tel_Portable, PrecImmat, Date_PrecImmat
+      ) LIKE ?`;
+      params.push(`%${search}%`);
+    }
+
+    const totalResult = await database.queryOne(
+      `SELECT COUNT(*) AS count FROM vehicules ${whereClause}`,
+      params
+    );
+
+    const rows = await database.query(
+      `SELECT
+        ID, Numero_Immatriculation, Code_Type, Numero_Serie, Date_Immatriculation, Serie_Immatriculation,
+        Categorie, Marque, Appelation_Com, Genre, Carrosserie, Etat_Initial, Immat_Etrangere, Date_Etrangere,
+        Date_Mise_Circulation, Date_Premiere_Immat, Energie, Puissance_Adm, Cylindre, Places_Assises,
+        PTR, PTAC_Code, Poids_Vide, CU, Prenoms, Nom, Date_Naissance, Exact, Lieu_Naissance,
+        Adresse_Vehicule, Code_Localite, Tel_Fixe, Tel_Portable, PrecImmat, Date_PrecImmat
+      FROM vehicules ${whereClause} LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
+    );
+
+    res.json({ entries: rows, total: totalResult.count });
   } catch (error) {
     console.error('Erreur récupération véhicules:', error);
     res.status(500).json({ error: 'Erreur lors de la récupération des véhicules' });


### PR DESCRIPTION
## Summary
- add pagination and search parameters to entreprise and vehicule API routes
- request paginated data on the client and compute total pages from server counts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ad8e148a8c8326a317dd26f06d1c0b