### PR TITLE
Ajout d'un filtre horaire et indicateurs de chargement

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -71,7 +71,14 @@ class Cdr {
     }
   }
 
-  static async findByIdentifier(identifier, startDate = null, endDate = null, tableName) {
+  static async findByIdentifier(
+    identifier,
+    startDate = null,
+    endDate = null,
+    startTime = null,
+    endTime = null,
+    tableName
+  ) {
     const table = this.escapeIdentifier(tableName);
     let query = `SELECT * FROM ${table} WHERE (
       numero_intl_appelant = ? OR
@@ -88,6 +95,14 @@ class Cdr {
     if (endDate) {
       query += ` AND date_debut <= ?`;
       params.push(endDate);
+    }
+    if (startTime) {
+      query += ` AND heure_debut >= ?`;
+      params.push(startTime);
+    }
+    if (endTime) {
+      query += ` AND heure_debut <= ?`;
+      params.push(endTime);
     }
 
     query += ' ORDER BY date_debut, heure_debut';

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -71,15 +71,22 @@ router.get('/:id/search', authenticate, async (req, res) => {
     if (!identifier) {
       return res.status(400).json({ error: 'Paramètre phone ou imei requis' });
     }
-    const { start, end } = req.query;
+    const { start, end, startTime, endTime } = req.query;
     const isValidDate = (str) => {
       if (!str) return false;
       const regex = /^\d{4}-\d{2}-\d{2}$/;
       if (!regex.test(str)) return false;
       return !isNaN(new Date(str).getTime());
     };
+    const isValidTime = (str) => {
+      const regex = /^\d{2}:\d{2}(?::\d{2})?$/;
+      return regex.test(str);
+    };
     if ((start && !isValidDate(start)) || (end && !isValidDate(end))) {
       return res.status(400).json({ error: 'Format de date invalide (YYYY-MM-DD)' });
+    }
+    if ((startTime && !isValidTime(startTime)) || (endTime && !isValidTime(endTime))) {
+      return res.status(400).json({ error: "Format d'heure invalide (HH:MM ou HH:MM:SS)" });
     }
     if (start && end && new Date(start) > new Date(end)) {
       return res.status(400).json({ error: 'La date de début doit précéder la date de fin' });
@@ -87,6 +94,8 @@ router.get('/:id/search', authenticate, async (req, res) => {
     const result = await caseService.search(caseId, identifier, {
       startDate: start || null,
       endDate: end || null,
+      startTime: startTime || null,
+      endTime: endTime || null,
     });
     res.json(result);
   } catch (err) {

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -111,8 +111,18 @@ class CdrService {
     return { inserted: records.length };
   }
 
-  async search(identifier, { startDate = null, endDate = null, caseName } = {}) {
-    const records = await Cdr.findByIdentifier(identifier, startDate, endDate, caseName);
+  async search(
+    identifier,
+    { startDate = null, endDate = null, startTime = null, endTime = null, caseName } = {}
+  ) {
+    const records = await Cdr.findByIdentifier(
+      identifier,
+      startDate,
+      endDate,
+      startTime,
+      endTime,
+      caseName
+    );
     const contactsMap = {};
     const locationsMap = {};
     const path = [];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,8 @@ import {
   Link as LinkIcon,
   ExternalLink,
   UserCircle,
-  List
+  List,
+  Loader2
 } from 'lucide-react';
 import { Line, Bar, Doughnut } from 'react-chartjs-2';
 import {
@@ -427,6 +428,8 @@ const App: React.FC = () => {
   const [cdrIdentifier, setCdrIdentifier] = useState('');
   const [cdrStart, setCdrStart] = useState('');
   const [cdrEnd, setCdrEnd] = useState('');
+  const [cdrStartTime, setCdrStartTime] = useState('');
+  const [cdrEndTime, setCdrEndTime] = useState('');
   const [cdrResult, setCdrResult] = useState<CdrSearchResult | null>(null);
   const [cdrLoading, setCdrLoading] = useState(false);
   const [cdrError, setCdrError] = useState('');
@@ -1074,6 +1077,8 @@ const App: React.FC = () => {
       params.append(param, cdrIdentifier.trim());
       if (cdrStart) params.append('start', new Date(cdrStart).toISOString().split('T')[0]);
       if (cdrEnd) params.append('end', new Date(cdrEnd).toISOString().split('T')[0]);
+      if (cdrStartTime) params.append('startTime', cdrStartTime);
+      if (cdrEndTime) params.append('endTime', cdrEndTime);
       const res = await fetch(`/api/cases/${selectedCase.id}/search?${params.toString()}`, {
         headers: { Authorization: token ? `Bearer ${token}` : '' }
       });
@@ -2493,7 +2498,11 @@ const App: React.FC = () => {
                   disabled={cdrUploading || !cdrFile}
                   className="px-4 py-2 bg-green-600 text-white rounded-lg disabled:opacity-50"
                 >
-                  Importer CDR
+                  {cdrUploading ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    'Importer CDR'
+                  )}
                 </button>
                 {cdrUploadMessage && <p className="text-green-600">{cdrUploadMessage}</p>}
                 {cdrUploadError && <p className="text-red-600">{cdrUploadError}</p>}
@@ -2529,6 +2538,20 @@ const App: React.FC = () => {
                     type="date"
                     value={cdrEnd}
                     onChange={(e) => setCdrEnd(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                  <input
+                    type="time"
+                    value={cdrStartTime}
+                    onChange={(e) => setCdrStartTime(e.target.value)}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  <input
+                    type="time"
+                    value={cdrEndTime}
+                    onChange={(e) => setCdrEndTime(e.target.value)}
                     className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
@@ -3088,7 +3111,11 @@ const App: React.FC = () => {
                       disabled={loading}
                       className="w-full px-4 py-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 transition-colors"
                     >
-                      {loading ? 'Chargement...' : 'Importer'}
+                      {loading ? (
+                        <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+                      ) : (
+                        'Importer'
+                      )}
                     </button>
                   </form>
                 </div>

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Circle } from 'react-leaflet';
 import L from 'leaflet';
-import { PhoneIncoming, PhoneOutgoing, MessageSquare } from 'lucide-react';
+import { PhoneIncoming, PhoneOutgoing, MessageSquare, Loader2 } from 'lucide-react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 interface Point {
@@ -49,7 +49,7 @@ const getIcon = (type: string, direction: string) => {
       direction === 'outgoing' ? (
         <PhoneOutgoing size={size} className="text-blue-600" />
       ) : (
-        <PhoneIncoming size={size} className="text-blue-600" />
+        <PhoneIncoming size={size} className="text-red-600" />
       );
   }
 
@@ -69,6 +69,7 @@ const CdrMap: React.FC<Props> = ({ points, topContacts, topLocations, total }) =
 
   const [fullScreen, setFullScreen] = useState(false);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [mapLoading, setMapLoading] = useState(true);
 
   useEffect(() => {
     if (mapInstance) {
@@ -77,6 +78,10 @@ const CdrMap: React.FC<Props> = ({ points, topContacts, topLocations, total }) =
       }, 0);
     }
   }, [fullScreen, mapInstance]);
+
+  useEffect(() => {
+    setMapLoading(true);
+  }, [points]);
 
   return (
     <div
@@ -89,7 +94,10 @@ const CdrMap: React.FC<Props> = ({ points, topContacts, topLocations, total }) =
         zoom={13}
         className="w-full h-[70vh]"
         style={{ height: fullScreen ? '100vh' : undefined }}
-        whenCreated={setMapInstance}
+        whenCreated={(map) => {
+          setMapInstance(map);
+          map.on('load', () => setMapLoading(false));
+        }}
       >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -161,6 +169,11 @@ const CdrMap: React.FC<Props> = ({ points, topContacts, topLocations, total }) =
           </div>
         )}
       </div>
+      {mapLoading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75 z-[1000]">
+          <Loader2 className="h-10 w-10 animate-spin text-blue-600" />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Ajout du filtrage par heure (`heure_debut`) pour les recherches CDR
- Icônes de chargement lors de l'import CSV et de l'affichage de la carte
- Couleurs différenciées pour les appels entrants et sortants

## Testing
- `npm test` *(erreur : Missing script: "test")*
- `npm run lint` *(erreur : Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b463064c788326a8d5ea2739c113d6