### PR TITLE
feat: improve profile pdf export

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mysql2": "^3.6.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "pdfkit": "^0.13.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",


### PR DESCRIPTION
## Summary
- enhance profile PDF generator with header, field layout, and optional photo
- add pdfkit dependency for PDF rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm install` *(fails: 403 Forbidden for pdfkit package)*

------
https://chatgpt.com/codex/tasks/task_e_68b077ff7ec4832686d102071dccf586