### PR TITLE
feat: add link diagram for common contacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "pdfkit": "^0.13.0",
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "force-graph": "^1.45.0",
+    "react-force-graph-2d": "^1.25.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -113,6 +113,21 @@ router.get('/:id/search', authenticate, async (req, res) => {
   }
 });
 
+router.post('/:id/link-diagram', authenticate, async (req, res) => {
+  try {
+    const caseId = parseInt(req.params.id, 10);
+    const { numbers } = req.body;
+    if (!Array.isArray(numbers) || numbers.length === 0) {
+      return res.status(400).json({ error: 'Liste de numéros requise' });
+    }
+    const result = await caseService.linkDiagram(caseId, numbers, req.user);
+    res.json(result);
+  } catch (err) {
+    console.error('Erreur diagramme des liens:', err);
+    res.status(500).json({ error: 'Erreur diagramme des liens' });
+  }
+});
+
 router.get('/:id/files', authenticate, async (req, res) => {
   try {
     const caseId = parseInt(req.params.id, 10);

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -56,6 +56,14 @@ class CaseService {
     return await this.cdrService.search(identifier, { ...options, caseName: existingCase.name });
   }
 
+  async linkDiagram(caseId, numbers, user) {
+    const existingCase = await this.getCaseById(caseId, user);
+    if (!existingCase) {
+      throw new Error('Case not found');
+    }
+    return await this.cdrService.findCommonContacts(numbers, existingCase.name);
+  }
+
   async deleteCase(id, user) {
     const existingCase = await this.getCaseById(id, user);
     if (!existingCase) {

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import ForceGraph2D from 'react-force-graph-2d';
+import { X } from 'lucide-react';
+
+interface GraphNode {
+  id: string;
+  type: string;
+}
+
+interface GraphLink {
+  source: string;
+  target: string;
+  callCount: number;
+  smsCount: number;
+}
+
+interface LinkDiagramProps {
+  data: { nodes: GraphNode[]; links: GraphLink[] };
+  onClose: () => void;
+}
+
+const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-lg w-11/12 h-5/6 relative">
+        <button
+          className="absolute top-3 right-3 text-gray-500 hover:text-gray-700"
+          onClick={onClose}
+        >
+          <X className="w-6 h-6" />
+        </button>
+        <ForceGraph2D
+          graphData={data}
+          nodeLabel={(node: any) => node.id}
+          nodeAutoColorBy="type"
+          linkWidth={(link: any) => 1 + Math.log(link.callCount + link.smsCount)}
+          linkDirectionalParticles={2}
+          linkDirectionalParticleSpeed={0.005}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default LinkDiagram;


### PR DESCRIPTION
## Summary
- compute common contacts among numbers and expose API
- visualize common links with a modern force-directed diagram
- wire frontend to request and render link diagram

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b58890ae148326828cccce3b7a48dc