### PR TITLE
feat(search): parallelize table queries and auto-index fields

### DIFF
--- a/server/services/SearchService.cjs
+++ b/server/services/SearchService.cjs
@@ -105,7 +105,12 @@ class SearchService {
   async searchInTable(tableName, config, searchTerms, filters) {
     const results = [];
     const primaryKey = config.primaryKey || 'id';
-    const selectFields = [primaryKey, ...(config.preview || [])].join(', ');
+    const fields = new Set([
+      primaryKey,
+      ...(config.preview || []),
+      ...(config.searchable || [])
+    ]);
+    const selectFields = Array.from(fields).join(', ');
     let sql = `SELECT ${selectFields} FROM ${tableName} WHERE `;
     const params = [];
     const conditions = [];

--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -341,6 +341,7 @@ class SearchService {
     const fields = new Set([
       ...(config.preview || []),
       ...(config.linkedFields || []),
+      ...(config.searchable || []),
       primaryKey,
     ]);
     const selectFields = Array.from(fields).join(', ');


### PR DESCRIPTION
## Summary
- run table searches in parallel using `Promise.all`
- restrict SELECT columns to preview fields and primary key
- auto-generate search indexes from catalog for all searchable fields
- add `IF NOT EXISTS` when creating indexes
- include searchable columns in SELECT clause for relevance scoring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b6d65e7ebc83269f08e2b0bd7aaa05