### PR TITLE
Remove default profile fields and fix profile export auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -274,17 +274,11 @@ const App: React.FC = () => {
   const [uploadFile, setUploadFile] = useState<File | null>(null);
 
   const openCreateProfile = (data: {
-    first_name?: string;
-    last_name?: string;
-    phone?: string;
     email?: string;
     comment?: string;
     extra_fields?: Record<string, string>;
   }) => {
     const infoFields: ExtraField[] = [
-      { key: 'First Name', value: data.first_name || '' },
-      { key: 'Last Name', value: data.last_name || '' },
-      { key: 'Phone', value: data.phone || '' },
       { key: 'Email', value: data.email || '' }
     ];
     const extraFields: ExtraField[] = Object.entries(data.extra_fields || {}).map(([k, v]) => ({
@@ -334,9 +328,6 @@ const App: React.FC = () => {
           {
             title: 'Informations',
             fields: [
-              { key: 'First Name', value: profile.first_name || '' },
-              { key: 'Last Name', value: profile.last_name || '' },
-              { key: 'Phone', value: profile.phone || '' },
               { key: 'Email', value: profile.email || '' }
             ]
           }
@@ -1631,11 +1622,8 @@ const App: React.FC = () => {
                                   }
                                 });
                               });
-                              const { first_name, last_name, phone, email, ...extra } = combined;
+                              const { email, ...extra } = combined;
                               const data = {
-                                first_name: String(first_name || ''),
-                                last_name: String(last_name || ''),
-                                phone: String(phone || ''),
                                 email: String(email || ''),
                                 extra_fields: Object.fromEntries(
                                   Object.entries(extra).map(([k, v]) => [k, String(v ?? '')])

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -116,9 +116,6 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     const form = new FormData();
-    let firstName = '';
-    let lastName = '';
-    let phone = '';
     let email = '';
     const formatted = categories.map(cat => ({
       title: cat.title,
@@ -127,15 +124,9 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
     formatted.forEach(cat => {
       cat.fields.forEach(f => {
         const lower = f.key.trim().toLowerCase();
-        if (lower === 'first name') firstName = f.value;
-        else if (lower === 'last name') lastName = f.value;
-        else if (lower === 'phone') phone = f.value;
-        else if (lower === 'email') email = f.value;
+        if (lower === 'email') email = f.value;
       });
     });
-    form.append('first_name', firstName);
-    form.append('last_name', lastName);
-    form.append('phone', phone);
     form.append('email', email);
     form.append('comment', comment);
     form.append('extra_fields', JSON.stringify(formatted));

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -72,6 +72,25 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
     load();
   };
 
+  const exportProfile = async (id: number) => {
+    const token = localStorage.getItem('token');
+    const res = await fetch(`/api/profiles/${id}/pdf`, {
+      headers: {
+        Authorization: token ? `Bearer ${token}` : ''
+      }
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `profile-${id}.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row gap-2 bg-white/80 backdrop-blur-sm p-4 rounded-2xl shadow-lg">
@@ -176,14 +195,12 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
                     >
                       Supprimer
                     </button>
-                    <a
+                    <button
                       className="text-blue-600 hover:underline"
-                      href={`/api/profiles/${p.id}/pdf`}
-                      target="_blank"
-                      rel="noopener"
+                      onClick={() => exportProfile(p.id)}
                     >
                       Exporter Profil
-                    </a>
+                    </button>
                   </div>
                 </div>
               );

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -12,9 +12,6 @@ interface ProfilesProps {
   hits: SearchResult[];
   query: string;
   onCreateProfile?: (data: {
-    first_name: string;
-    last_name: string;
-    phone: string;
     email: string;
     comment?: string;
     extra_fields?: Record<string, string>;
@@ -72,11 +69,8 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
                 }
               });
             });
-            const { first_name, last_name, phone, email, ...extra } = combined;
+            const { email, ...extra } = combined;
             const data = {
-              first_name: String(first_name || ''),
-              last_name: String(last_name || ''),
-              phone: String(phone || ''),
               email: String(email || ''),
               extra_fields: Object.fromEntries(
                 Object.entries(extra).map(([k, v]) => [k, String(v ?? '')])
@@ -85,7 +79,10 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
             if (onCreateProfile) {
               onCreateProfile(data);
             } else {
-              const params = new URLSearchParams(data as any);
+              const params = new URLSearchParams({
+                email: data.email,
+                extra_fields: JSON.stringify(data.extra_fields || {})
+              });
               window.location.href = `/profiles/new?${params.toString()}`;
             }
           }}


### PR DESCRIPTION
## Summary
- drop First Name, Last Name and Phone from default profile editing fields
- adjust profile form submission and search result integration for email-only defaults
- fetch profile PDF with auth token to fix export

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext' - eslint.config.js)*
- `npx eslint .` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68b07afdba0883269316c7fd65149326