### PR TITLE
feat(cdr): add csv import and search

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -17,6 +17,7 @@ import entreprisesRoutes from './routes/entreprises.js';
 import ongRoutes from './routes/ong.js';
 import vehiculesRoutes from './routes/vehicules.js';
 import profilesRoutes from './routes/profiles.js';
+import cdrRoutes from './routes/cdr.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -59,6 +60,7 @@ app.use('/api/entreprises', entreprisesRoutes);
 app.use('/api/ong', ongRoutes);
 app.use('/api/vehicules', vehiculesRoutes);
 app.use('/api/profiles', profilesRoutes);
+app.use('/api/cdr', cdrRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -136,6 +136,37 @@ class DatabaseManager {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
       `);
 
+      await this.query(`
+        CREATE TABLE IF NOT EXISTS autres.cdr_records (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          oce VARCHAR(50) DEFAULT NULL,
+          type_cdr VARCHAR(50) DEFAULT NULL,
+          date_debut DATE DEFAULT NULL,
+          heure_debut TIME DEFAULT NULL,
+          date_fin DATE DEFAULT NULL,
+          heure_fin TIME DEFAULT NULL,
+          duree INT DEFAULT NULL,
+          numero_intl_appelant VARCHAR(50) DEFAULT NULL,
+          numero_intl_appele VARCHAR(50) DEFAULT NULL,
+          numero_intl_appele_original VARCHAR(50) DEFAULT NULL,
+          imei_appelant VARCHAR(50) DEFAULT NULL,
+          imei_appele VARCHAR(50) DEFAULT NULL,
+          imei_appele_original VARCHAR(50) DEFAULT NULL,
+          imsi_appelant VARCHAR(50) DEFAULT NULL,
+          imsi_appele VARCHAR(50) DEFAULT NULL,
+          cgi_appelant VARCHAR(50) DEFAULT NULL,
+          cgi_appele VARCHAR(50) DEFAULT NULL,
+          cgi_appele_original VARCHAR(50) DEFAULT NULL,
+          latitude DECIMAL(10,6) DEFAULT NULL,
+          longitude DECIMAL(10,6) DEFAULT NULL,
+          nom_localisation VARCHAR(255) DEFAULT NULL,
+          INDEX idx_numero_appelant (numero_intl_appelant),
+          INDEX idx_numero_appele (numero_intl_appele),
+          INDEX idx_imei_appelant (imei_appelant),
+          INDEX idx_imei_appele (imei_appele)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
       console.log('✅ Tables système créées avec succès');
     } catch (error) {
       console.error('❌ Erreur création tables système:', error);

--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -1,0 +1,54 @@
+import database from '../config/database.js';
+
+class Cdr {
+  static async bulkInsert(records) {
+    for (const rec of records) {
+      await database.query(
+        `INSERT INTO autres.cdr_records (
+          oce, type_cdr, date_debut, heure_debut, date_fin, heure_fin, duree,
+          numero_intl_appelant, numero_intl_appele, numero_intl_appele_original,
+          imei_appelant, imei_appele, imei_appele_original,
+          imsi_appelant, imsi_appele,
+          cgi_appelant, cgi_appele, cgi_appele_original,
+          latitude, longitude, nom_localisation
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        [
+          rec.oce,
+          rec.type_cdr,
+          rec.date_debut,
+          rec.heure_debut,
+          rec.date_fin,
+          rec.heure_fin,
+          rec.duree,
+          rec.numero_intl_appelant,
+          rec.numero_intl_appele,
+          rec.numero_intl_appele_original,
+          rec.imei_appelant,
+          rec.imei_appele,
+          rec.imei_appele_original,
+          rec.imsi_appelant,
+          rec.imsi_appele,
+          rec.cgi_appelant,
+          rec.cgi_appele,
+          rec.cgi_appele_original,
+          rec.latitude,
+          rec.longitude,
+          rec.nom_localisation
+        ]
+      );
+    }
+  }
+
+  static async findByIdentifier(identifier) {
+    return await database.query(
+      `SELECT * FROM autres.cdr_records WHERE
+        numero_intl_appelant = ? OR
+        numero_intl_appele = ? OR
+        imei_appelant = ? OR
+        imei_appele = ?`,
+      [identifier, identifier, identifier, identifier]
+    );
+  }
+}
+
+export default Cdr;

--- a/server/routes/cdr.js
+++ b/server/routes/cdr.js
@@ -1,0 +1,46 @@
+import express from 'express';
+import multer from 'multer';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import CdrService from '../services/CdrService.js';
+import { authenticate, requireAdmin } from '../middleware/auth.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const router = express.Router();
+const cdrService = new CdrService();
+
+const upload = multer({ dest: path.join(__dirname, '../../uploads') });
+
+router.post('/upload', authenticate, requireAdmin, upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ error: 'Aucun fichier fourni' });
+    }
+    const filePath = req.file.path;
+    const result = await cdrService.importCsv(filePath);
+    fs.unlinkSync(filePath);
+    res.json({ message: 'CDR importés', ...result });
+  } catch (error) {
+    console.error('Erreur import CDR:', error);
+    res.status(500).json({ error: "Erreur lors de l'import du fichier" });
+  }
+});
+
+router.get('/search', authenticate, async (req, res) => {
+  try {
+    const identifier = req.query.phone || req.query.imei;
+    if (!identifier) {
+      return res.status(400).json({ error: 'Paramètre phone ou imei requis' });
+    }
+    const result = await cdrService.search(identifier);
+    res.json(result);
+  } catch (error) {
+    console.error('Erreur recherche CDR:', error);
+    res.status(500).json({ error: 'Erreur lors de la recherche' });
+  }
+});
+
+export default router;

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import csv from 'csv-parser';
+import Cdr from '../models/Cdr.js';
+
+class CdrService {
+  async importCsv(filePath) {
+    return new Promise((resolve, reject) => {
+      const records = [];
+      fs.createReadStream(filePath)
+        .pipe(csv())
+        .on('data', row => {
+          records.push({
+            oce: row['OCE'] || null,
+            type_cdr: row['Type CDR'] || null,
+            date_debut: row['Date debut'] || null,
+            heure_debut: row['Heure debut'] || null,
+            date_fin: row['Date fin'] || null,
+            heure_fin: row['Heure fin'] || null,
+            duree: row['Duree'] || null,
+            numero_intl_appelant: row['Numero intl appelant'] || null,
+            numero_intl_appele: row['Numero intl appele'] || null,
+            numero_intl_appele_original: row['Numero intl appele original'] || null,
+            imei_appelant: row['IMEI appelant'] || null,
+            imei_appele: row['IMEI appele'] || null,
+            imei_appele_original: row['IMEI appele original'] || null,
+            imsi_appelant: row['IMSI appelant'] || null,
+            imsi_appele: row['IMSI appele'] || null,
+            cgi_appelant: row['CGI appelant'] || null,
+            cgi_appele: row['CGI appele'] || null,
+            cgi_appele_original: row['CGI appele original'] || null,
+            latitude: row['Latitude'] || null,
+            longitude: row['Longitude'] || null,
+            nom_localisation: row['Nom localisation'] || null
+          });
+        })
+        .on('end', async () => {
+          try {
+            await Cdr.bulkInsert(records);
+            resolve({ inserted: records.length });
+          } catch (err) {
+            reject(err);
+          }
+        })
+        .on('error', err => reject(err));
+    });
+  }
+
+  async search(identifier) {
+    const records = await Cdr.findByIdentifier(identifier);
+    const contactsMap = {};
+    const locationsMap = {};
+
+    for (const r of records) {
+      const caller = r.numero_intl_appelant;
+      const callee = r.numero_intl_appele;
+      const other = caller === identifier ? callee : caller;
+      if (other) {
+        contactsMap[other] = (contactsMap[other] || 0) + 1;
+      }
+      if (r.latitude && r.longitude) {
+        const key = `${r.latitude},${r.longitude}`;
+        if (!locationsMap[key]) {
+          locationsMap[key] = {
+            latitude: r.latitude,
+            longitude: r.longitude,
+            nom: r.nom_localisation,
+            count: 0
+          };
+        }
+        locationsMap[key].count++;
+      }
+    }
+
+    const contacts = Object.entries(contactsMap)
+      .map(([number, count]) => ({ number, count }))
+      .sort((a, b) => b.count - a.count);
+
+    const locations = Object.values(locationsMap);
+
+    return {
+      total: records.length,
+      contacts,
+      topContacts: contacts.slice(0, 5),
+      locations
+    };
+  }
+}
+
+export default CdrService;


### PR DESCRIPTION
## Summary
- add MySQL table and data model for CDR records
- support CSV import and search aggregation for CDR data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b1892d893883269a0e72db06178747