### PR TITLE
Fix photo path resolution in profile PDF generation

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -122,8 +122,12 @@ class ProfileService {
               const arr = await res.arrayBuffer();
               imageBuffer = Buffer.from(arr);
             } else {
-              const normalizedPath = profile.photo_path.split(/[/\\]+/).join(path.sep);
-              const imgPath = path.resolve(__dirname, '../../', normalizedPath);
+              // Always resolve the photo path relative to the project root
+              const normalizedPath = profile.photo_path
+                .split(/[/\\]+/)
+                .join(path.sep)
+                .replace(/^[/\\]+/, '');
+              const imgPath = path.join(process.cwd(), normalizedPath);
               if (fs.existsSync(imgPath)) {
                 imageBuffer = fs.readFileSync(imgPath);
               }


### PR DESCRIPTION
## Summary
- Resolve local profile photos relative to project root when embedding them in generated PDFs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b1703985148326a1fd50ee72f0fc59