### PR TITLE
Add full-screen CDR map with filtering and itinerary

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -39,15 +39,27 @@ class Cdr {
     }
   }
 
-  static async findByIdentifier(identifier) {
-    return await database.query(
-      `SELECT * FROM autres.cdr_records WHERE
-        numero_intl_appelant = ? OR
-        numero_intl_appele = ? OR
-        imei_appelant = ? OR
-        imei_appele = ?`,
-      [identifier, identifier, identifier, identifier]
-    );
+  static async findByIdentifier(identifier, startDateTime = null, endDateTime = null) {
+    let query = `SELECT * FROM autres.cdr_records WHERE (
+      numero_intl_appelant = ? OR
+      numero_intl_appele = ? OR
+      imei_appelant = ? OR
+      imei_appele = ?
+    )`;
+    const params = [identifier, identifier, identifier, identifier];
+
+    if (startDateTime) {
+      query += ` AND CONCAT(date_debut, ' ', heure_debut) >= ?`;
+      params.push(startDateTime);
+    }
+    if (endDateTime) {
+      query += ` AND CONCAT(date_debut, ' ', heure_debut) <= ?`;
+      params.push(endDateTime);
+    }
+
+    query += ' ORDER BY date_debut, heure_debut';
+
+    return await database.query(query, params);
   }
 }
 

--- a/server/routes/cdr.js
+++ b/server/routes/cdr.js
@@ -40,7 +40,11 @@ router.get('/search', authenticate, async (req, res) => {
     if (!identifier) {
       return res.status(400).json({ error: 'Paramètre phone ou imei requis' });
     }
-    const result = await cdrService.search(identifier);
+    const { start, end } = req.query;
+    const result = await cdrService.search(identifier, {
+      startDateTime: start || null,
+      endDateTime: end || null
+    });
     res.json(result);
   } catch (error) {
     console.error('Erreur recherche CDR:', error);


### PR DESCRIPTION
## Summary
- Support date/time range filtering for CDR queries and return ordered location path with stats
- Replace CDR results pane with full-screen map showing markers, itineraries, and top contacts/locations
- Add modern map UI with popup details and fullscreen toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b1963165208326a0d2382f5fd102c2