### PR TITLE
fix: preserve metadata when loading more results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -479,11 +479,12 @@ const App: React.FC = () => {
       const data = await response.json();
 
       if (response.ok) {
-        setSearchResults(prev =>
+        setSearchResults((prev) =>
           prev
             ? {
+                ...prev,
                 ...data,
-                hits: [...prev.hits, ...data.hits],
+                hits: [...prev.hits, ...(data.hits || [])],
                 tables_searched: Array.from(
                   new Set([...(prev.tables_searched || []), ...(data.tables_searched || [])])
                 )


### PR DESCRIPTION
## Summary
- keep previous search metadata when appending new results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68b03f78dbe48326a9fd89832047db6c