### PR TITLE
Affichage tableau des fichiers importés et bouton diagramme des liens

### DIFF
--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -32,16 +32,16 @@ class Case {
     await database.query('DELETE FROM autres.cdr_cases WHERE id = ?', [id]);
   }
 
-  static async addFile(caseId, filename) {
+  static async addFile(caseId, filename, lineCount) {
     await database.query(
-      'INSERT INTO autres.cdr_case_files (case_id, filename, uploaded_at) VALUES (?, ?, NOW())',
-      [caseId, filename]
+      'INSERT INTO autres.cdr_case_files (case_id, filename, line_count, uploaded_at) VALUES (?, ?, ?, NOW())',
+      [caseId, filename, lineCount]
     );
   }
 
   static async listFiles(caseId) {
     return await database.query(
-      'SELECT id, filename, uploaded_at FROM autres.cdr_case_files WHERE case_id = ? ORDER BY uploaded_at DESC',
+      'SELECT id, filename, uploaded_at, line_count FROM autres.cdr_case_files WHERE case_id = ? ORDER BY uploaded_at DESC',
       [caseId]
     );
   }

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -43,7 +43,7 @@ class CaseService {
     } else {
       result = await this.cdrService.importCsv(filePath, existingCase.name);
     }
-    await Case.addFile(caseId, originalName);
+    await Case.addFile(caseId, originalName, result.inserted);
     return result;
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,6 +229,7 @@ interface CaseFile {
   id: number;
   filename: string;
   uploaded_at: string;
+  line_count: number;
 }
 
 const usefulLinks = [
@@ -1111,6 +1112,11 @@ const App: React.FC = () => {
     } finally {
       setCdrLoading(false);
     }
+  };
+
+  const handleLinkDiagram = () => {
+    // Placeholder action for link diagram
+    setShowCdrMap(false);
   };
 
   const fetchCases = async () => {
@@ -2521,19 +2527,33 @@ const App: React.FC = () => {
                   {caseFiles.length > 0 && (
                     <div>
                       <h4 className="font-semibold mb-2">Fichiers importés</h4>
-                      <ul className="divide-y divide-gray-200 text-sm text-gray-700">
-                        {caseFiles.map((f) => (
-                          <li key={f.id} className="py-2 flex items-center justify-between">
-                            <span className="truncate">{f.filename}</span>
-                            <button
-                              className="text-red-600 hover:underline ml-2"
-                              onClick={() => handleDeleteFile(f.id)}
-                            >
-                              Supprimer
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
+                      <div className="overflow-x-auto">
+                        <table className="min-w-full text-sm text-gray-700">
+                          <thead>
+                            <tr>
+                              <th className="px-4 py-2 text-left">Nom du fichier</th>
+                              <th className="px-4 py-2 text-left">Lignes</th>
+                              <th className="px-4 py-2" />
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-gray-200">
+                            {caseFiles.map((f) => (
+                              <tr key={f.id}>
+                                <td className="px-4 py-2 truncate">{f.filename}</td>
+                                <td className="px-4 py-2">{f.line_count}</td>
+                                <td className="px-4 py-2 text-right">
+                                  <button
+                                    className="text-red-600 hover:underline"
+                                    onClick={() => handleDeleteFile(f.id)}
+                                  >
+                                    Supprimer
+                                  </button>
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
                     </div>
                   )}
                 </div>
@@ -2596,13 +2616,22 @@ const App: React.FC = () => {
                         <option value="sms">Seulement SMS</option>
                       </select>
                     </div>
-                    <button
-                      type="submit"
-                      disabled={cdrLoading}
-                      className="px-6 py-2 bg-blue-600 text-white rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-transform transform hover:scale-105 active:scale-95"
-                    >
-                      Rechercher
-                    </button>
+                    <div className="flex gap-2">
+                      <button
+                        type="submit"
+                        disabled={cdrLoading}
+                        className="px-6 py-2 bg-blue-600 text-white rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-transform transform hover:scale-105 active:scale-95"
+                      >
+                        Rechercher
+                      </button>
+                      <button
+                        type="button"
+                        className="px-6 py-2 bg-gray-600 text-white rounded-full hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-transform transform hover:scale-105 active:scale-95"
+                        onClick={handleLinkDiagram}
+                      >
+                        Diagram des liens
+                      </button>
+                    </div>
                   </form>
                 </div>
               </div>


### PR DESCRIPTION
## Résumé
- Présente les fichiers importés dans un tableau indiquant le nombre de lignes
- Enregistre et expose le nombre de lignes côté serveur lors de l’import
- Ajoute un bouton **Diagram des liens** à côté du bouton de recherche CDR

## Tests
- `npm test` *(échoue : Missing script "test")*
- `npm run lint` *(échoue : Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b56f85fccc8326872eb75997d358fc