### PR TITLE
Fix stats display for normal users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -525,13 +525,14 @@ const App: React.FC = () => {
 
   // Charger les statistiques
   const loadStatistics = async () => {
-    if (!currentUser || (currentUser.admin !== 1 && currentUser.admin !== "1")) return;
+    if (!currentUser) return;
 
     try {
       setLoadingStats(true);
       const headers = { 'Authorization': `Bearer ${localStorage.getItem('token')}` };
 
-      const logQuery = logUserFilter ? `?username=${encodeURIComponent(logUserFilter)}` : '';
+      const isAdmin = currentUser.admin === 1 || currentUser.admin === "1";
+      const logQuery = isAdmin && logUserFilter ? `?username=${encodeURIComponent(logUserFilter)}` : '';
 
       const [statsResponse, logsResponse, timeResponse, distResponse] = await Promise.all([
         fetch('/api/stats/overview', { headers }),


### PR DESCRIPTION
## Summary
- allow statistics to load for all authenticated users
- restrict log filtering to administrators only

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68adc799c6ac83268dfffbd0d7b97bc3