### PR TITLE
fix: guard against invalid CDR call dates

### DIFF
--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -104,9 +104,13 @@ class CdrService {
           }
         }
 
-        const callDate = r.date_debut
-          ? new Date(r.date_debut).toISOString().split('T')[0]
-          : 'N/A';
+        const callDate = (() => {
+          if (!r.date_debut) return 'N/A';
+          const parsed = new Date(r.date_debut);
+          return isNaN(parsed.getTime())
+            ? r.date_debut
+            : parsed.toISOString().split('T')[0];
+        })();
         const startTime = r.heure_debut
           ? r.heure_debut.toString().slice(0, 8)
           : 'N/A';


### PR DESCRIPTION
## Summary
- prevent crash on malformed CDR dates by validating before ISO conversion

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b19f74c0408326a288494d301c4dc4