### PR TITLE
fix: handle numeric cdr numbers when building link diagram

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1163,7 +1163,7 @@ const App: React.FC = () => {
     const numbers = Array.from(
       new Set(
         caseFiles
-          .map((f) => f.cdr_number)
+          .map((f) => (f.cdr_number ? String(f.cdr_number) : null))
           .filter((n): n is string => !!n)
           .filter((n) => LINK_DIAGRAM_PREFIXES.some((p) => n.startsWith(p)))
       )


### PR DESCRIPTION
## Summary
- ensure cdr numbers are coerced to strings before filtering for link diagram generation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden for @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68b5be5c6f6c8326ae852a9773c20ec2