### PR TITLE
Support new Annuaire Gendarmerie columns

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -79,6 +79,8 @@ class DatabaseManager {
           id INT AUTO_INCREMENT PRIMARY KEY,
           Libelle VARCHAR(255) NOT NULL,
           Telephone VARCHAR(50) NOT NULL,
+          `Sous-Categorie` VARCHAR(255) DEFAULT NULL,
+          Secteur VARCHAR(255) DEFAULT NULL,
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
       `);

--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -421,11 +421,13 @@ export default {
   'autres.annuaire_gendarmerie': {
     display: 'annuaire_gendarmerie',
     database: 'autres',
-    searchable: ['Libelle', 'Telephone'],
-    preview: ['Libelle', 'Telephone'],
+    searchable: ['Libelle', 'Telephone', 'Sous-Categorie', 'Secteur'],
+    preview: ['Libelle', 'Telephone', 'Sous-Categorie', 'Secteur'],
     filters: {
       Libelle: 'string',
-      Telephone: 'string'
+      Telephone: 'string',
+      'Sous-Categorie': 'string',
+      Secteur: 'string'
     },
     theme: 'pro'
   },

--- a/server/routes/annuaire.js
+++ b/server/routes/annuaire.js
@@ -6,7 +6,9 @@ const router = express.Router();
 
 router.get('/', authenticate, async (req, res) => {
   try {
-    const rows = await database.query('SELECT id, Libelle, Telephone FROM annuaire_gendarmerie ORDER BY id');
+    const rows = await database.query(
+      'SELECT id, Libelle, Telephone, `Sous-Categorie`, Secteur, created_at FROM annuaire_gendarmerie ORDER BY id'
+    );
     res.json({ entries: rows });
   } catch (error) {
     console.error('Erreur annuaire gendarmerie:', error);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,9 @@ interface GendarmerieEntry {
   id: number;
   Libelle: string;
   Telephone: string;
+  'Sous-Categorie'?: string;
+  Secteur?: string;
+  created_at?: string;
 }
 
 interface EntrepriseEntry {
@@ -1048,6 +1051,8 @@ const App: React.FC = () => {
             const matches =
               entry.Libelle.toLowerCase().includes(searchLower) ||
               (entry.Telephone || '').toLowerCase().includes(searchLower) ||
+              (entry['Sous-Categorie'] || '').toLowerCase().includes(searchLower) ||
+              (entry.Secteur || '').toLowerCase().includes(searchLower) ||
               entry.id.toString().includes(searchLower);
 
             if (matches) {
@@ -1646,6 +1651,9 @@ const App: React.FC = () => {
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">ID</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Libellé</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Téléphone</th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Sous-Categorie</th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Secteur</th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Créé le</th>
                         </tr>
                       </thead>
                       <tbody className="bg-white divide-y divide-gray-200">
@@ -1653,7 +1661,7 @@ const App: React.FC = () => {
                           const isTitle = !entry.Telephone || entry.Telephone.trim() === '';
                           return isTitle ? (
                             <tr key={entry.id} className="bg-gray-100">
-                              <td colSpan={3} className="px-6 py-4 font-semibold">
+                              <td colSpan={6} className="px-6 py-4 font-semibold">
                                 {entry.Libelle}
                               </td>
                             </tr>
@@ -1662,6 +1670,9 @@ const App: React.FC = () => {
                               <td className="px-6 py-4 whitespace-nowrap">{entry.id}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Libelle}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Telephone}</td>
+                              <td className="px-6 py-4 whitespace-nowrap">{entry['Sous-Categorie']}</td>
+                              <td className="px-6 py-4 whitespace-nowrap">{entry.Secteur}</td>
+                              <td className="px-6 py-4 whitespace-nowrap">{entry.created_at ? new Date(entry.created_at).toLocaleDateString() : ''}</td>
                             </tr>
                           );
                         })}


### PR DESCRIPTION
## Summary
- add Sous-Categorie and Secteur fields to annuaire_gendarmerie schema
- expose new fields in API and search catalog
- update Annuaire Gendarmerie page to show new columns and allow searching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68add63577f48326b5e4a26dbd0062e8