### PR TITLE
fix(search): skip redundant extra searches

### DIFF
--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -187,22 +187,26 @@ class SearchService {
     if (depth === 0) {
       const extraValues = new Set();
       const phoneRegex = /^tel(ephone)?\d*$/i;
+      const queryNormalized = String(query).trim().toLowerCase();
       for (const res of results) {
         const preview = res.preview || {};
         for (const [key, value] of Object.entries(preview)) {
           const keyLower = key.toLowerCase();
+          const valueStr = String(value).trim();
           if (
             (keyLower === 'cni' ||
               keyLower === 'tet' ||
               phoneRegex.test(keyLower)) &&
-            value
+            valueStr &&
+            valueStr.toLowerCase() !== queryNormalized
           ) {
-            extraValues.add(value);
+            extraValues.add(valueStr);
           }
         }
       }
 
       for (const val of extraValues) {
+        if (val.toLowerCase() === queryNormalized) continue;
         extraSearches++;
         const sub = await this.search(val, {}, 1, 50, null, 'linked', {
           depth: depth + 1


### PR DESCRIPTION
## Summary
- avoid running extra searches for CNI/TET/phone values identical to the original query
- prevent duplicate logs and results caused by redundant searches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --no-save --package-lock=false @eslint/js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e157e2d883268704726d9380f35b