### PR TITLE
fix: scope blue button styling in dark theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@
   .dark select {
     @apply bg-gray-800 text-gray-100 border-gray-600 placeholder-gray-400;
   }
-  .dark button {
+  .dark .btn-primary {
     @apply bg-blue-600 text-white border-blue-600 hover:bg-blue-700;
   }
 }


### PR DESCRIPTION
## Summary
- limit dark-mode blue styling to `.btn-primary` to avoid overriding custom buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b8593ec083268228e9dba5eef42f