### PR TITLE
Add ONG dataset and fix enterprise stats query

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ La plateforme supporte les bases de données suivantes :
 #### Base `autres`
 - **Vehicules** : Numero_Immatriculation, Marque, Categorie, Prenoms, Nom, etc.
 - **entreprises** : ninea_ninet, raison_social, region, forme_juridique, etc.
+- **ong** : OrganizationName, Type, Name, EmailAddress, Telephone, etc.
 - **affaire_etrangere**, **agent_non_fonctionnaire**, **fpublique**, **demdikk**
 
 ## Utilisation

--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -603,6 +603,24 @@ export default {
     theme: 'militaire'
   },
 
+  'autres.ong': {
+    display: 'ong',
+    database: 'autres',
+    searchable: [
+      'OrganizationName',
+      'Name',
+      'EmailAddress',
+      'Telephone'
+    ],
+    preview: ['OrganizationName', 'Name', 'EmailAddress', 'Telephone'],
+    filters: {
+      Type: 'string',
+      SelectAreaofInterest: 'string',
+      SelectSectorsofInterest: 'string'
+    },
+    theme: 'ong'
+  },
+
   'autres.entreprises': {
     display: 'entreprises',
     database: 'autres',

--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -178,7 +178,7 @@ class StatsService {
     try {
       const regions = await database.query(`
         SELECT region, COUNT(*) as count
-        FROM autres_entreprises
+        FROM autres.entreprises
         WHERE region IS NOT NULL AND region != ''
         GROUP BY region
         ORDER BY count DESC


### PR DESCRIPTION
## Summary
- include `ong` table in catalog for search and statistics
- fix region distribution query to use `autres.entreprises`
- document new ONG data source

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9dfe3dfc832681b8cf9278add633