### PR TITLE
fix(cdr): ensure upload directory exists

### DIFF
--- a/server/routes/cdr.js
+++ b/server/routes/cdr.js
@@ -12,7 +12,12 @@ const __dirname = path.dirname(__filename);
 const router = express.Router();
 const cdrService = new CdrService();
 
-const upload = multer({ dest: path.join(__dirname, '../../uploads') });
+// Ensure upload directory exists before initializing multer
+const uploadDir = path.join(__dirname, '../../uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+const upload = multer({ dest: uploadDir });
 
 router.post('/upload', authenticate, requireAdmin, upload.single('file'), async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- create uploads directory before configuring multer for CDR import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b18b6ecee48326bf418b210b9eeeea