### PR TITLE
Fix dark mode preview background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,7 @@
   .dark .bg-white\/60 { @apply bg-gray-800/60; }
   .dark .bg-white\/70 { @apply bg-gray-800/70; }
   .dark .bg-white\/80 { @apply bg-gray-800/80; }
+  .dark .bg-white\/90 { @apply bg-gray-800/90; }
   .dark .border-gray-100 { @apply border-gray-700; }
   .dark .border-gray-200 { @apply border-gray-700; }
   .dark .border-gray-300 { @apply border-gray-600; }


### PR DESCRIPTION
## Summary
- ensure profile preview modal adopts dark background when theme is dark

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext'; using eslint.config.js)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b06ecfa1848326aa51f50b1317c78b