### PR TITLE
Show link diagram button only when multiple CDR files exist

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2643,13 +2643,15 @@ const App: React.FC = () => {
                       >
                         Rechercher
                       </button>
-                        <button
-                          type="button"
-                          className="px-6 py-2 bg-blue-600 text-white rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-transform transform hover:scale-105 active:scale-95"
-                          onClick={handleLinkDiagram}
-                        >
-                          Diagram des liens
-                        </button>
+                        {caseFiles.length >= 2 && (
+                          <button
+                            type="button"
+                            className="px-6 py-2 bg-blue-600 text-white rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-transform transform hover:scale-105 active:scale-95"
+                            onClick={handleLinkDiagram}
+                          >
+                            Diagram des liens
+                          </button>
+                        )}
                     </div>
                   </form>
                 </div>


### PR DESCRIPTION
## Summary
- display link diagram button only when at least two CDR files are imported

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b5828de8108326b3b97c11fa82cb4e