### PR TITLE
fix: handle missing upload id during cleanup

### DIFF
--- a/server/services/UploadService.js
+++ b/server/services/UploadService.js
@@ -270,7 +270,12 @@ class UploadService {
       if (rows[0].upload_mode === 'new_table' || rows[0].upload_mode === 'sql') {
         await database.query(`DROP TABLE IF EXISTS \`${db}\`.\`${table}\``);
       } else {
-        await database.query(`DELETE FROM \`${db}\`.\`${table}\` WHERE upload_id = ?`, [id]);
+        const columns = await database.query(`SHOW COLUMNS FROM \`${db}\`.\`${table}\` LIKE 'upload_id'`);
+        if (columns.length === 0) {
+          await database.query(`DROP TABLE IF EXISTS \`${db}\`.\`${table}\``);
+        } else {
+          await database.query(`DELETE FROM \`${db}\`.\`${table}\` WHERE upload_id = ?`, [id]);
+        }
       }
       await database.query('DELETE FROM upload_history WHERE id = ?', [id]);
     } catch (error) {


### PR DESCRIPTION
## Summary
- drop table when legacy uploads lack `upload_id` column
- retain row-level cleanup when `upload_id` exists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b57aa95ce0832685d3cb4c28145cb1