### PR TITLE
feat: add cdr number field for imports

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -12,6 +12,7 @@ class Cdr {
           id INT AUTO_INCREMENT PRIMARY KEY,
           oce VARCHAR(50) DEFAULT NULL,
           type_cdr VARCHAR(50) DEFAULT NULL,
+          cdr_numb VARCHAR(50) DEFAULT NULL,
           date_debut VARCHAR(50) DEFAULT NULL,
           heure_debut TIME DEFAULT NULL,
           date_fin VARCHAR(50) DEFAULT NULL,
@@ -38,16 +39,17 @@ class Cdr {
     for (const rec of records) {
       await database.query(
           `INSERT INTO ${table} (
-            oce, type_cdr, date_debut, heure_debut, date_fin, heure_fin, duree,
+            oce, type_cdr, cdr_numb, date_debut, heure_debut, date_fin, heure_fin, duree,
             numero_intl_appelant, numero_intl_appele, numero_intl_appele_original,
             imei_appelant, imei_appele, imei_appele_original,
             imsi_appelant, imsi_appele,
             cgi_appelant, cgi_appele, cgi_appele_original,
             latitude, longitude, nom_localisation, file_id
-          ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
           [
             rec.oce,
             rec.type_cdr,
+            rec.cdr_numb,
             rec.date_debut,
             rec.heure_debut,
             rec.date_fin,
@@ -86,9 +88,10 @@ class Cdr {
       numero_intl_appelant = ? OR
       numero_intl_appele = ? OR
       imei_appelant = ? OR
-      imei_appele = ?
+      imei_appele = ? OR
+      cdr_numb = ?
     )`;
-    const params = [identifier, identifier, identifier, identifier];
+    const params = [identifier, identifier, identifier, identifier, identifier];
 
     if (startDate) {
       query += ` AND date_debut >= ?`;

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -48,10 +48,15 @@ router.post('/', authenticate, async (req, res) => {
 router.post('/:id/upload', authenticate, upload.single('file'), async (req, res) => {
   try {
     const caseId = parseInt(req.params.id, 10);
+    const number = (req.body.cdrNumber || '').toString().trim();
     if (!req.file) {
       return res.status(400).json({ error: 'Aucun fichier fourni' });
     }
-    const result = await caseService.importFile(caseId, req.file.path, req.file.originalname, req.user);
+    if (!number) {
+      fs.unlinkSync(req.file.path);
+      return res.status(400).json({ error: 'Numéro CDR requis' });
+    }
+    const result = await caseService.importFile(caseId, req.file.path, req.file.originalname, req.user, number);
     fs.unlinkSync(req.file.path);
     res.json({ message: 'CDR importés', ...result });
   } catch (err) {

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -31,7 +31,7 @@ class CaseService {
     return await Case.findAllByUser(user.id);
   }
 
-  async importFile(caseId, filePath, originalName, user) {
+  async importFile(caseId, filePath, originalName, user, cdrNumber) {
     const existingCase = await this.getCaseById(caseId, user);
     if (!existingCase) {
       throw new Error('Case not found');
@@ -40,9 +40,9 @@ class CaseService {
     const ext = path.extname(originalName).toLowerCase();
     let result;
     if (ext === '.xlsx' || ext === '.xls') {
-      result = await this.cdrService.importExcel(filePath, existingCase.name, fileRecord.id);
+      result = await this.cdrService.importExcel(filePath, existingCase.name, fileRecord.id, cdrNumber);
     } else {
-      result = await this.cdrService.importCsv(filePath, existingCase.name, fileRecord.id);
+      result = await this.cdrService.importCsv(filePath, existingCase.name, fileRecord.id, cdrNumber);
     }
     await Case.updateFileLineCount(fileRecord.id, result.inserted);
     return result;

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -6,7 +6,8 @@ import Cdr from '../models/Cdr.js';
 import database from '../config/database.js';
 
 class CdrService {
-  async importCsv(filePath, caseName, fileId) {
+  async importCsv(filePath, caseName, fileId, cdrNumber) {
+    const cdrNum = cdrNumber.startsWith('221') ? cdrNumber : `221${cdrNumber}`;
     return new Promise((resolve, reject) => {
       const records = [];
       fs.createReadStream(filePath)
@@ -32,6 +33,7 @@ class CdrService {
           records.push({
             oce: row['OCE'] || null,
             type_cdr: row['Type CDR'] || null,
+            cdr_numb: cdrNum,
             date_debut: normalizeDate(row['Date debut']),
             heure_debut: normalizeTime(row['Heure debut']),
             date_fin: normalizeDate(row['Date fin']),
@@ -65,7 +67,7 @@ class CdrService {
     });
   }
 
-  async importExcel(filePath, caseName, fileId) {
+  async importExcel(filePath, caseName, fileId, cdrNumber) {
     const workbook = XLSX.readFile(filePath);
     const sheet = workbook.Sheets[workbook.SheetNames[0]];
     const rows = XLSX.utils.sheet_to_json(sheet);
@@ -85,9 +87,11 @@ class CdrService {
       if (isNaN(parsed.getTime())) return null;
       return parsed.toISOString().slice(11, 19);
     };
+    const cdrNum = cdrNumber.startsWith('221') ? cdrNumber : `221${cdrNumber}`;
     const records = rows.map((row) => ({
       oce: row['OCE'] || null,
       type_cdr: row['Type CDR'] || null,
+      cdr_numb: cdrNum,
       date_debut: normalizeDate(row['Date debut']),
       heure_debut: normalizeTime(row['Heure debut']),
       date_fin: normalizeDate(row['Date fin']),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -456,6 +456,7 @@ const App: React.FC = () => {
   const [cdrError, setCdrError] = useState('');
   const [cdrInfoMessage, setCdrInfoMessage] = useState('');
   const [cdrFile, setCdrFile] = useState<File | null>(null);
+  const [cdrNumber, setCdrNumber] = useState('');
   const [cdrUploadMessage, setCdrUploadMessage] = useState('');
   const [cdrUploadError, setCdrUploadError] = useState('');
   const [cdrUploading, setCdrUploading] = useState(false);
@@ -1289,7 +1290,7 @@ const App: React.FC = () => {
 
   const handleCdrUpload = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!cdrFile || !selectedCase) return;
+    if (!cdrFile || !selectedCase || !cdrNumber.trim()) return;
     setCdrUploading(true);
     setCdrUploadMessage('');
     setCdrUploadError('');
@@ -1297,6 +1298,7 @@ const App: React.FC = () => {
       const token = localStorage.getItem('token');
       const formData = new FormData();
       formData.append('file', cdrFile);
+      formData.append('cdrNumber', cdrNumber.trim());
       const res = await fetch(`/api/cases/${selectedCase.id}/upload`, {
         method: 'POST',
         headers: { Authorization: token ? `Bearer ${token}` : '' },
@@ -1306,6 +1308,7 @@ const App: React.FC = () => {
       if (res.ok) {
         setCdrUploadMessage('Fichier importé avec succès');
         setCdrFile(null);
+        setCdrNumber('');
         await fetchCaseFiles(selectedCase.id);
       } else {
         setCdrUploadError(data.error || "Erreur lors de l'import");
@@ -2578,6 +2581,13 @@ const App: React.FC = () => {
                   <h3 className="text-lg font-semibold text-gray-700">Importation CDR</h3>
                   <form onSubmit={handleCdrUpload} className="space-y-4">
                     <input
+                      type="text"
+                      value={cdrNumber}
+                      onChange={(e) => setCdrNumber(e.target.value)}
+                      placeholder="Numéro associé"
+                      className="block w-full border rounded-md p-2"
+                    />
+                    <input
                       type="file"
                       accept=".csv"
                       onChange={(e) => setCdrFile(e.target.files?.[0] || null)}
@@ -2585,7 +2595,7 @@ const App: React.FC = () => {
                     />
                       <button
                         type="submit"
-                        disabled={cdrUploading || !cdrFile}
+                        disabled={cdrUploading || !cdrFile || !cdrNumber}
                         className="flex items-center justify-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md disabled:opacity-50"
                       >
                         {cdrUploading ? (


### PR DESCRIPTION
## Summary
- allow specifying a CDR number when uploading records
- store the associated number (prefixed with 221) on each imported row
- include the new number column in CDR search and storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install @eslint/js` *(fails: 403 Forbidden fetching @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68b58f91a5c4832694a32c07bc46e197