### PR TITLE
fix: keep case CDR table on file removal

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -114,6 +114,11 @@ class Cdr {
     const table = this.escapeIdentifier(tableName);
     await database.query(`DROP TABLE IF EXISTS ${table}`);
   }
+
+  static async truncateTable(tableName) {
+    const table = this.escapeIdentifier(tableName);
+    await database.query(`TRUNCATE TABLE ${table}`);
+  }
 }
 
 export default Cdr;

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -58,7 +58,7 @@ class CaseService {
       throw new Error('Case not found');
     }
     await Case.deleteFile(caseId, fileId);
-    await this.cdrService.deleteTable(existingCase.name);
+    await this.cdrService.clearTable(existingCase.name);
   }
 }
 

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -248,6 +248,10 @@ class CdrService {
   async deleteTable(caseName) {
     await Cdr.deleteTable(caseName);
   }
+
+  async clearTable(caseName) {
+    await Cdr.truncateTable(caseName);
+  }
 }
 
 export default CdrService;


### PR DESCRIPTION
## Summary
- avoid dropping case CDR table when a file is deleted
- add helper to truncate table instead of drop

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b475dbd02c83269acfdf9c84204c48