### PR TITLE
Fix link diagram close button and restrict link results to allowed prefixes

### DIFF
--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -4,6 +4,8 @@ import Case from '../models/Case.js';
 import CdrService from './CdrService.js';
 import User from '../models/User.js';
 
+const ALLOWED_PREFIXES = ['22177', '22176', '22178', '22170', '22175', '22133'];
+
 class CaseService {
   constructor() {
     this.cdrService = new CdrService();
@@ -62,7 +64,10 @@ class CaseService {
     if (!existingCase) {
       throw new Error('Case not found');
     }
-    return await this.cdrService.findCommonContacts(numbers, existingCase.name);
+    const filteredNumbers = Array.isArray(numbers)
+      ? numbers.filter(n => ALLOWED_PREFIXES.some(p => String(n).startsWith(p)))
+      : [];
+    return await this.cdrService.findCommonContacts(filteredNumbers, existingCase.name);
   }
 
   async deleteCase(id, user) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,8 @@ import LinkDiagram from './components/LinkDiagram';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip, Legend);
 
+const LINK_DIAGRAM_PREFIXES = ['22177', '22176', '22178', '22170', '22175', '22133'];
+
 interface User {
   id: number;
   login: string;
@@ -1158,7 +1160,14 @@ const App: React.FC = () => {
 
   const handleLinkDiagram = async () => {
     if (!selectedCase) return;
-    const numbers = Array.from(new Set(caseFiles.map((f) => f.cdr_number).filter((n): n is string => !!n)));
+    const numbers = Array.from(
+      new Set(
+        caseFiles
+          .map((f) => f.cdr_number)
+          .filter((n): n is string => !!n)
+          .filter((n) => LINK_DIAGRAM_PREFIXES.some((p) => n.startsWith(p)))
+      )
+    );
     if (numbers.length < 2) {
       setCdrError('Au moins deux fichiers avec un numéro sont requis');
       return;

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -24,7 +24,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg shadow-lg w-11/12 h-5/6 relative">
         <button
-          className="absolute top-3 right-3 text-gray-500 hover:text-gray-700"
+          className="absolute top-3 right-3 text-gray-500 hover:text-gray-700 z-10"
           onClick={onClose}
         >
           <X className="w-6 h-6" />


### PR DESCRIPTION
## Summary
- Ensure link diagram overlay close button sits above graph canvas
- Limit link diagram generation to numbers with prefixes 22177, 22176, 22178, 22170, 22175 and 22133 on client and server

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b599ce2a6c83269054d20f4d53f10e