### PR TITLE
Fix profile creation data merge and preview fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1585,8 +1585,15 @@ const App: React.FC = () => {
                           <button
                             className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
                             onClick={() => {
-                              const firstHit = searchResults.hits[0];
-                              const { first_name, last_name, phone, email, ...extra } = firstHit.preview || {};
+                              const combined: Record<string, any> = {};
+                              searchResults.hits.forEach(h => {
+                                Object.entries(h.preview || {}).forEach(([k, v]) => {
+                                  if (v != null && combined[k] === undefined) {
+                                    combined[k] = v;
+                                  }
+                                });
+                              });
+                              const { first_name, last_name, phone, email, ...extra } = combined;
                               const data = {
                                 first_name: String(first_name || ''),
                                 last_name: String(last_name || ''),

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -184,18 +184,17 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               {(() => {
                 const extra = selected.extra_fields ? JSON.parse(selected.extra_fields) : {};
                 const all: Record<string, string | null> = {
-                  'First Name': selected.first_name,
-                  'Last Name': selected.last_name,
-                  Phone: selected.phone,
                   Email: selected.email,
                   ...extra
                 };
-                return Object.entries(all).map(([k, v]) => (
-                  <div key={k} className="flex justify-between">
-                    <span className="font-medium mr-2">{k}:</span>
-                    <span>{v}</span>
-                  </div>
-                ));
+                return Object.entries(all)
+                  .filter(([, v]) => v && v !== '')
+                  .map(([k, v]) => (
+                    <div key={k} className="flex justify-between">
+                      <span className="font-medium mr-2">{k}:</span>
+                      <span>{v}</span>
+                    </div>
+                  ));
               })()}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- ensure creating profile from list view merges fields from all search hits
- remove default name and phone fields from profile preview

## Testing
- `npm run lint` *(fails: Invalid option '--ext' and missing package 'typescript-eslint')*
- `npx eslint src/App.tsx src/components/ProfileList.tsx` *(fails: Cannot find package 'typescript-eslint')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b04293de248326856e52f37fd90a41