### PR TITLE
feat: improve profile creation flow and list view

### DIFF
--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -6,9 +6,15 @@ interface Profile {
   last_name: string | null;
   phone: string | null;
   email: string | null;
+  photo_path: string | null;
 }
 
-const ProfileList: React.FC = () => {
+interface ProfileListProps {
+  onCreate?: () => void;
+  onEdit?: (id: number) => void;
+}
+
+const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [query, setQuery] = useState('');
   const token = localStorage.getItem('token');
@@ -47,12 +53,36 @@ const ProfileList: React.FC = () => {
           onChange={e => setQuery(e.target.value)}
         />
         <button className="px-4 py-2 bg-indigo-600 text-white rounded" onClick={load}>Rechercher</button>
+        {onCreate && (
+          <button
+            className="px-4 py-2 bg-green-600 text-white rounded"
+            onClick={onCreate}
+          >
+            Créer profil
+          </button>
+        )}
       </div>
       <ul className="divide-y">
         {profiles.map(p => (
           <li key={p.id} className="py-2 flex items-center justify-between">
-            <span>{p.first_name} {p.last_name} - {p.phone}</span>
-            <div className="space-x-2">
+            <div className="flex items-center space-x-3">
+              {p.photo_path && (
+                <img
+                  src={`/${p.photo_path}`}
+                  alt="profil"
+                  className="w-12 h-12 rounded-full object-cover"
+                />
+              )}
+              <div className="flex flex-col">
+                <span className="font-medium">{p.first_name} {p.last_name}</span>
+                <span className="text-sm text-gray-600">{p.phone}</span>
+                <span className="text-sm text-gray-600">{p.email}</span>
+              </div>
+            </div>
+            <div className="space-x-2 flex items-center">
+              {onEdit && (
+                <button className="text-indigo-600" onClick={() => onEdit(p.id)}>Modifier</button>
+              )}
               <a
                 className="text-blue-600"
                 href={`/api/profiles/${p.id}/pdf`}

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -11,9 +11,15 @@ interface SearchResult {
 interface ProfilesProps {
   hits: SearchResult[];
   query: string;
+  onCreateProfile?: (data: {
+    first_name: string;
+    last_name: string;
+    phone: string;
+    email: string;
+  }) => void;
 }
 
-const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query }) => {
+const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreateProfile }) => {
   if (hits.length === 0) {
     return (
       <div className="text-center text-gray-500">Aucun résultat pour {query}</div>
@@ -57,13 +63,18 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query }) => {
           className="mt-4 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
           onClick={() => {
             const firstHit = hits[0];
-            const params = new URLSearchParams({
+            const data = {
               first_name: String(firstHit.preview.first_name || ''),
               last_name: String(firstHit.preview.last_name || ''),
               phone: String(firstHit.preview.phone || ''),
               email: String(firstHit.preview.email || '')
-            });
-            window.location.href = `/profiles/new?${params.toString()}`;
+            };
+            if (onCreateProfile) {
+              onCreateProfile(data);
+            } else {
+              const params = new URLSearchParams(data);
+              window.location.href = `/profiles/new?${params.toString()}`;
+            }
           }}
         >
           Créer profil


### PR DESCRIPTION
## Summary
- enable profile creation from search results without dashboard redirect
- enhance profile list with photos, edit option, and internal create button
- support editing profiles via improved form component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b02efd05148326be2a6d6910a37ca3