### PR TITLE
Support new autres datasets and gendarmerie column rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ La plateforme supporte les bases de données suivantes :
 - **entreprises** : ninea_ninet, raison_social, region, forme_juridique, etc.
 - **ong** : OrganizationName, Type, Name, EmailAddress, Telephone, etc.
 - **affaire_etrangere**, **agent_non_fonctionnaire**, **fpublique**, **demdikk**
-- **annuaire_gendarmerie** : id, Libelle, Telephone, Sous-Categorie, Secteur, created_at
+- **annuaire_gendarmerie** : id, Libelle, Telephone, SousCategorie, Secteur, created_at
+- **uvs** : id, date, matricule, cniPasseport, prenom, genre, nom, email, mail_perso, telephone, adresse, eno, pole, filiere, login
+- **collections** : id, Nom, Prenom, DateNaissance, CNI, Telephone, Localite, created_at
 
 ## Utilisation
 

--- a/server/config/database.cjs
+++ b/server/config/database.cjs
@@ -300,8 +300,39 @@ class DatabaseManager {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         Libelle TEXT,
         Telephone TEXT,
-        "Sous-Categorie" TEXT,
+        SousCategorie TEXT,
         Secteur TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )`,
+
+      // Base autres - uvs
+      `CREATE TABLE IF NOT EXISTS autres_uvs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        date TEXT,
+        matricule TEXT,
+        cniPasseport TEXT,
+        prenom TEXT,
+        genre TEXT,
+        nom TEXT,
+        email TEXT,
+        mail_perso TEXT,
+        telephone TEXT,
+        adresse TEXT,
+        eno TEXT,
+        pole TEXT,
+        filiere TEXT,
+        login TEXT
+      )`,
+
+      // Base autres - collections
+      `CREATE TABLE IF NOT EXISTS autres_collections (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        Nom TEXT,
+        Prenom TEXT,
+        DateNaissance TEXT,
+        CNI TEXT,
+        Telephone TEXT,
+        Localite TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )`,
 

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -79,8 +79,41 @@ class DatabaseManager {
           id INT AUTO_INCREMENT PRIMARY KEY,
           Libelle VARCHAR(255) NOT NULL,
           Telephone VARCHAR(50) NOT NULL,
-          \`Sous-Categorie\` VARCHAR(255) DEFAULT NULL,
+          SousCategorie VARCHAR(255) DEFAULT NULL,
           Secteur VARCHAR(255) DEFAULT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
+      await this.query(`
+        CREATE TABLE IF NOT EXISTS autres.uvs (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          date DATE DEFAULT NULL,
+          matricule VARCHAR(100) DEFAULT NULL,
+          cniPasseport VARCHAR(100) DEFAULT NULL,
+          prenom VARCHAR(255) DEFAULT NULL,
+          genre VARCHAR(50) DEFAULT NULL,
+          nom VARCHAR(255) DEFAULT NULL,
+          email VARCHAR(255) DEFAULT NULL,
+          mail_perso VARCHAR(255) DEFAULT NULL,
+          telephone VARCHAR(50) DEFAULT NULL,
+          adresse VARCHAR(255) DEFAULT NULL,
+          eno VARCHAR(100) DEFAULT NULL,
+          pole VARCHAR(100) DEFAULT NULL,
+          filiere VARCHAR(100) DEFAULT NULL,
+          login VARCHAR(255) DEFAULT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
+      await this.query(`
+        CREATE TABLE IF NOT EXISTS autres.collections (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          Nom VARCHAR(255) NOT NULL,
+          Prenom VARCHAR(255) NOT NULL,
+          DateNaissance DATE DEFAULT NULL,
+          CNI VARCHAR(100) DEFAULT NULL,
+          Telephone VARCHAR(50) DEFAULT NULL,
+          Localite VARCHAR(255) DEFAULT NULL,
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
       `);

--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -425,12 +425,12 @@ export default {
   'autres.annuaire_gendarmerie': {
     display: 'annuaire_gendarmerie',
     database: 'autres',
-    searchable: ['Libelle', 'Telephone', 'Sous-Categorie', 'Secteur'],
-    preview: ['Libelle', 'Telephone', 'Sous-Categorie', 'Secteur'],
+    searchable: ['Libelle', 'Telephone', 'SousCategorie', 'Secteur'],
+    preview: ['Libelle', 'Telephone', 'SousCategorie', 'Secteur'],
     filters: {
       Libelle: 'string',
       Telephone: 'string',
-      'Sous-Categorie': 'string',
+      SousCategorie: 'string',
       Secteur: 'string'
     },
     theme: 'pro'
@@ -662,12 +662,15 @@ export default {
   'autres.uvs': {
     display: 'uvs',
     database: 'autres',
-    searchable: ['id', 'nom', 'telephone', 'email'],
+    searchable: ['id', 'matricule', 'cniPasseport', 'prenom', 'nom', 'telephone', 'email', 'login'],
     linkedFields: ['telephone', 'email'],
-    preview: ['id', 'nom', 'telephone', 'email'],
+    preview: ['id', 'prenom', 'nom', 'telephone', 'email'],
     filters: {
-      telephone: 'string',
-      email: 'string'
+      genre: 'enum',
+      date: 'date',
+      eno: 'string',
+      pole: 'string',
+      filiere: 'string'
     },
     theme: 'identite'
   },
@@ -675,11 +678,14 @@ export default {
   'autres.collections': {
     display: 'collections',
     database: 'autres',
-    searchable: ['id', 'titre', 'description'],
-    preview: ['id', 'titre', 'description'],
+    searchable: ['Nom', 'Prenom', 'DateNaissance', 'CNI', 'Telephone', 'Localite'],
+    preview: ['Nom', 'Prenom', 'Telephone', 'Localite'],
     filters: {
-      titre: 'string'
+      DateNaissance: 'date',
+      CNI: 'string',
+      Telephone: 'string',
+      Localite: 'string'
     },
-    theme: 'autre'
+    theme: 'identite'
   }
 };

--- a/server/routes/annuaire.js
+++ b/server/routes/annuaire.js
@@ -7,7 +7,7 @@ const router = express.Router();
 router.get('/', authenticate, async (req, res) => {
   try {
     const rows = await database.query(
-      'SELECT id, Libelle, Telephone, `Sous-Categorie`, Secteur, created_at FROM annuaire_gendarmerie ORDER BY id'
+      'SELECT id, Libelle, Telephone, SousCategorie, Secteur, created_at FROM annuaire_gendarmerie ORDER BY id'
     );
     res.json({ entries: rows });
   } catch (error) {

--- a/server/services/StatsService.cjs
+++ b/server/services/StatsService.cjs
@@ -56,7 +56,9 @@ class StatsService {
       'elections_dakar',
       'autres_vehicules',
       'autres_entreprises',
-      'autres_annuaire_gendarmerie'
+      'autres_annuaire_gendarmerie',
+      'autres_uvs',
+      'autres_collections'
     ];
 
     const results = await Promise.all(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,7 @@ interface GendarmerieEntry {
   id: number;
   Libelle: string;
   Telephone: string;
-  'Sous-Categorie'?: string;
+  SousCategorie?: string;
   Secteur?: string;
   created_at?: string;
 }
@@ -900,7 +900,7 @@ const App: React.FC = () => {
             const matches =
               entry.Libelle.toLowerCase().includes(searchLower) ||
               (entry.Telephone || '').toLowerCase().includes(searchLower) ||
-              (entry['Sous-Categorie'] || '').toLowerCase().includes(searchLower) ||
+              (entry.SousCategorie || '').toLowerCase().includes(searchLower) ||
               (entry.Secteur || '').toLowerCase().includes(searchLower) ||
               entry.id.toString().includes(searchLower);
 
@@ -1476,7 +1476,7 @@ const App: React.FC = () => {
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">ID</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Libellé</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Téléphone</th>
-                          <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Sous-Categorie</th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">SousCategorie</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Secteur</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Créé le</th>
                         </tr>
@@ -1495,7 +1495,7 @@ const App: React.FC = () => {
                               <td className="px-6 py-4 whitespace-nowrap">{entry.id}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Libelle}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Telephone}</td>
-                              <td className="px-6 py-4 whitespace-nowrap">{entry['Sous-Categorie']}</td>
+                              <td className="px-6 py-4 whitespace-nowrap">{entry.SousCategorie}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Secteur}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.created_at ? new Date(entry.created_at).toLocaleDateString() : ''}</td>
                             </tr>


### PR DESCRIPTION
## Summary
- rename `Sous-Categorie` column to `SousCategorie` across backend, frontend, and docs
- add UVS and collections tables with schema definitions and search support
- include new tables in statistics service

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_68af02122f248326a343e3f9589e675f