### PR TITLE
feat: add profile cards feature

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -16,6 +16,7 @@ import annuaireRoutes from './routes/annuaire.js';
 import entreprisesRoutes from './routes/entreprises.js';
 import ongRoutes from './routes/ong.js';
 import vehiculesRoutes from './routes/vehicules.js';
+import profilesRoutes from './routes/profiles.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -57,6 +58,7 @@ app.use('/api/annuaire-gendarmerie', annuaireRoutes);
 app.use('/api/entreprises', entreprisesRoutes);
 app.use('/api/ong', ongRoutes);
 app.use('/api/vehicules', vehiculesRoutes);
+app.use('/api/profiles', profilesRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -118,6 +118,23 @@ class DatabaseManager {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
       `);
 
+      await this.query(`
+        CREATE TABLE IF NOT EXISTS autres.profiles (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          user_id INT NOT NULL,
+          first_name VARCHAR(255) DEFAULT NULL,
+          last_name VARCHAR(255) DEFAULT NULL,
+          phone VARCHAR(50) DEFAULT NULL,
+          email VARCHAR(255) DEFAULT NULL,
+          extra_fields TEXT,
+          photo_path VARCHAR(255) DEFAULT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          INDEX idx_user_id (user_id),
+          FOREIGN KEY (user_id) REFERENCES autres.users(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
       console.log('✅ Tables système créées avec succès');
     } catch (error) {
       console.error('❌ Erreur création tables système:', error);

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -1,0 +1,58 @@
+import database from '../config/database.js';
+
+class Profile {
+  static async create(data) {
+    const { user_id, first_name, last_name, phone, email, extra_fields = {}, photo_path } = data;
+    const result = await database.query(
+      `INSERT INTO autres.profiles (user_id, first_name, last_name, phone, email, extra_fields, photo_path) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [user_id, first_name, last_name, phone, email, JSON.stringify(extra_fields), photo_path]
+    );
+    return { id: result.insertId, ...data };
+  }
+
+  static async findById(id) {
+    return database.queryOne('SELECT * FROM autres.profiles WHERE id = ?', [id]);
+  }
+
+  static async findAll(userId = null) {
+    let sql = 'SELECT * FROM autres.profiles';
+    const params = [];
+    if (userId) {
+      sql += ' WHERE user_id = ?';
+      params.push(userId);
+    }
+    sql += ' ORDER BY created_at DESC';
+    return database.query(sql, params);
+  }
+
+  static async update(id, data) {
+    const fields = [];
+    const params = [];
+    for (const [key, value] of Object.entries(data)) {
+      fields.push(`${key} = ?`);
+      params.push(key === 'extra_fields' ? JSON.stringify(value) : value);
+    }
+    if (fields.length === 0) return this.findById(id);
+    params.push(id);
+    await database.query(`UPDATE autres.profiles SET ${fields.join(', ')} WHERE id = ?`, params);
+    return this.findById(id);
+  }
+
+  static async delete(id) {
+    await database.query('DELETE FROM autres.profiles WHERE id = ?', [id]);
+    return true;
+  }
+
+  static async searchByNameOrPhone(term, userId, isAdmin) {
+    let sql = 'SELECT * FROM autres.profiles WHERE (first_name LIKE ? OR last_name LIKE ? OR phone LIKE ?)';
+    const params = [`%${term}%`, `%${term}%`, `%${term}%`];
+    if (!isAdmin) {
+      sql += ' AND user_id = ?';
+      params.push(userId);
+    }
+    sql += ' ORDER BY created_at DESC';
+    return database.query(sql, params);
+  }
+}
+
+export default Profile;

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -1,0 +1,100 @@
+import express from 'express';
+import multer from 'multer';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import ProfileService from '../services/ProfileService.js';
+import { authenticate } from '../middleware/auth.js';
+
+const router = express.Router();
+const service = new ProfileService();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    const dir = path.join(__dirname, '../../uploads/profiles');
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    cb(null, dir);
+  },
+  filename: (req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, unique + path.extname(file.originalname));
+  }
+});
+
+const upload = multer({ storage });
+
+router.use(authenticate);
+
+router.post('/', upload.single('photo'), async (req, res) => {
+  try {
+    const data = { ...req.body };
+    if (data.extra_fields && typeof data.extra_fields === 'string') {
+      try { data.extra_fields = JSON.parse(data.extra_fields); } catch (_) {}
+    }
+    const profile = await service.create(data, req.user.id, req.file);
+    res.json({ profile });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/', async (req, res) => {
+  try {
+    const profiles = await service.list(req.user, req.query.q);
+    res.json({ profiles });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const profile = await service.get(parseInt(req.params.id), req.user);
+    if (!profile) return res.status(404).json({ error: 'Profil non trouvé' });
+    res.json({ profile });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.patch('/:id', upload.single('photo'), async (req, res) => {
+  try {
+    const data = { ...req.body };
+    if (data.extra_fields && typeof data.extra_fields === 'string') {
+      try { data.extra_fields = JSON.parse(data.extra_fields); } catch (_) {}
+    }
+    const profile = await service.update(parseInt(req.params.id), data, req.user, req.file);
+    res.json({ profile });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    await service.delete(parseInt(req.params.id), req.user);
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.get('/:id/pdf', async (req, res) => {
+  try {
+    const profile = await service.get(parseInt(req.params.id), req.user);
+    if (!profile) return res.status(404).json({ error: 'Profil non trouvé' });
+    const pdf = await service.generatePDF(profile);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename=profile-${profile.id}.pdf`);
+    res.send(pdf);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/server/scripts/create-profiles-table.js
+++ b/server/scripts/create-profiles-table.js
@@ -1,0 +1,34 @@
+import database from '../config/database.js';
+
+async function createProfilesTable() {
+  await database.query(`
+    CREATE TABLE IF NOT EXISTS autres.profiles (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      user_id INT NOT NULL,
+      first_name VARCHAR(255) DEFAULT NULL,
+      last_name VARCHAR(255) DEFAULT NULL,
+      phone VARCHAR(50) DEFAULT NULL,
+      email VARCHAR(255) DEFAULT NULL,
+      extra_fields TEXT,
+      photo_path VARCHAR(255) DEFAULT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      INDEX idx_user_id (user_id),
+      FOREIGN KEY (user_id) REFERENCES autres.users(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  createProfilesTable()
+    .then(() => {
+      console.log('✅ Table profiles prête');
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error('❌ Erreur création table profiles:', err);
+      process.exit(1);
+    });
+}
+
+export default createProfilesTable;

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Profile from '../models/Profile.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+class ProfileService {
+  constructor() {
+    this.photosDir = path.join(__dirname, '../../uploads/profiles');
+    if (!fs.existsSync(this.photosDir)) {
+      fs.mkdirSync(this.photosDir, { recursive: true });
+    }
+  }
+
+  async create(data, userId, file) {
+    const profileData = {
+      user_id: userId,
+      first_name: data.first_name || null,
+      last_name: data.last_name || null,
+      phone: data.phone || null,
+      email: data.email || null,
+      extra_fields: data.extra_fields || {},
+      photo_path: file ? path.join('uploads/profiles', file.filename) : null
+    };
+    return Profile.create(profileData);
+  }
+
+  async update(id, data, user, file) {
+    const existing = await Profile.findById(id);
+    if (!existing) throw new Error('Profil non trouvé');
+    if (user.admin !== 1 && existing.user_id !== user.id) {
+      throw new Error('Accès refusé');
+    }
+    const updateData = {
+      first_name: data.first_name ?? existing.first_name,
+      last_name: data.last_name ?? existing.last_name,
+      phone: data.phone ?? existing.phone,
+      email: data.email ?? existing.email,
+      extra_fields: data.extra_fields || JSON.parse(existing.extra_fields || '{}'),
+      photo_path: file ? path.join('uploads/profiles', file.filename) : existing.photo_path
+    };
+    return Profile.update(id, updateData);
+  }
+
+  async delete(id, user) {
+    const existing = await Profile.findById(id);
+    if (!existing) throw new Error('Profil non trouvé');
+    if (user.admin !== 1 && existing.user_id !== user.id) {
+      throw new Error('Accès refusé');
+    }
+    return Profile.delete(id);
+  }
+
+  async get(id, user) {
+    const profile = await Profile.findById(id);
+    if (!profile) return null;
+    if (user.admin !== 1 && profile.user_id !== user.id) return null;
+    return profile;
+  }
+
+  async list(user, search) {
+    if (search) {
+      return Profile.searchByNameOrPhone(search, user.id, user.admin === 1);
+    }
+    return Profile.findAll(user.admin === 1 ? null : user.id);
+  }
+
+  async generatePDF(profile) {
+    try {
+      const { default: PDFDocument } = await import('pdfkit');
+      const doc = new PDFDocument();
+      const chunks = [];
+      doc.on('data', chunk => chunks.push(chunk));
+      doc.on('end', () => {});
+
+      doc.fontSize(18).text('Fiche de Profil', { align: 'center' });
+      doc.moveDown();
+      doc.fontSize(12).text(`Nom: ${profile.first_name || ''} ${profile.last_name || ''}`);
+      doc.text(`Téléphone: ${profile.phone || ''}`);
+      doc.text(`Email: ${profile.email || ''}`);
+      if (profile.extra_fields) {
+        try {
+          const extra = JSON.parse(profile.extra_fields);
+          Object.entries(extra).forEach(([k, v]) => {
+            doc.text(`${k}: ${v}`);
+          });
+        } catch (_) {}
+      }
+      doc.end();
+      return Buffer.concat(chunks);
+    } catch (error) {
+      return Buffer.from('PDF generation not available');
+    }
+  }
+}
+
+export default ProfileService;

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+
+interface ExtraField {
+  key: string;
+  value: string;
+}
+
+const ProfileForm: React.FC = () => {
+  const params = new URLSearchParams(window.location.search);
+  const [firstName, setFirstName] = useState(params.get('first_name') || '');
+  const [lastName, setLastName] = useState(params.get('last_name') || '');
+  const [phone, setPhone] = useState(params.get('phone') || '');
+  const [email, setEmail] = useState(params.get('email') || '');
+  const [extraFields, setExtraFields] = useState<ExtraField[]>([]);
+  const [photo, setPhoto] = useState<File | null>(null);
+  const [message, setMessage] = useState('');
+
+  const addField = () => setExtraFields([...extraFields, { key: '', value: '' }]);
+  const removeField = (idx: number) => {
+    setExtraFields(extraFields.filter((_, i) => i !== idx));
+  };
+  const updateField = (idx: number, key: keyof ExtraField, value: string) => {
+    const updated = [...extraFields];
+    updated[idx] = { ...updated[idx], [key]: value };
+    setExtraFields(updated);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const form = new FormData();
+    form.append('first_name', firstName);
+    form.append('last_name', lastName);
+    form.append('phone', phone);
+    form.append('email', email);
+    const extras: Record<string, string> = {};
+    extraFields.forEach(f => {
+      if (f.key) extras[f.key] = f.value;
+    });
+    form.append('extra_fields', JSON.stringify(extras));
+    if (photo) form.append('photo', photo);
+    const token = localStorage.getItem('token');
+    const res = await fetch('/api/profiles', {
+      method: 'POST',
+      headers: {
+        Authorization: token ? `Bearer ${token}` : ''
+      },
+      body: form
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setMessage('Profil créé avec succès');
+    } else {
+      setMessage(data.error || 'Erreur lors de la création');
+    }
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={submit}>
+      {message && <div className="text-sm text-green-600">{message}</div>}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <input
+          className="border p-2 rounded"
+          placeholder="Prénom"
+          value={firstName}
+          onChange={e => setFirstName(e.target.value)}
+        />
+        <input
+          className="border p-2 rounded"
+          placeholder="Nom"
+          value={lastName}
+          onChange={e => setLastName(e.target.value)}
+        />
+        <input
+          className="border p-2 rounded"
+          placeholder="Téléphone"
+          value={phone}
+          onChange={e => setPhone(e.target.value)}
+        />
+        <input
+          className="border p-2 rounded"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        {extraFields.map((field, idx) => (
+          <div key={idx} className="flex space-x-2">
+            <input
+              className="border p-2 rounded w-1/2"
+              placeholder="Libellé"
+              value={field.key}
+              onChange={e => updateField(idx, 'key', e.target.value)}
+            />
+            <input
+              className="border p-2 rounded w-1/2"
+              placeholder="Valeur"
+              value={field.value}
+              onChange={e => updateField(idx, 'value', e.target.value)}
+            />
+            <button type="button" className="text-red-600" onClick={() => removeField(idx)}>Supprimer</button>
+          </div>
+        ))}
+        <button type="button" className="px-3 py-1 bg-gray-200 rounded" onClick={addField}>Ajouter un champ</button>
+      </div>
+      <div>
+        <input type="file" onChange={e => setPhoto(e.target.files?.[0] || null)} />
+      </div>
+      <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded">Enregistrer</button>
+    </form>
+  );
+};
+
+export default ProfileForm;

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+
+interface Profile {
+  id: number;
+  first_name: string | null;
+  last_name: string | null;
+  phone: string | null;
+  email: string | null;
+}
+
+const ProfileList: React.FC = () => {
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [query, setQuery] = useState('');
+  const token = localStorage.getItem('token');
+
+  const load = async () => {
+    const res = await fetch(`/api/profiles?q=${encodeURIComponent(query)}`, {
+      headers: {
+        Authorization: token ? `Bearer ${token}` : ''
+      }
+    });
+    const data = await res.json();
+    setProfiles(data.profiles || []);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const remove = async (id: number) => {
+    await fetch(`/api/profiles/${id}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: token ? `Bearer ${token}` : ''
+      }
+    });
+    load();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <input
+          className="border p-2 rounded flex-1"
+          placeholder="Recherche"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-indigo-600 text-white rounded" onClick={load}>Rechercher</button>
+      </div>
+      <ul className="divide-y">
+        {profiles.map(p => (
+          <li key={p.id} className="py-2 flex items-center justify-between">
+            <span>{p.first_name} {p.last_name} - {p.phone}</span>
+            <div className="space-x-2">
+              <a
+                className="text-blue-600"
+                href={`/api/profiles/${p.id}/pdf`}
+                target="_blank"
+                rel="noopener"
+              >PDF</a>
+              <button className="text-red-600" onClick={() => remove(p.id)}>Supprimer</button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ProfileList;

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -50,6 +50,22 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query }) => {
               );
             })}
           </div>
+          <div className="px-6 pb-6">
+            <button
+              className="mt-2 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+              onClick={() => {
+                const params = new URLSearchParams({
+                  first_name: String(hit.preview.first_name || ''),
+                  last_name: String(hit.preview.last_name || ''),
+                  phone: String(hit.preview.phone || ''),
+                  email: String(hit.preview.email || '')
+                });
+                window.location.href = `/profiles/new?${params.toString()}`;
+              }}
+            >
+              Créer profil
+            </button>
+          </div>
         </div>
       ))}
     </div>
@@ -57,4 +73,3 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query }) => {
 };
 
 export default SearchResultProfiles;
-


### PR DESCRIPTION
## Summary
- add database table and model for user profile cards
- implement service and REST routes for managing profiles with optional PDF export
- add basic React components and create-profile button in search results

## Testing
- `npm run lint` (fails: Invalid option '--ext' - using eslint.config.js)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b026fa7a1883268917e28cc239e0ad