### PR TITLE
fix: handle profile list parsing errors

### DIFF
--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -45,7 +45,8 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
         setTotal(0);
         return;
       }
-      setProfiles(data.profiles || []);
+      // Ensure the profiles field from the API is always an array
+      setProfiles(Array.isArray(data.profiles) ? data.profiles : []);
       setTotal(data.total || 0);
     } catch (err) {
       setError('Erreur de réseau');
@@ -111,6 +112,8 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               let parsed: any[] = [];
               try {
                 parsed = p.extra_fields ? JSON.parse(p.extra_fields) : [];
+                // Some records might store extra_fields as an object instead of an array
+                parsed = Array.isArray(parsed) ? parsed : [];
               } catch {
                 parsed = [];
               }


### PR DESCRIPTION
## Summary
- Ensure API profiles field is always treated as an array
- Guard ProfileList against non-array extra_fields data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_68b068d3fd248326b816bb1e79518cdb