### PR TITLE
feat: modernize theme toggle icon

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import {
   Download,
   Menu,
   X,
+  Sun,
+  Moon,
   Shield,
   UserCheck,
   Clock,
@@ -1088,8 +1090,13 @@ const App: React.FC = () => {
                   setTheme(theme === 'dark' ? 'light' : 'dark')
                 }
                 className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                aria-label="Toggle theme"
               >
-                {theme === 'dark' ? 'Light' : 'Black'}
+                {theme === 'dark' ? (
+                  <Sun className="h-5 w-5" />
+                ) : (
+                  <Moon className="h-5 w-5" />
+                )}
               </button>
               <button
                 onClick={() => setSidebarOpen(!sidebarOpen)}


### PR DESCRIPTION
## Summary
- replace text-based theme toggle with sun/moon icons for a modern look

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68aedc769ee08326b37fe08f9ed9c0a1