### PR TITLE
Use uploaded CDR numbers for link diagram

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -157,6 +157,8 @@ class DatabaseManager {
           id INT AUTO_INCREMENT PRIMARY KEY,
           case_id INT NOT NULL,
           filename VARCHAR(255) NOT NULL,
+          cdr_number VARCHAR(50) DEFAULT NULL,
+          line_count INT DEFAULT 0,
           uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
           INDEX idx_case_id (case_id),
           FOREIGN KEY (case_id) REFERENCES autres.cdr_cases(id) ON DELETE CASCADE

--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -32,10 +32,10 @@ class Case {
     await database.query('DELETE FROM autres.cdr_cases WHERE id = ?', [id]);
   }
 
-  static async addFile(caseId, filename, lineCount = 0) {
+  static async addFile(caseId, filename, cdrNumber, lineCount = 0) {
     const result = await database.query(
-      'INSERT INTO autres.cdr_case_files (case_id, filename, line_count, uploaded_at) VALUES (?, ?, ?, NOW())',
-      [caseId, filename, lineCount]
+      'INSERT INTO autres.cdr_case_files (case_id, filename, cdr_number, line_count, uploaded_at) VALUES (?, ?, ?, ?, NOW())',
+      [caseId, filename, cdrNumber, lineCount]
     );
     return { id: result.insertId };
   }
@@ -49,7 +49,7 @@ class Case {
 
   static async listFiles(caseId) {
     return await database.query(
-      'SELECT id, filename, uploaded_at, line_count FROM autres.cdr_case_files WHERE case_id = ? ORDER BY uploaded_at DESC',
+      'SELECT id, filename, uploaded_at, line_count, cdr_number FROM autres.cdr_case_files WHERE case_id = ? ORDER BY uploaded_at DESC',
       [caseId]
     );
   }

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -36,13 +36,14 @@ class CaseService {
     if (!existingCase) {
       throw new Error('Case not found');
     }
-    const fileRecord = await Case.addFile(caseId, originalName);
+    const cdrNum = cdrNumber.startsWith('221') ? cdrNumber : `221${cdrNumber}`;
+    const fileRecord = await Case.addFile(caseId, originalName, cdrNum);
     const ext = path.extname(originalName).toLowerCase();
     let result;
     if (ext === '.xlsx' || ext === '.xls') {
-      result = await this.cdrService.importExcel(filePath, existingCase.name, fileRecord.id, cdrNumber);
+      result = await this.cdrService.importExcel(filePath, existingCase.name, fileRecord.id, cdrNum);
     } else {
-      result = await this.cdrService.importCsv(filePath, existingCase.name, fileRecord.id, cdrNumber);
+      result = await this.cdrService.importCsv(filePath, existingCase.name, fileRecord.id, cdrNum);
     }
     await Case.updateFileLineCount(fileRecord.id, result.inserted);
     return result;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -231,6 +231,7 @@ interface CaseFile {
   filename: string;
   uploaded_at: string;
   line_count: number;
+  cdr_number: string | null;
 }
 
 interface GraphNode {
@@ -1157,12 +1158,9 @@ const App: React.FC = () => {
 
   const handleLinkDiagram = async () => {
     if (!selectedCase) return;
-    const numbers = cdrIdentifier
-      .split(/[\s,;]+/)
-      .map((n) => n.trim())
-      .filter((n) => n);
+    const numbers = Array.from(new Set(caseFiles.map((f) => f.cdr_number).filter((n): n is string => !!n)));
     if (numbers.length < 2) {
-      setCdrError('Veuillez saisir au moins deux numéros séparés par des virgules');
+      setCdrError('Au moins deux fichiers avec un numéro sont requis');
       return;
     }
     try {
@@ -2615,6 +2613,7 @@ const App: React.FC = () => {
                           <thead>
                             <tr>
                               <th className="px-4 py-2 text-left">Nom du fichier</th>
+                              <th className="px-4 py-2 text-left">Numéro</th>
                               <th className="px-4 py-2 text-left">Lignes</th>
                               <th className="px-4 py-2" />
                             </tr>
@@ -2623,6 +2622,7 @@ const App: React.FC = () => {
                             {caseFiles.map((f) => (
                               <tr key={f.id}>
                                 <td className="px-4 py-2 truncate">{f.filename}</td>
+                                <td className="px-4 py-2">{f.cdr_number || '-'}</td>
                                 <td className="px-4 py-2">{f.line_count}</td>
                                 <td className="px-4 py-2 text-right">
                                   <button
@@ -2707,7 +2707,7 @@ const App: React.FC = () => {
                       >
                         Rechercher
                       </button>
-                        {caseFiles.length >= 2 && (
+                        {caseFiles.filter(f => f.cdr_number).length >= 2 && (
                           <button
                             type="button"
                             className="px-6 py-2 bg-blue-600 text-white rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-transform transform hover:scale-105 active:scale-95"


### PR DESCRIPTION
## Summary
- store associated phone number for each uploaded CDR file
- include CDR numbers when importing files and retrieving case files
- build link diagram from numbers of uploaded files and display them

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b593025e588326a789f5207c0b52fb