### PR TITLE
Improve CDR map visualization and filtering

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -53,7 +53,7 @@ class Cdr {
       params.push(startDateTime);
     }
     if (endDateTime) {
-      query += ` AND TIMESTAMP(date_debut, heure_debut) <= ?`;
+      query += ` AND TIMESTAMP(date_fin, heure_fin) <= ?`;
       params.push(endDateTime);
     }
 

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
+import React, { useState, useEffect } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, Polyline, Circle } from 'react-leaflet';
 import L from 'leaflet';
 
 interface Point {
@@ -62,6 +62,15 @@ const CdrMap: React.FC<Props> = ({ points, topContacts, topLocations, total }) =
     return { mid, icon };
   });
   const [fullScreen, setFullScreen] = useState(false);
+  const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+
+  useEffect(() => {
+    if (mapInstance) {
+      setTimeout(() => {
+        mapInstance.invalidateSize();
+      }, 0);
+    }
+  }, [fullScreen, mapInstance]);
 
   return (
     <div className={`relative ${fullScreen ? 'fixed inset-0 z-50' : ''}`}>
@@ -70,12 +79,23 @@ const CdrMap: React.FC<Props> = ({ points, topContacts, topLocations, total }) =
         zoom={13}
         className="w-full"
         style={{ height: fullScreen ? '100vh' : '70vh' }}
+        whenCreated={setMapInstance}
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Polyline positions={positions} color="#2563eb" />
+        {topLocations && topLocations.length > 0 && (
+          <Circle
+            center={[
+              parseFloat(topLocations[0].latitude),
+              parseFloat(topLocations[0].longitude)
+            ]}
+            radius={200}
+            pathOptions={{ color: 'red', fillColor: 'red', fillOpacity: 0.2 }}
+          />
+        )}
         {arrows.map((a, idx) => (
           <Marker key={`arrow-${idx}`} position={a.mid} icon={a.icon} interactive={false} />
         ))}


### PR DESCRIPTION
## Summary
- Highlight busiest location with a red circle on the CDR map
- Fix full-screen map resizing by invalidating Leaflet size
- Correct CDR search date range by filtering on end timestamps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install @eslint/js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a11f8968832699fa2f6e21a0faa8