### PR TITLE
Fix CDR map visibility and lock xlsx version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pdfkit": "^0.13.0",
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
-    "xlsx": "^0.19.3"
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1085,9 +1085,16 @@ const App: React.FC = () => {
       const data = await res.json();
       if (res.ok) {
         setCdrResult(data);
-        setShowCdrMap(data.total > 0);
+
+        const hasPath = Array.isArray(data.path) && data.path.length > 0;
+        setShowCdrMap(hasPath);
+
         setCdrInfoMessage(
-          data.total === 0 ? 'Aucun CDR trouvé pour l\u2019intervalle sélectionné' : ''
+          data.total === 0
+            ? 'Aucun CDR trouvé pour l\u2019intervalle sélectionné'
+            : !hasPath
+              ? 'Aucune donnée de localisation disponible pour cet intervalle'
+              : ''
         );
       } else {
         setCdrError(data.error || 'Erreur lors de la recherche');


### PR DESCRIPTION
## Summary
- Show a helpful message when CDR results lack location data and avoid rendering an empty map
- Pin xlsx dependency to ^0.18.5

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b467af9d908326a0019a220a3f9a6a