### PR TITLE
Fix photo path resolution in profile PDF generation

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -127,7 +127,7 @@ class ProfileService {
                 .split(/[/\\]+/)
                 .join(path.sep)
                 .replace(/^[/\\]+/, '');
-              const imgPath = path.join(process.cwd(), normalizedPath);
+              const imgPath = path.resolve(__dirname, '../../', normalizedPath);
               if (fs.existsSync(imgPath)) {
                 imageBuffer = fs.readFileSync(imgPath);
               }


### PR DESCRIPTION
## Summary
- Resolve local profile photos relative to project root when embedding them in generated PDFs
- Use module-relative project root instead of `process.cwd` for reliable path resolution

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b17210d5c883269942d72b942aa781