### PR TITLE
Escape SQL backticks in initialization query

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -79,7 +79,7 @@ class DatabaseManager {
           id INT AUTO_INCREMENT PRIMARY KEY,
           Libelle VARCHAR(255) NOT NULL,
           Telephone VARCHAR(50) NOT NULL,
-          `Sous-Categorie` VARCHAR(255) DEFAULT NULL,
+          \`Sous-Categorie\` VARCHAR(255) DEFAULT NULL,
           Secteur VARCHAR(255) DEFAULT NULL,
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4


### PR DESCRIPTION
## Summary
- escape backticks in annuaire_gendarmerie creation query

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68aeb550fa5483269d4ccff4cfd22755