### PR TITLE
feat: apply blue theme to buttons and cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1383,12 +1383,12 @@ const App: React.FC = () => {
         className={`min-h-screen flex items-center justify-center p-4 ${
           theme === 'dark'
             ? 'bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100'
-            : 'bg-gradient-to-br from-blue-50 via-white to-indigo-50'
+            : 'bg-gradient-to-br from-blue-50 via-white to-blue-50'
         }`}
       >
         <div className="max-w-md w-full">
           <div className="bg-white shadow-2xl rounded-2xl overflow-hidden">
-            <div className="bg-gradient-to-r from-blue-600 to-indigo-600 px-8 py-6">
+            <div className="bg-gradient-to-r from-blue-600 to-blue-700 px-8 py-6">
               <div className="text-center">
                 <div className="inline-flex items-center justify-center w-16 h-16 bg-white/20 rounded-full mb-4">
                   <Database className="h-8 w-8 text-white" />
@@ -1438,7 +1438,7 @@ const App: React.FC = () => {
                 <button
                   type="submit"
                   disabled={loading}
-                  className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 text-white py-3 px-4 rounded-lg font-semibold hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-all"
+                  className="w-full bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 px-4 rounded-lg font-semibold hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-all"
                 >
                   {loading ? (
                     <div className="flex items-center justify-center">
@@ -1471,12 +1471,12 @@ const App: React.FC = () => {
         <div className="p-6 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between">
             <div className={`flex items-center ${!sidebarOpen && 'justify-center'}`}>
-              <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-lg">
+              <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-600 to-blue-700 rounded-lg">
                 <Database className="h-6 w-6 text-white" />
               </div>
               {sidebarOpen && (
                 <div className="ml-3">
-                  <h1 className="text-xl font-extrabold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">VEGETA</h1>
+                  <h1 className="text-xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-700 bg-clip-text text-transparent">VEGETA</h1>
                   <p className="text-xs text-gray-500 dark:text-gray-400">Recherche Pro</p>
                 </div>
               )}
@@ -1512,7 +1512,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('dashboard')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'dashboard'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1524,7 +1524,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('search')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'search'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1536,7 +1536,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('annuaire')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'annuaire'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1548,7 +1548,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('ong')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'ong'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1560,7 +1560,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('entreprises')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'entreprises'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1572,7 +1572,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('vehicules')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'vehicules'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1584,7 +1584,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('cdr')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'cdr'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1599,7 +1599,7 @@ const App: React.FC = () => {
               }}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'profiles'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1611,7 +1611,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('links')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'links'
-                  ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                  ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1624,7 +1624,7 @@ const App: React.FC = () => {
                 onClick={() => setCurrentPage('users')}
                 className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                   currentPage === 'users'
-                    ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                    ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                     : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
                 } ${!sidebarOpen && 'justify-center'}`}
               >
@@ -1638,7 +1638,7 @@ const App: React.FC = () => {
                 onClick={() => setCurrentPage('upload')}
                 className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                   currentPage === 'upload'
-                    ? 'bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-lg'
+                    ? 'bg-gradient-to-r from-blue-500 to-blue-700 text-white shadow-lg'
                     : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
               } ${!sidebarOpen && 'justify-center'}`}
               >
@@ -1719,7 +1719,7 @@ const App: React.FC = () => {
                     <button
                       type="submit"
                       disabled={loading}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 px-6 py-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-all flex items-center"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 px-6 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-full hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-all flex items-center"
                     >
                       {loading ? (
                         <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
@@ -1751,7 +1751,7 @@ const App: React.FC = () => {
               {/* Résultats */}
               {searchResults && (
                 <div className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg shadow-2xl rounded-3xl border border-gray-200 dark:border-gray-700 overflow-hidden">
-                  <div className="px-8 py-6 border-b border-gray-200 dark:border-gray-700 bg-gradient-to-r from-indigo-600 to-blue-600 text-white">
+                  <div className="px-8 py-6 border-b border-gray-200 dark:border-gray-700 bg-gradient-to-r from-blue-600 to-blue-700 text-white">
                     <div className="flex justify-between items-center">
                       <div>
                         <h2 className="text-xl font-bold">Résultats de recherche</h2>
@@ -1809,12 +1809,12 @@ const App: React.FC = () => {
                           {searchResults.hits.map((result, index) => (
                             <div
                               key={index}
-                              className="group relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 rounded-2xl p-6 hover:shadow-xl hover:border-indigo-300 dark:hover:border-indigo-500 transform transition-all duration-300 hover:-translate-y-1"
+                              className="group relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 rounded-2xl p-6 hover:shadow-xl hover:border-blue-300 dark:hover:border-blue-500 transform transition-all duration-300 hover:-translate-y-1"
                             >
                               {/* Header de la carte */}
                               <div className="flex justify-between items-start mb-4">
                                 <div className="flex items-center space-x-3">
-                                  <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-indigo-500 to-blue-500 rounded-xl text-white shadow-md">
+                                  <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-500 to-blue-700 rounded-xl text-white shadow-md">
                                     <Database className="w-5 h-5" />
                                   </div>
                                   <div>
@@ -1823,7 +1823,7 @@ const App: React.FC = () => {
                                   </div>
                                 </div>
                                 <div className="flex items-center space-x-2">
-                                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700">
+                                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700">
                                     <Activity className="w-3 h-3 mr-1" />
                                     Score: {result.score.toFixed(1)}
                                   </span>
@@ -1838,8 +1838,8 @@ const App: React.FC = () => {
                                   return (
                                     <div
                                       key={key}
-                                      className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-lg p-3 border border-transparent group-hover:border-indigo-200 dark:group-hover:border-indigo-500 transition-colors"
-                                    >
+                                      className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-lg p-3 border border-transparent group-hover:border-blue-200 dark:group-hover:border-blue-500 transition-colors"
+                                      >
                                       <div className="flex flex-col">
                                         <span className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-1">
                                           {key.replace(/_/g, ' ')}
@@ -1876,7 +1876,7 @@ const App: React.FC = () => {
                                     navigator.clipboard.writeText(dataText);
                                     alert('Données copiées dans le presse-papier !');
                                   }}
-                                  className="inline-flex items-center px-3 py-1 text-xs font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-800 transition-colors"
+                                  className="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900 rounded-md hover:bg-blue-100 dark:hover:bg-blue-800 transition-colors"
                                 >
                                   <User className="w-3 h-3 mr-1" />
                                   Copier
@@ -1887,7 +1887,7 @@ const App: React.FC = () => {
                         </div>
                         <div className="mt-8 text-center">
                           <button
-                            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
                             onClick={() => {
                               const combined: Record<string, any> = {};
                               searchResults.hits.forEach(h => {
@@ -1925,7 +1925,7 @@ const App: React.FC = () => {
                         <button
                           onClick={loadMoreResults}
                           disabled={loading}
-                          className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
                         >
                           Charger plus
                         </button>
@@ -2682,7 +2682,7 @@ const App: React.FC = () => {
                 <PageHeader icon={<User className="h-6 w-6" />} title="Gestion des utilisateurs" subtitle="Créez et gérez les comptes utilisateurs" />
                 <button
                   onClick={openCreateModal}
-                  className="flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-xl hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all shadow-lg"
+                  className="flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-xl hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all shadow-lg"
                 >
                   <Plus className="w-5 h-5 mr-2" />
                   Nouvel utilisateur
@@ -2730,7 +2730,7 @@ const App: React.FC = () => {
                           <tr key={user.id} className="hover:bg-gray-50 transition-colors">
                             <td className="px-6 py-4 whitespace-nowrap">
                               <div className="flex items-center">
-                                <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-500 to-indigo-500 rounded-full">
+                                <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-500 to-blue-700 rounded-full">
                                   <User className="h-5 w-5 text-white" />
                                 </div>
                                 <div className="ml-4">
@@ -3022,7 +3022,7 @@ const App: React.FC = () => {
                     <div className="lg:col-span-2">
                       <div className="bg-white rounded-2xl shadow-xl p-6">
                         <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-center">
-                          <FileText className="h-6 w-6 mr-2 text-indigo-600" />
+                          <FileText className="h-6 w-6 mr-2 text-blue-600" />
                           Logs de recherche
                         </h3>
                         {isAdmin && (
@@ -3032,11 +3032,11 @@ const App: React.FC = () => {
                               value={logUserFilter}
                               onChange={(e) => setLogUserFilter(e.target.value)}
                               placeholder="Filtrer par utilisateur"
-                              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                             />
                             <button
                               onClick={loadStatistics}
-                              className="ml-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+                              className="ml-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
                             >
                               Rechercher
                             </button>
@@ -3091,7 +3091,7 @@ const App: React.FC = () => {
                     </h3>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                       {statsData?.top_search_terms?.slice(0, 9).map((term, index) => (
-                        <div key={index} className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl hover:from-blue-50 hover:to-indigo-50 transition-all dark:from-gray-800 dark:to-gray-700 dark:hover:from-blue-900 dark:hover:to-indigo-900">
+                        <div key={index} className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl hover:from-blue-50 hover:to-blue-100 transition-all dark:from-gray-800 dark:to-gray-700 dark:hover:from-blue-900 dark:hover:to-blue-800">
                           <div className="flex items-center space-x-3">
                             <div className="flex items-center justify-center w-8 h-8 bg-blue-100 rounded-full text-blue-600 font-bold text-sm dark:bg-blue-900 dark:text-blue-200">
                               {index + 1}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -10,10 +10,10 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, title, subtitle }) => {
   return (
     <div>
       <div className="flex items-center space-x-3">
-        <div className="p-3 rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 text-white shadow-md">
+        <div className="p-3 rounded-xl bg-gradient-to-br from-blue-500 to-blue-700 text-white shadow-md">
           {icon}
         </div>
-        <h1 className="text-3xl font-extrabold bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+        <h1 className="text-3xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-700 bg-clip-text text-transparent">
           {title}
         </h1>
       </div>

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -166,7 +166,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
           >
             <div className="flex items-center space-x-3">
               <input
-                className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="Titre de la catégorie"
                 value={cat.title}
                 onChange={e => updateCategoryTitle(cIdx, e.target.value)}
@@ -189,13 +189,13 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
                 onDrop={() => handleDrop(cIdx, fIdx)}
               >
                 <input
-                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   placeholder="Nom du champ"
                   value={field.key}
                   onChange={e => updateField(cIdx, fIdx, 'key', e.target.value)}
                 />
                 <input
-                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   placeholder="Valeur"
                   value={field.value}
                   onChange={e => updateField(cIdx, fIdx, 'value', e.target.value)}
@@ -211,7 +211,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
             ))}
             <button
               type="button"
-              className="px-4 py-2 bg-indigo-100 text-indigo-700 rounded-lg hover:bg-indigo-200"
+              className="px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200"
               onClick={() => addField(cIdx)}
             >
               Ajouter un champ
@@ -220,7 +220,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
         ))}
         <button
           type="button"
-          className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
           onClick={addCategory}
         >
           Ajouter une catégorie
@@ -229,7 +229,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
       <div>
         <label className="block mb-2 font-medium text-gray-700">Commentaire</label>
         <textarea
-          className="w-full rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+          className="w-full rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           value={comment}
           onChange={e => setComment(e.target.value)}
         />
@@ -238,7 +238,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
         <input
           type="file"
           onChange={handlePhoto}
-          className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+          className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
         />
         {preview && (
           <img
@@ -250,7 +250,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
       </div>
       <button
         type="submit"
-        className="px-6 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+        className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
       >
         Enregistrer
       </button>

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -95,13 +95,13 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row gap-2 bg-white/80 backdrop-blur-sm p-4 rounded-2xl shadow-lg">
         <input
-          className="border border-gray-300 p-2 rounded-lg flex-1 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          className="border border-gray-300 p-2 rounded-lg flex-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
           placeholder="Recherche"
           value={query}
           onChange={e => setQuery(e.target.value)}
         />
         <button
-          className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
           onClick={() => {
             setPage(1);
             load();
@@ -111,7 +111,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
         </button>
         {onCreate && (
           <button
-            className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
             onClick={onCreate}
           >
             Créer profil
@@ -153,14 +153,14 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               return (
                 <div
                   key={p.id}
-                  className="bg-white/80 backdrop-blur-sm shadow-md rounded-2xl p-6 flex flex-col hover:shadow-xl transition-shadow"
+                  className="bg-white/80 backdrop-blur-sm shadow-md rounded-2xl p-6 flex flex-col border border-blue-100 hover:border-blue-300 hover:shadow-xl transition-shadow"
                 >
                   <div className="flex items-center space-x-4">
                     {p.photo_path ? (
                       <img
                         src={`/${p.photo_path}`}
                         alt="profil"
-                        className="w-16 h-16 rounded-full object-cover ring-2 ring-indigo-500"
+                        className="w-16 h-16 rounded-full object-cover ring-2 ring-blue-500"
                       />
                     ) : (
                       <div className="w-16 h-16 rounded-full bg-gray-200" />
@@ -183,7 +183,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
                     </button>
                     {onEdit && (
                       <button
-                        className="text-indigo-600 hover:underline"
+                        className="text-blue-600 hover:underline"
                         onClick={() => onEdit(p.id)}
                       >
                         Modifier
@@ -208,7 +208,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
           </div>
           <div className="flex justify-center items-center space-x-2 mt-4">
             <button
-              className="px-3 py-1 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+              className="px-3 py-1 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
               onClick={() => setPage(p => Math.max(1, p - 1))}
               disabled={page === 1}
             >
@@ -218,7 +218,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               Page {page} / {Math.max(1, Math.ceil(total / limit))}
             </span>
             <button
-              className="px-3 py-1 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+              className="px-3 py-1 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
               onClick={() => setPage(p => p + 1)}
               disabled={page >= Math.ceil(total / limit)}
             >
@@ -240,7 +240,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               <img
                 src={`/${selected.photo_path}`}
                 alt="profil"
-                className="mx-auto w-32 h-32 rounded-full object-cover mb-4 ring-2 ring-indigo-500"
+                className="mx-auto w-32 h-32 rounded-full object-cover mb-4 ring-2 ring-blue-500"
               />
             )}
             <h2 className="text-2xl font-semibold text-center mb-4">Détails du profil</h2>

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -29,11 +29,11 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
     <div className="space-y-8">
       {hits.map((hit, idx) => (
         <div key={idx} className="bg-white shadow-lg rounded-2xl overflow-hidden">
-          <div className="bg-gradient-to-r from-indigo-500 to-blue-500 p-4 flex items-center">
+          <div className="bg-gradient-to-r from-blue-500 to-blue-700 p-4 flex items-center">
             <User className="w-8 h-8 text-white mr-3" />
             <div>
               <h3 className="text-xl font-semibold text-white">{hit.table}</h3>
-              <p className="text-indigo-100 text-sm">{hit.database}</p>
+              <p className="text-blue-100 text-sm">{hit.database}</p>
             </div>
             <span className="ml-auto inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white/20 text-white">
               <Activity className="w-3 h-3 mr-1" />
@@ -59,7 +59,7 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
       ))}
       <div className="text-center">
         <button
-          className="mt-4 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+          className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
           onClick={() => {
             const combined: Record<string, any> = {};
             hits.forEach(h => {


### PR DESCRIPTION
## Summary
- restyle all buttons with consistent blue backgrounds
- update profile cards and headers to use platform blue
- apply blue focus and upload styles in profile forms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b56c9a55dc8326b04b97e6fd6168ac