### PR TITLE
Fix CDR date range filtering

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -39,7 +39,7 @@ class Cdr {
     }
   }
 
-  static async findByIdentifier(identifier, startDateTime = null, endDateTime = null) {
+  static async findByIdentifier(identifier, startDate = null, endDate = null) {
     let query = `SELECT * FROM autres.cdr_records WHERE (
       numero_intl_appelant = ? OR
       numero_intl_appele = ? OR
@@ -48,13 +48,13 @@ class Cdr {
     )`;
     const params = [identifier, identifier, identifier, identifier];
 
-    if (startDateTime) {
-      query += ` AND TIMESTAMP(date_debut, heure_debut) >= ?`;
-      params.push(startDateTime);
+    if (startDate) {
+      query += ` AND date_debut >= ?`;
+      params.push(startDate);
     }
-    if (endDateTime) {
-      query += ` AND TIMESTAMP(date_debut, heure_debut) <= ?`;
-      params.push(endDateTime);
+    if (endDate) {
+      query += ` AND date_debut <= ?`;
+      params.push(endDate);
     }
 
     query += ' ORDER BY date_debut, heure_debut';

--- a/server/routes/cdr.js
+++ b/server/routes/cdr.js
@@ -40,10 +40,10 @@ router.get('/search', authenticate, async (req, res) => {
     if (!identifier) {
       return res.status(400).json({ error: 'Paramètre phone ou imei requis' });
     }
-    const { start, end, startTime, endTime } = req.query;
+    const { start, end } = req.query;
     const result = await cdrService.search(identifier, {
-      startDateTime: start ? `${start} ${startTime || '00:00:00'}` : null,
-      endDateTime: end ? `${end} ${endTime || '23:59:59'}` : null
+      startDate: start || null,
+      endDate: end || null
     });
     res.json(result);
   } catch (error) {

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -45,8 +45,8 @@ class CdrService {
     });
   }
 
-  async search(identifier, { startDateTime = null, endDateTime = null } = {}) {
-    const records = await Cdr.findByIdentifier(identifier, startDateTime, endDateTime);
+  async search(identifier, { startDate = null, endDate = null } = {}) {
+    const records = await Cdr.findByIdentifier(identifier, startDate, endDate);
     const contactsMap = {};
     const locationsMap = {};
     const path = [];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -415,8 +415,6 @@ const App: React.FC = () => {
   const [cdrIdentifier, setCdrIdentifier] = useState('');
   const [cdrStart, setCdrStart] = useState('');
   const [cdrEnd, setCdrEnd] = useState('');
-  const [cdrStartTime, setCdrStartTime] = useState('');
-  const [cdrEndTime, setCdrEndTime] = useState('');
   const [cdrResult, setCdrResult] = useState<CdrSearchResult | null>(null);
   const [cdrLoading, setCdrLoading] = useState(false);
   const [cdrError, setCdrError] = useState('');
@@ -1041,9 +1039,7 @@ const App: React.FC = () => {
       const params = new URLSearchParams();
       params.append(param, cdrIdentifier.trim());
       if (cdrStart) params.append('start', cdrStart);
-      if (cdrStartTime) params.append('startTime', cdrStartTime);
       if (cdrEnd) params.append('end', cdrEnd);
-      if (cdrEndTime) params.append('endTime', cdrEndTime);
       const res = await fetch(`/api/cdr/search?${params.toString()}`, {
         headers: { Authorization: token ? `Bearer ${token}` : '' }
       });
@@ -2305,34 +2301,18 @@ const App: React.FC = () => {
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                  <div className="flex gap-2">
-                    <input
-                      type="date"
-                      value={cdrStart}
-                      onChange={(e) => setCdrStart(e.target.value)}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    <input
-                      type="time"
-                      value={cdrStartTime}
-                      onChange={(e) => setCdrStartTime(e.target.value)}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                  </div>
-                  <div className="flex gap-2">
-                    <input
-                      type="date"
-                      value={cdrEnd}
-                      onChange={(e) => setCdrEnd(e.target.value)}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                    <input
-                      type="time"
-                      value={cdrEndTime}
-                      onChange={(e) => setCdrEndTime(e.target.value)}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                  </div>
+                  <input
+                    type="date"
+                    value={cdrStart}
+                    onChange={(e) => setCdrStart(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <input
+                    type="date"
+                    value={cdrEnd}
+                    onChange={(e) => setCdrEnd(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
                 </div>
                 <button
                   type="submit"


### PR DESCRIPTION
## Summary
- filter CDR searches by `date_debut`
- wire search API to accept start/end dates
- simplify client search form to only use dates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aa3125848326834b1586b4f3f3bc