### PR TITLE
Make Dashboard default home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VEGETA est une plateforme Web professionnelle permettant des recherches ultra-ra
 
 - 🔍 **Recherche unifiée** : Recherche simultanée sur toutes les tables configurées
 - 🎯 **Filtres avancés** : Filtres dynamiques par thématique (identité, contact, pro, transport, etc.)
-- 📊 **Statistiques interactives** : Graphiques et tableaux de bord avec Chart.js
+- 📊 **Dashboard interactif** : Graphiques et tableaux de bord avec Chart.js
 - 👥 **Gestion RBAC** : Système de rôles (ADMIN, ANALYSTE, LECTEUR)
 - 📤 **Upload de données** : Interface d'import CSV/Excel avec validation
 - 📝 **Journalisation** : Audit complet des recherches et actions
@@ -149,7 +149,7 @@ La plateforme supporte plusieurs opérateurs :
 - `POST /api/search` : Recherche principale
 - `GET /api/search/details/:table/:id` : Détails d'un enregistrement
 
-### Statistiques
+### Dashboard
 - `GET /api/stats/overview` : Vue d'ensemble
 - `GET /api/stats/tables-distribution` : Répartition par table
 - `GET /api/stats/time-series` : Évolution temporelle
@@ -241,7 +241,7 @@ Les logs sont disponibles dans :
 ### Monitoring
 
 - Endpoint de santé : `GET /api/health`
-- Statistiques temps réel via l'interface admin
+- Dashboard temps réel via l'interface admin
 - Métriques de performance dans les logs
 
 ### Sauvegarde

--- a/public/index.html
+++ b/public/index.html
@@ -36,16 +36,16 @@
             
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
+                    <li class="nav-item" id="statsNavItem" style="display: none;">
+                        <a class="nav-link" href="#" onclick="showPage('stats')">
+                            <i data-lucide="bar-chart-3" class="me-1"></i>
+                            Dashboard
+                        </a>
+                    </li>
                     <li class="nav-item">
                         <a class="nav-link" href="#" onclick="showPage('home')">
                             <i data-lucide="home" class="me-1"></i>
                             Recherche
-                        </a>
-                    </li>
-                    <li class="nav-item" id="statsNavItem" style="display: none;">
-                        <a class="nav-link" href="#" onclick="showPage('stats')">
-                            <i data-lucide="bar-chart-3" class="me-1"></i>
-                            Statistiques
                         </a>
                     </li>
                     <li class="nav-item" id="uploadNavItem" style="display: none;">
@@ -194,7 +194,7 @@
             </div>
         </div>
 
-        <!-- Page Statistiques -->
+        <!-- Page Dashboard -->
         <div id="statsPage" class="page-content" style="display: none;">
             <h2 class="mb-4">
                 <i data-lucide="bar-chart-3" class="me-2 text-primary"></i>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -315,7 +315,7 @@ const App: React.FC = () => {
         console.log('🔍 Admin status:', data.user.admin, 'Type:', typeof data.user.admin);
         setCurrentUser(data.user);
         setIsAuthenticated(true);
-        setCurrentPage('statistics');
+        setCurrentPage('dashboard');
       } else {
         localStorage.removeItem('token');
       }
@@ -345,7 +345,7 @@ const App: React.FC = () => {
         console.log('🔍 Admin status:', data.user.admin, 'Type:', typeof data.user.admin);
         setCurrentUser(data.user);
         setIsAuthenticated(true);
-        setCurrentPage('statistics');
+        setCurrentPage('dashboard');
         setLoginData({ login: '', password: '' });
       } else {
         setLoginError(data.error || 'Erreur de connexion');
@@ -895,7 +895,7 @@ const App: React.FC = () => {
     if (currentPage === 'users' && currentUser && (currentUser.admin === 1 || currentUser.admin === "1")) {
       loadUsers();
     }
-    if (currentPage === 'statistics' && currentUser) {
+    if (currentPage === 'dashboard' && currentUser) {
       loadStatistics();
     }
     if (currentPage === 'upload' && currentUser && (currentUser.admin === 1 || currentUser.admin === "1")) {
@@ -1157,6 +1157,18 @@ const App: React.FC = () => {
         <nav className="flex-1 p-4">
           <div className="space-y-2">
             <button
+              onClick={() => setCurrentPage('dashboard')}
+              className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
+                currentPage === 'dashboard'
+                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+              } ${!sidebarOpen && 'justify-center'}`}
+            >
+              <Activity className="h-5 w-5" />
+              {sidebarOpen && <span className="ml-3">Dashboard</span>}
+            </button>
+
+            <button
               onClick={() => setCurrentPage('search')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'search'
@@ -1242,18 +1254,6 @@ const App: React.FC = () => {
               </button>
             )}
 
-            <button
-              onClick={() => setCurrentPage('statistics')}
-              className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
-                currentPage === 'statistics'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
-                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-              } ${!sidebarOpen && 'justify-center'}`}
-            >
-              <Activity className="h-5 w-5" />
-              {sidebarOpen && <span className="ml-3">Statistiques</span>}
-            </button>
-
             {isAdmin && (
               <button
                 onClick={() => setCurrentPage('upload')}
@@ -1261,7 +1261,7 @@ const App: React.FC = () => {
                   currentPage === 'upload'
                     ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
                     : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-                } ${!sidebarOpen && 'justify-center'}`}
+              } ${!sidebarOpen && 'justify-center'}`}
               >
                 <Upload className="h-5 w-5" />
                 {sidebarOpen && <span className="ml-3">Charger des données</span>}
@@ -2164,7 +2164,7 @@ const App: React.FC = () => {
             </div>
           )}
 
-          {currentPage === 'statistics' && (
+          {currentPage === 'dashboard' && (
             <div className="space-y-8">
               {/* Header */}
               <PageHeader icon={<BarChart3 className="h-6 w-6" />} title="Dashboard" subtitle="Analyse complète de l'utilisation de la plateforme VEGETA" />


### PR DESCRIPTION
## Summary
- Rename "Statistiques" menu to "Dashboard" and make it the default landing page after login
- Reorder navigation so Dashboard appears first in the menu
- Update documentation and static HTML to reflect the new Dashboard naming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option `--ext`; missing `typescript-eslint` dependency)*
- `npx eslint . --report-unused-disable-directives --max-warnings 0` *(fails: Cannot find package `typescript-eslint`)*


------
https://chatgpt.com/codex/tasks/task_e_68b01f758a2c8326a9571a3c2967cf47