### PR TITLE
Set statistics page as default landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,7 +305,7 @@ const App: React.FC = () => {
         console.log('🔍 Admin status:', data.user.admin, 'Type:', typeof data.user.admin);
         setCurrentUser(data.user);
         setIsAuthenticated(true);
-        setCurrentPage('search');
+        setCurrentPage('statistics');
       } else {
         localStorage.removeItem('token');
       }
@@ -335,7 +335,7 @@ const App: React.FC = () => {
         console.log('🔍 Admin status:', data.user.admin, 'Type:', typeof data.user.admin);
         setCurrentUser(data.user);
         setIsAuthenticated(true);
-        setCurrentPage('search');
+        setCurrentPage('statistics');
         setLoginData({ login: '', password: '' });
       } else {
         setLoginError(data.error || 'Erreur de connexion');
@@ -2267,7 +2267,7 @@ const App: React.FC = () => {
               {/* Header */}
               <div className="text-center">
                 <h1 className="text-4xl font-bold text-gray-900 mb-2">
-                  Tableau de Bord Statistiques
+                  Dashboard
                 </h1>
                 <p className="text-lg text-gray-600">
                   Analyse complète de l'utilisation de la plateforme VEGETA


### PR DESCRIPTION
## Summary
- Show statistics page after user login instead of search
- Rename statistics dashboard heading to simply "Dashboard"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68adcd70ed34832692cb70e5f9d2eb13