### PR TITLE
Prevent duplicate search submissions and disable StrictMode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -552,6 +552,7 @@ const App: React.FC = () => {
 
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (loading) return;
     if (!searchQuery.trim()) return;
 
     setLoading(true);
@@ -582,6 +583,7 @@ const App: React.FC = () => {
   };
 
   const loadMoreResults = async () => {
+    if (loading) return;
     if (!searchResults || searchResults.page >= searchResults.pages) return;
 
     setLoading(true);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,6 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import 'leaflet/dist/leaflet.css';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## Summary
- guard search handlers against concurrent requests
- render App without React StrictMode to avoid double invocations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b6da8047ac832681048c6b555a716a