### PR TITLE
Use all search data for profile creation and modernize preview

### DIFF
--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
 
 interface Profile {
   id: number;
@@ -164,8 +165,21 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
       )}
       {selected && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
-          <div className="bg-white p-6 rounded-lg max-w-md w-full">
-            <h2 className="text-xl font-semibold mb-4">Détails du profil</h2>
+          <div className="relative bg-white p-6 rounded-2xl shadow-2xl max-w-md w-full">
+            <button
+              className="absolute top-4 right-4 text-gray-500 hover:text-gray-700"
+              onClick={() => setSelected(null)}
+            >
+              <X className="w-5 h-5" />
+            </button>
+            {selected.photo_path && (
+              <img
+                src={`/${selected.photo_path}`}
+                alt="profil"
+                className="mx-auto w-32 h-32 rounded-full object-cover mb-4"
+              />
+            )}
+            <h2 className="text-2xl font-semibold text-center mb-4">Détails du profil</h2>
             <div className="space-y-2 text-sm">
               {(() => {
                 const extra = selected.extra_fields ? JSON.parse(selected.extra_fields) : {};
@@ -184,12 +198,6 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
                 ));
               })()}
             </div>
-            <button
-              className="mt-4 px-4 py-2 bg-indigo-600 text-white rounded"
-              onClick={() => setSelected(null)}
-            >
-              Fermer
-            </button>
           </div>
         </div>
       )}

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -63,8 +63,15 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
         <button
           className="mt-4 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
           onClick={() => {
-            const firstHit = hits[0];
-            const { first_name, last_name, phone, email, ...extra } = firstHit.preview || {};
+            const combined: Record<string, any> = {};
+            hits.forEach(h => {
+              Object.entries(h.preview || {}).forEach(([k, v]) => {
+                if (v != null && combined[k] === undefined) {
+                  combined[k] = v;
+                }
+              });
+            });
+            const { first_name, last_name, phone, email, ...extra } = combined;
             const data = {
               first_name: String(first_name || ''),
               last_name: String(last_name || ''),


### PR DESCRIPTION
## Summary
- Combine all search hits into the profile creation payload instead of using only the first result
- Redesign profile preview modal with centered photo and icon-based close button

## Testing
- `npm run lint` *(fails: Invalid option '--ext' with eslint.config.js)*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68b03b73710483269d4933b3cbf8059b