### PR TITLE
fix: normalize elasticsearch search response

### DIFF
--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -61,7 +61,20 @@ router.post('/', authenticate, searchLimiter, async (req, res) => {
     console.log('🔍 Lancement de la recherche...');
     let results;
     if (useElastic) {
-      results = await elasticService.search(query.trim(), parseInt(limit));
+      const es = await elasticService.search(
+        query.trim(),
+        parseInt(page),
+        parseInt(limit)
+      );
+      results = {
+        total: es.total,
+        page: parseInt(page),
+        limit: parseInt(limit),
+        pages: Math.ceil(es.total / parseInt(limit)),
+        elapsed_ms: es.elapsed_ms,
+        hits: es.hits,
+        tables_searched: ['profiles']
+      };
     } else {
       results = await searchService.search(
         query.trim(),

--- a/server/services/ElasticSearchService.js
+++ b/server/services/ElasticSearchService.js
@@ -10,9 +10,11 @@ class ElasticSearchService {
     });
   }
 
-  async search(query, limit = 20) {
-    const { hits } = await client.search({
+  async search(query, page = 1, limit = 20) {
+    const from = (page - 1) * limit;
+    const { hits, took } = await client.search({
       index: 'profiles',
+      from,
       size: limit,
       query: {
         multi_match: {
@@ -21,7 +23,13 @@ class ElasticSearchService {
         }
       }
     });
-    return hits.hits.map(h => h._source);
+
+    const total = typeof hits.total === 'number' ? hits.total : hits.total?.value ?? 0;
+    return {
+      total,
+      hits: hits.hits.map(h => h._source),
+      elapsed_ms: took
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add pagination and metadata handling to Elasticsearch service
- ensure search route returns SearchService-style object when using Elasticsearch

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b17be8ac848326bdf6767ae947e3d8