### PR TITLE
style: include buttons in dark theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,12 +11,14 @@
   }
   input,
   textarea,
-  select {
+  select,
+  button {
     @apply bg-white text-gray-900;
   }
   .dark input,
   .dark textarea,
-  .dark select {
+  .dark select,
+  .dark button {
     @apply bg-gray-800 text-gray-100 border-gray-600 placeholder-gray-400;
   }
 }


### PR DESCRIPTION
## Summary
- include button elements in default and dark theme styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aec6c156808326a3cbe190906e4209