### PR TITLE
Include annuaire gendarmerie dataset in search and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ La plateforme supporte les bases de données suivantes :
 - **entreprises** : ninea_ninet, raison_social, region, forme_juridique, etc.
 - **ong** : OrganizationName, Type, Name, EmailAddress, Telephone, etc.
 - **affaire_etrangere**, **agent_non_fonctionnaire**, **fpublique**, **demdikk**
+- **annuaire_gendarmerie** : Libelle, Telephone
 
 ## Utilisation
 

--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -418,6 +418,18 @@ export default {
     theme: 'pro'
   },
 
+  'autres.annuaire_gendarmerie': {
+    display: 'annuaire_gendarmerie',
+    database: 'autres',
+    searchable: ['Libelle', 'Telephone'],
+    preview: ['Libelle', 'Telephone'],
+    filters: {
+      Libelle: 'string',
+      Telephone: 'string'
+    },
+    theme: 'pro'
+  },
+
   'autres.collectes1': {
     display: 'collectes1',
     database: 'autres',


### PR DESCRIPTION
## Summary
- add annuaire_gendarmerie table to search catalog for query and stats
- document annuaire_gendarmerie in data structure overview

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68ada1d7a5ac8326b9249849855d2669