### PR TITLE
fix: enable profile creation from search results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,8 +272,15 @@ const App: React.FC = () => {
     last_name?: string;
     phone?: string;
     email?: string;
+    extra_fields?: Record<string, string>;
   }) => {
-    setProfileDefaults({ ...data });
+    setProfileDefaults({
+      first_name: data.first_name || '',
+      last_name: data.last_name || '',
+      phone: data.phone || '',
+      email: data.email || '',
+      extra_fields: data.extra_fields || {}
+    });
     setEditingProfileId(null);
     setShowProfileForm(true);
     setCurrentPage('profiles');
@@ -1572,6 +1579,27 @@ const App: React.FC = () => {
                               </div>
                             </div>
                           ))}
+                        </div>
+                        <div className="mt-8 text-center">
+                          <button
+                            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                            onClick={() => {
+                              const firstHit = searchResults.hits[0];
+                              const { first_name, last_name, phone, email, ...extra } = firstHit.preview || {};
+                              const data = {
+                                first_name: String(first_name || ''),
+                                last_name: String(last_name || ''),
+                                phone: String(phone || ''),
+                                email: String(email || ''),
+                                extra_fields: Object.fromEntries(
+                                  Object.entries(extra).map(([k, v]) => [k, String(v ?? '')])
+                                )
+                              };
+                              openCreateProfile(data);
+                            }}
+                          >
+                            Créer profil
+                          </button>
                         </div>
                       </div>
                     ) : (

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -44,8 +44,8 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex space-x-2">
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row gap-2">
         <input
           className="border p-2 rounded flex-1"
           placeholder="Recherche"
@@ -62,38 +62,42 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
           </button>
         )}
       </div>
-      <ul className="divide-y">
-        {profiles.map(p => (
-          <li key={p.id} className="py-2 flex items-center justify-between">
-            <div className="flex items-center space-x-3">
-              {p.photo_path && (
-                <img
-                  src={`/${p.photo_path}`}
-                  alt="profil"
-                  className="w-12 h-12 rounded-full object-cover"
-                />
-              )}
-              <div className="flex flex-col">
-                <span className="font-medium">{p.first_name} {p.last_name}</span>
-                <span className="text-sm text-gray-600">{p.phone}</span>
-                <span className="text-sm text-gray-600">{p.email}</span>
+      {profiles.length === 0 ? (
+        <div className="text-center text-gray-500">Aucun profil trouvé</div>
+      ) : (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {profiles.map(p => (
+            <div key={p.id} className="bg-white shadow rounded-xl p-4 flex flex-col">
+              <div className="flex items-center space-x-4">
+                {p.photo_path && (
+                  <img
+                    src={`/${p.photo_path}`}
+                    alt="profil"
+                    className="w-16 h-16 rounded-full object-cover"
+                  />
+                )}
+                <div>
+                  <h3 className="text-lg font-semibold">{p.first_name} {p.last_name}</h3>
+                  <p className="text-sm text-gray-500">{p.phone}</p>
+                  <p className="text-sm text-gray-500">{p.email}</p>
+                </div>
+              </div>
+              <div className="mt-4 flex justify-end space-x-4 text-sm">
+                {onEdit && (
+                  <button className="text-indigo-600 hover:underline" onClick={() => onEdit(p.id)}>Modifier</button>
+                )}
+                <a
+                  className="text-blue-600 hover:underline"
+                  href={`/api/profiles/${p.id}/pdf`}
+                  target="_blank"
+                  rel="noopener"
+                >PDF</a>
+                <button className="text-red-600 hover:underline" onClick={() => remove(p.id)}>Supprimer</button>
               </div>
             </div>
-            <div className="space-x-2 flex items-center">
-              {onEdit && (
-                <button className="text-indigo-600" onClick={() => onEdit(p.id)}>Modifier</button>
-              )}
-              <a
-                className="text-blue-600"
-                href={`/api/profiles/${p.id}/pdf`}
-                target="_blank"
-                rel="noopener"
-              >PDF</a>
-              <button className="text-red-600" onClick={() => remove(p.id)}>Supprimer</button>
-            </div>
-          </li>
-        ))}
-      </ul>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -16,6 +16,7 @@ interface ProfilesProps {
     last_name: string;
     phone: string;
     email: string;
+    extra_fields?: Record<string, string>;
   }) => void;
 }
 
@@ -63,16 +64,20 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
           className="mt-4 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
           onClick={() => {
             const firstHit = hits[0];
+            const { first_name, last_name, phone, email, ...extra } = firstHit.preview || {};
             const data = {
-              first_name: String(firstHit.preview.first_name || ''),
-              last_name: String(firstHit.preview.last_name || ''),
-              phone: String(firstHit.preview.phone || ''),
-              email: String(firstHit.preview.email || '')
+              first_name: String(first_name || ''),
+              last_name: String(last_name || ''),
+              phone: String(phone || ''),
+              email: String(email || ''),
+              extra_fields: Object.fromEntries(
+                Object.entries(extra).map(([k, v]) => [k, String(v ?? '')])
+              )
             };
             if (onCreateProfile) {
               onCreateProfile(data);
             } else {
-              const params = new URLSearchParams(data);
+              const params = new URLSearchParams(data as any);
               window.location.href = `/profiles/new?${params.toString()}`;
             }
           }}


### PR DESCRIPTION
## Summary
- show Create Profile in list view search results
- preload search data when creating a profile
- modernize profile list layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68b0326715208326a1e3d2ceb7a1583b