### PR TITLE
Refactor CDR handling and modernize case UI

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -1,19 +1,50 @@
 import database from '../config/database.js';
 
 class Cdr {
-  static async bulkInsert(records, caseId = null) {
+  static escapeIdentifier(name) {
+    return `\`${name.replace(/`/g, '``')}\``;
+  }
+
+  static async bulkInsert(records, tableName) {
+    const table = this.escapeIdentifier(tableName);
+    await database.query(
+      `CREATE TABLE IF NOT EXISTS ${table} (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        oce VARCHAR(50) DEFAULT NULL,
+        type_cdr VARCHAR(50) DEFAULT NULL,
+        date_debut DATE DEFAULT NULL,
+        heure_debut TIME DEFAULT NULL,
+        date_fin DATE DEFAULT NULL,
+        heure_fin TIME DEFAULT NULL,
+        duree INT DEFAULT NULL,
+        numero_intl_appelant VARCHAR(50) DEFAULT NULL,
+        numero_intl_appele VARCHAR(50) DEFAULT NULL,
+        numero_intl_appele_original VARCHAR(50) DEFAULT NULL,
+        imei_appelant VARCHAR(50) DEFAULT NULL,
+        imei_appele VARCHAR(50) DEFAULT NULL,
+        imei_appele_original VARCHAR(50) DEFAULT NULL,
+        imsi_appelant VARCHAR(50) DEFAULT NULL,
+        imsi_appele VARCHAR(50) DEFAULT NULL,
+        cgi_appelant VARCHAR(50) DEFAULT NULL,
+        cgi_appele VARCHAR(50) DEFAULT NULL,
+        cgi_appele_original VARCHAR(50) DEFAULT NULL,
+        latitude DECIMAL(10,6) DEFAULT NULL,
+        longitude DECIMAL(10,6) DEFAULT NULL,
+        nom_localisation VARCHAR(255) DEFAULT NULL
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+    );
+
     for (const rec of records) {
       await database.query(
-        `INSERT INTO autres.cdr_records (
-          case_id, oce, type_cdr, date_debut, heure_debut, date_fin, heure_fin, duree,
+        `INSERT INTO ${table} (
+          oce, type_cdr, date_debut, heure_debut, date_fin, heure_fin, duree,
           numero_intl_appelant, numero_intl_appele, numero_intl_appele_original,
           imei_appelant, imei_appele, imei_appele_original,
           imsi_appelant, imsi_appele,
           cgi_appelant, cgi_appele, cgi_appele_original,
           latitude, longitude, nom_localisation
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
         [
-          caseId,
           rec.oce,
           rec.type_cdr,
           rec.date_debut,
@@ -40,19 +71,15 @@ class Cdr {
     }
   }
 
-  static async findByIdentifier(identifier, startDate = null, endDate = null, caseId = null) {
-    let query = `SELECT * FROM autres.cdr_records WHERE (
+  static async findByIdentifier(identifier, startDate = null, endDate = null, tableName) {
+    const table = this.escapeIdentifier(tableName);
+    let query = `SELECT * FROM ${table} WHERE (
       numero_intl_appelant = ? OR
       numero_intl_appele = ? OR
       imei_appelant = ? OR
       imei_appele = ?
     )`;
     const params = [identifier, identifier, identifier, identifier];
-
-    if (caseId) {
-      query += ' AND case_id = ?';
-      params.push(caseId);
-    }
 
     if (startDate) {
       query += ` AND date_debut >= ?`;

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -21,16 +21,24 @@ class CaseService {
   }
 
   async importFile(caseId, filePath, originalName) {
+    const existingCase = await Case.findById(caseId);
+    if (!existingCase) {
+      throw new Error('Case not found');
+    }
     const ext = path.extname(originalName).toLowerCase();
     if (ext === '.xlsx' || ext === '.xls') {
-      return await this.cdrService.importExcel(filePath, caseId);
+      return await this.cdrService.importExcel(filePath, existingCase.name);
     }
     // default to CSV
-    return await this.cdrService.importCsv(filePath, caseId);
+    return await this.cdrService.importCsv(filePath, existingCase.name);
   }
 
   async search(caseId, identifier, options = {}) {
-    return await this.cdrService.search(identifier, { ...options, caseId });
+    const existingCase = await Case.findById(caseId);
+    if (!existingCase) {
+      throw new Error('Case not found');
+    }
+    return await this.cdrService.search(identifier, { ...options, caseName: existingCase.name });
   }
 }
 

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -5,7 +5,7 @@ import { parse, format } from 'date-fns';
 import Cdr from '../models/Cdr.js';
 
 class CdrService {
-  async importCsv(filePath, caseId = null) {
+  async importCsv(filePath, caseName) {
     return new Promise((resolve, reject) => {
       const records = [];
       fs.createReadStream(filePath)
@@ -54,7 +54,7 @@ class CdrService {
         })
         .on('end', async () => {
           try {
-            await Cdr.bulkInsert(records, caseId);
+            await Cdr.bulkInsert(records, caseName);
             resolve({ inserted: records.length });
           } catch (err) {
             reject(err);
@@ -64,7 +64,7 @@ class CdrService {
     });
   }
 
-  async importExcel(filePath, caseId = null) {
+  async importExcel(filePath, caseName) {
     const workbook = XLSX.readFile(filePath);
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
     const rows = XLSX.utils.sheet_to_json(sheet);
@@ -107,12 +107,12 @@ class CdrService {
       longitude: row['Longitude'] || null,
       nom_localisation: row['Nom localisation'] || null,
     }));
-    await Cdr.bulkInsert(records, caseId);
+    await Cdr.bulkInsert(records, caseName);
     return { inserted: records.length };
   }
 
-  async search(identifier, { startDate = null, endDate = null, caseId = null } = {}) {
-    const records = await Cdr.findByIdentifier(identifier, startDate, endDate, caseId);
+  async search(identifier, { startDate = null, endDate = null, caseName } = {}) {
+    const records = await Cdr.findByIdentifier(identifier, startDate, endDate, caseName);
     const contactsMap = {};
     const locationsMap = {};
     const path = [];


### PR DESCRIPTION
## Summary
- Store CDR files in per-case tables using the case name
- Resolve case names in server services for imports and searches
- Add dedicated case page with modern case list grid and CSV upload/search

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b4567f84c08326b2d8ab6bf290eae2