### PR TITLE
feat: modern profile form with preview and pagination

### DIFF
--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -14,15 +14,19 @@ class Profile {
     return database.queryOne('SELECT * FROM autres.profiles WHERE id = ?', [id]);
   }
 
-  static async findAll(userId = null) {
-    let sql = 'SELECT * FROM autres.profiles';
+  static async findAll(userId = null, limit = 10, offset = 0) {
+    let base = 'FROM autres.profiles';
     const params = [];
     if (userId) {
-      sql += ' WHERE user_id = ?';
+      base += ' WHERE user_id = ?';
       params.push(userId);
     }
-    sql += ' ORDER BY created_at DESC';
-    return database.query(sql, params);
+    const rows = await database.query(
+      `SELECT * ${base} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
+    );
+    const totalRes = await database.queryOne(`SELECT COUNT(*) as count ${base}`, params);
+    return { rows, total: totalRes.count };
   }
 
   static async update(id, data) {
@@ -43,15 +47,19 @@ class Profile {
     return true;
   }
 
-  static async searchByNameOrPhone(term, userId, isAdmin) {
-    let sql = 'SELECT * FROM autres.profiles WHERE (first_name LIKE ? OR last_name LIKE ? OR phone LIKE ?)';
+  static async searchByNameOrPhone(term, userId, isAdmin, limit = 10, offset = 0) {
+    let base = 'FROM autres.profiles WHERE (first_name LIKE ? OR last_name LIKE ? OR phone LIKE ?)';
     const params = [`%${term}%`, `%${term}%`, `%${term}%`];
     if (!isAdmin) {
-      sql += ' AND user_id = ?';
+      base += ' AND user_id = ?';
       params.push(userId);
     }
-    sql += ' ORDER BY created_at DESC';
-    return database.query(sql, params);
+    const rows = await database.query(
+      `SELECT * ${base} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
+    );
+    const totalRes = await database.queryOne(`SELECT COUNT(*) as count ${base}`, params);
+    return { rows, total: totalRes.count };
   }
 }
 

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -45,8 +45,10 @@ router.post('/', upload.single('photo'), async (req, res) => {
 
 router.get('/', async (req, res) => {
   try {
-    const profiles = await service.list(req.user, req.query.q);
-    res.json({ profiles });
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 10;
+    const { rows, total } = await service.list(req.user, req.query.q, page, limit);
+    res.json({ profiles: rows, total });
   } catch (error) {
     res.status(500).json({ error: error.message });
   }

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -60,11 +60,12 @@ class ProfileService {
     return profile;
   }
 
-  async list(user, search) {
+  async list(user, search, page = 1, limit = 10) {
+    const offset = (page - 1) * limit;
     if (search) {
-      return Profile.searchByNameOrPhone(search, user.id, user.admin === 1);
+      return Profile.searchByNameOrPhone(search, user.id, user.admin === 1, limit, offset);
     }
-    return Profile.findAll(user.admin === 1 ? null : user.id);
+    return Profile.findAll(user.admin === 1 ? null : user.id, limit, offset);
   }
 
   async generatePDF(profile) {

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -19,49 +19,72 @@ interface ProfileFormProps {
   onSaved?: () => void;
 }
 
+const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
+
 const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId, onSaved }) => {
-  const params = new URLSearchParams(window.location.search);
-  const [firstName, setFirstName] = useState(initialValues.first_name || params.get('first_name') || '');
-  const [lastName, setLastName] = useState(initialValues.last_name || params.get('last_name') || '');
-  const [phone, setPhone] = useState(initialValues.phone || params.get('phone') || '');
-  const [email, setEmail] = useState(initialValues.email || params.get('email') || '');
-  const [extraFields, setExtraFields] = useState<ExtraField[]>(() => {
+  const [fields, setFields] = useState<ExtraField[]>(() => {
+    const arr: ExtraField[] = [];
+    if (initialValues.first_name) arr.push({ key: 'First Name', value: initialValues.first_name });
+    if (initialValues.last_name) arr.push({ key: 'Last Name', value: initialValues.last_name });
+    if (initialValues.phone) arr.push({ key: 'Phone', value: initialValues.phone });
+    if (initialValues.email) arr.push({ key: 'Email', value: initialValues.email });
     const extras = initialValues.extra_fields || {};
-    return Object.entries(extras).map(([key, value]) => ({ key, value }));
+    Object.entries(extras).forEach(([k, v]) => arr.push({ key: capitalize(k), value: v }));
+    return arr;
   });
   const [photo, setPhoto] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    setFirstName(initialValues.first_name || '');
-    setLastName(initialValues.last_name || '');
-    setPhone(initialValues.phone || '');
-    setEmail(initialValues.email || '');
+    const arr: ExtraField[] = [];
+    if (initialValues.first_name) arr.push({ key: 'First Name', value: initialValues.first_name });
+    if (initialValues.last_name) arr.push({ key: 'Last Name', value: initialValues.last_name });
+    if (initialValues.phone) arr.push({ key: 'Phone', value: initialValues.phone });
+    if (initialValues.email) arr.push({ key: 'Email', value: initialValues.email });
     const extras = initialValues.extra_fields || {};
-    setExtraFields(Object.entries(extras).map(([key, value]) => ({ key, value })));
+    Object.entries(extras).forEach(([k, v]) => arr.push({ key: capitalize(k), value: v }));
+    setFields(arr);
   }, [initialValues, profileId]);
 
-  const addField = () => setExtraFields([...extraFields, { key: '', value: '' }]);
+  const addField = () => setFields([...fields, { key: '', value: '' }]);
   const removeField = (idx: number) => {
-    setExtraFields(extraFields.filter((_, i) => i !== idx));
+    setFields(fields.filter((_, i) => i !== idx));
   };
   const updateField = (idx: number, key: keyof ExtraField, value: string) => {
-    const updated = [...extraFields];
+    const updated = [...fields];
+    if (key === 'key') value = capitalize(value);
     updated[idx] = { ...updated[idx], [key]: value };
-    setExtraFields(updated);
+    setFields(updated);
+  };
+
+  const handlePhoto = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setPhoto(file);
+    setPreview(file ? URL.createObjectURL(file) : null);
   };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     const form = new FormData();
+    let firstName = '';
+    let lastName = '';
+    let phone = '';
+    let email = '';
+    const extras: Record<string, string> = {};
+    fields.forEach(f => {
+      const key = f.key.trim();
+      const lower = key.toLowerCase();
+      if (lower === 'first name') firstName = f.value;
+      else if (lower === 'last name') lastName = f.value;
+      else if (lower === 'phone') phone = f.value;
+      else if (lower === 'email') email = f.value;
+      else if (key) extras[key] = f.value;
+    });
     form.append('first_name', firstName);
     form.append('last_name', lastName);
     form.append('phone', phone);
     form.append('email', email);
-    const extras: Record<string, string> = {};
-    extraFields.forEach(f => {
-      if (f.key) extras[f.key] = f.value;
-    });
     form.append('extra_fields', JSON.stringify(extras));
     if (photo) form.append('photo', photo);
     const token = localStorage.getItem('token');
@@ -84,58 +107,59 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
   };
 
   return (
-    <form className="space-y-4" onSubmit={submit}>
+    <form
+      className="max-w-lg mx-auto bg-white p-6 rounded-xl shadow-md space-y-4"
+      onSubmit={submit}
+    >
       {message && <div className="text-sm text-green-600">{message}</div>}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <input
-          className="border p-2 rounded"
-          placeholder="Prénom"
-          value={firstName}
-          onChange={e => setFirstName(e.target.value)}
-        />
-        <input
-          className="border p-2 rounded"
-          placeholder="Nom"
-          value={lastName}
-          onChange={e => setLastName(e.target.value)}
-        />
-        <input
-          className="border p-2 rounded"
-          placeholder="Téléphone"
-          value={phone}
-          onChange={e => setPhone(e.target.value)}
-        />
-        <input
-          className="border p-2 rounded"
-          placeholder="Email"
-          value={email}
-          onChange={e => setEmail(e.target.value)}
-        />
-      </div>
       <div className="space-y-2">
-        {extraFields.map((field, idx) => (
+        {fields.map((field, idx) => (
           <div key={idx} className="flex space-x-2">
             <input
-              className="border p-2 rounded w-1/2"
-              placeholder="Libellé"
+              className="flex-1 border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              placeholder="Nom du champ"
               value={field.key}
               onChange={e => updateField(idx, 'key', e.target.value)}
             />
             <input
-              className="border p-2 rounded w-1/2"
+              className="flex-1 border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="Valeur"
               value={field.value}
               onChange={e => updateField(idx, 'value', e.target.value)}
             />
-            <button type="button" className="text-red-600" onClick={() => removeField(idx)}>Supprimer</button>
+            <button
+              type="button"
+              className="text-red-600"
+              onClick={() => removeField(idx)}
+            >
+              Supprimer
+            </button>
           </div>
         ))}
-        <button type="button" className="px-3 py-1 bg-gray-200 rounded" onClick={addField}>Ajouter un champ</button>
+        <button
+          type="button"
+          className="px-3 py-1 bg-gray-200 rounded"
+          onClick={addField}
+        >
+          Ajouter un champ
+        </button>
       </div>
       <div>
-        <input type="file" onChange={e => setPhoto(e.target.files?.[0] || null)} />
+        <input type="file" onChange={handlePhoto} />
+        {preview && (
+          <img
+            src={preview}
+            alt="preview"
+            className="mt-2 w-32 h-32 object-cover rounded-full"
+          />
+        )}
       </div>
-      <button type="submit" className="px-4 py-2 bg-indigo-600 text-white rounded">Enregistrer</button>
+      <button
+        type="submit"
+        className="px-4 py-2 bg-indigo-600 text-white rounded"
+      >
+        Enregistrer
+      </button>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- redesign profile creation form with user-defined fields and photo preview
- show quick profile data with modal details and pagination support
- add server-side pagination for profile queries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68b036f8532083268758267b6b652e6e