### PR TITLE
Fix map full-screen display

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -108,14 +108,15 @@ const CdrMap: React.FC<Props> = ({ points }) => {
   return (
     <div
       className={`relative ${
-        fullScreen ? 'fixed inset-0 z-50' : 'rounded-lg overflow-hidden shadow-lg'
+        fullScreen
+          ? 'fixed inset-0 z-50 w-screen h-screen'
+          : 'rounded-lg overflow-hidden shadow-lg'
       }`}
     >
       <MapContainer
         center={center}
         zoom={13}
-        className="w-full h-[70vh]"
-        style={{ height: fullScreen ? '100vh' : undefined }}
+        className={`w-full ${fullScreen ? 'h-full' : 'h-[70vh]'}`}
         whenCreated={(map) => {
           setMapInstance(map);
         }}


### PR DESCRIPTION
## Summary
- ensure map expands to entire viewport when toggling full screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden fetching package)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b483f7b8908326a8a625d1174f9528