### PR TITLE
feat: add profile comments and export option

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -126,6 +126,7 @@ class DatabaseManager {
           last_name VARCHAR(255) DEFAULT NULL,
           phone VARCHAR(50) DEFAULT NULL,
           email VARCHAR(255) DEFAULT NULL,
+          comment TEXT DEFAULT NULL,
           extra_fields TEXT,
           photo_path VARCHAR(255) DEFAULT NULL,
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -2,10 +2,10 @@ import database from '../config/database.js';
 
 class Profile {
   static async create(data) {
-    const { user_id, first_name, last_name, phone, email, extra_fields = {}, photo_path } = data;
+    const { user_id, first_name, last_name, phone, email, comment, extra_fields = {}, photo_path } = data;
     const result = await database.query(
-      `INSERT INTO autres.profiles (user_id, first_name, last_name, phone, email, extra_fields, photo_path) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      [user_id, first_name, last_name, phone, email, JSON.stringify(extra_fields), photo_path]
+      `INSERT INTO autres.profiles (user_id, first_name, last_name, phone, email, comment, extra_fields, photo_path) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [user_id, first_name, last_name, phone, email, comment, JSON.stringify(extra_fields), photo_path]
     );
     return { id: result.insertId, ...data };
   }

--- a/server/scripts/create-profiles-table.js
+++ b/server/scripts/create-profiles-table.js
@@ -9,6 +9,7 @@ async function createProfilesTable() {
       last_name VARCHAR(255) DEFAULT NULL,
       phone VARCHAR(50) DEFAULT NULL,
       email VARCHAR(255) DEFAULT NULL,
+      comment TEXT DEFAULT NULL,
       extra_fields TEXT,
       photo_path VARCHAR(255) DEFAULT NULL,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -21,6 +21,7 @@ class ProfileService {
       last_name: data.last_name || null,
       phone: data.phone || null,
       email: data.email || null,
+      comment: data.comment || null,
       extra_fields: data.extra_fields || {},
       photo_path: file ? path.join('uploads/profiles', file.filename) : null
     };
@@ -38,6 +39,7 @@ class ProfileService {
       last_name: data.last_name ?? existing.last_name,
       phone: data.phone ?? existing.phone,
       email: data.email ?? existing.email,
+      comment: data.comment ?? existing.comment,
       extra_fields: data.extra_fields || JSON.parse(existing.extra_fields || '{}'),
       photo_path: file ? path.join('uploads/profiles', file.filename) : existing.photo_path
     };
@@ -81,6 +83,9 @@ class ProfileService {
       doc.fontSize(12).text(`Nom: ${profile.first_name || ''} ${profile.last_name || ''}`);
       doc.text(`Téléphone: ${profile.phone || ''}`);
       doc.text(`Email: ${profile.email || ''}`);
+      if (profile.comment) {
+        doc.text(`Commentaire: ${profile.comment}`);
+      }
       if (profile.extra_fields) {
         try {
           const extra = JSON.parse(profile.extra_fields);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -235,6 +235,7 @@ const App: React.FC = () => {
     last_name?: string;
     phone?: string;
     email?: string;
+    comment?: string;
     extra_fields?: Record<string, string>;
   }>({});
   const [editingProfileId, setEditingProfileId] = useState<number | null>(null);
@@ -272,6 +273,7 @@ const App: React.FC = () => {
     last_name?: string;
     phone?: string;
     email?: string;
+    comment?: string;
     extra_fields?: Record<string, string>;
   }) => {
     setProfileDefaults({
@@ -279,6 +281,7 @@ const App: React.FC = () => {
       last_name: data.last_name || '',
       phone: data.phone || '',
       email: data.email || '',
+      comment: data.comment || '',
       extra_fields: data.extra_fields || {}
     });
     setEditingProfileId(null);
@@ -307,6 +310,7 @@ const App: React.FC = () => {
         last_name: profile.last_name || '',
         phone: profile.phone || '',
         email: profile.email || '',
+        comment: profile.comment || '',
         extra_fields: extra
       });
       setEditingProfileId(id);

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -10,6 +10,7 @@ interface InitialValues {
   last_name?: string;
   phone?: string;
   email?: string;
+  comment?: string;
   extra_fields?: Record<string, string>;
 }
 
@@ -35,6 +36,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
   const [photo, setPhoto] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [message, setMessage] = useState('');
+  const [comment, setComment] = useState(initialValues.comment || '');
 
   useEffect(() => {
     const arr: ExtraField[] = [];
@@ -45,6 +47,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
     const extras = initialValues.extra_fields || {};
     Object.entries(extras).forEach(([k, v]) => arr.push({ key: capitalize(k), value: v }));
     setFields(arr);
+    setComment(initialValues.comment || '');
   }, [initialValues, profileId]);
 
   const addField = () => setFields([...fields, { key: '', value: '' }]);
@@ -85,6 +88,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
     form.append('last_name', lastName);
     form.append('phone', phone);
     form.append('email', email);
+    form.append('comment', comment);
     form.append('extra_fields', JSON.stringify(extras));
     if (photo) form.append('photo', photo);
     const token = localStorage.getItem('token');
@@ -143,6 +147,14 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
         >
           Ajouter un champ
         </button>
+      </div>
+      <div>
+        <label className="block mb-1">Commentaire</label>
+        <textarea
+          className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          value={comment}
+          onChange={e => setComment(e.target.value)}
+        />
       </div>
       <div>
         <input type="file" onChange={handlePhoto} />

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -7,6 +7,7 @@ interface Profile {
   last_name: string | null;
   phone: string | null;
   email: string | null;
+  comment: string | null;
   photo_path: string | null;
   extra_fields?: string | null;
 }
@@ -125,18 +126,18 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
                         Modifier
                       </button>
                     )}
-                    <a
-                      className="text-blue-600 hover:underline"
-                      href={`/api/profiles/${p.id}/pdf`}
-                      target="_blank"
-                      rel="noopener"
-                    >PDF</a>
                     <button
                       className="text-red-600 hover:underline"
                       onClick={() => remove(p.id)}
                     >
                       Supprimer
                     </button>
+                    <a
+                      className="text-blue-600 hover:underline"
+                      href={`/api/profiles/${p.id}/pdf`}
+                      target="_blank"
+                      rel="noopener"
+                    >Exporter Profil</a>
                   </div>
                 </div>
               );
@@ -180,10 +181,11 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               />
             )}
             <h2 className="text-2xl font-semibold text-center mb-4">Détails du profil</h2>
-            <div className="space-y-2 text-sm">
+            <div className="space-y-2 text-sm max-h-60 overflow-y-auto">
               {(() => {
                 const extra = selected.extra_fields ? JSON.parse(selected.extra_fields) : {};
                 const all: Record<string, string | null> = {
+                  Commentaire: selected.comment,
                   Email: selected.email,
                   ...extra
                 };

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -16,6 +16,7 @@ interface ProfilesProps {
     last_name: string;
     phone: string;
     email: string;
+    comment?: string;
     extra_fields?: Record<string, string>;
   }) => void;
 }


### PR DESCRIPTION
## Summary
- add comment text field for profiles and store it on server
- allow scrolling preview of profile details
- rename PDF link to Exporter Profil in profile list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b046c75e2c8326a6de44d27ccd5a33