### PR TITLE
feat(search): parallelize table queries and auto-index fields

### DIFF
--- a/server/scripts/create-search-indexes.js
+++ b/server/scripts/create-search-indexes.js
@@ -7,7 +7,9 @@ async function createIndexes() {
     for (const field of fields) {
       const indexName = `idx_${table.replace(/\./g, '_')}_${field}`;
       try {
-        await database.query(`CREATE INDEX ${indexName} ON ${table} (${field})`);
+        await database.query(
+          `CREATE INDEX IF NOT EXISTS ${indexName} ON ${table} (${field})`
+        );
         console.log(`✅ Index ${indexName} créé`);
       } catch (err) {
         console.log(`ℹ️ Index ${indexName} ignoré: ${err.message}`);


### PR DESCRIPTION
## Summary
- run table searches in parallel using `Promise.all`
- restrict SELECT columns to preview fields and primary key
- auto-generate search indexes from catalog for all searchable fields
- add `IF NOT EXISTS` when creating indexes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b6ce0b90808326b94590d567db3ad6