### PR TITLE
feat: modernize link diagram visuals

### DIFF
--- a/src/components/LinkDiagramLegend.tsx
+++ b/src/components/LinkDiagramLegend.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface LegendProps {
+  typeColorMap: Record<string, string>;
+  className?: string;
+}
+
+const LinkDiagramLegend: React.FC<LegendProps> = ({ typeColorMap, className = '' }) => {
+  return (
+    <div className={`bg-white/80 p-3 rounded-lg shadow text-xs ${className}`}>
+      <div className="mb-2 font-semibold">Types de nœuds</div>
+      <div className="space-y-1">
+        {Object.entries(typeColorMap).map(([type, color]) => (
+          <div key={type} className="flex items-center space-x-2">
+            <span
+              className="w-3 h-3 rounded-full"
+              style={{ backgroundColor: color }}
+            ></span>
+            <span>{type}</span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 mb-2 font-semibold">Liens</div>
+      <div className="space-y-1">
+        <div className="flex items-center space-x-2">
+          <span className="w-3 h-3 rounded-full bg-blue-500"></span>
+          <span>Appels</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <span className="w-3 h-3 rounded-full bg-green-500"></span>
+          <span>SMS</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkDiagramLegend;


### PR DESCRIPTION
## Summary
- restyle link diagram modal with glassmorphism card and gradient header
- add legend explaining node colors and link types
- enhance node and link rendering with gradients, icons, tooltips, and colored particles

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ba4791a48326ad010685e8425202