### PR TITLE
fix: update xlsx dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pdfkit": "^0.13.0",
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.19.3"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import csv from 'csv-parser';
-import xlsx from 'xlsx';
+import { readFile, utils } from 'xlsx';
 import { parse, format } from 'date-fns';
 import Cdr from '../models/Cdr.js';
 
@@ -65,9 +65,9 @@ class CdrService {
   }
 
   async importExcel(filePath, caseId = null) {
-    const workbook = xlsx.readFile(filePath);
+    const workbook = readFile(filePath);
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
-    const rows = xlsx.utils.sheet_to_json(sheet);
+    const rows = utils.sheet_to_json(sheet);
     const normalizeDate = (str) => {
       if (!str) return null;
       try {


### PR DESCRIPTION
## Summary
- bump xlsx to ^0.19.3
- adjust CdrService to use named xlsx imports

## Testing
- `npm install --package-lock-only --no-audit --prefer-offline` *(fails: No matching version found for xlsx@^0.19.3)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm audit` *(fails: 403 Forbidden - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk)*

------
https://chatgpt.com/codex/tasks/task_e_68b44be7db288326a0030c32a7d1e597