### PR TITLE
Navigate to search on CDR number identification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -554,10 +554,10 @@ const App: React.FC = () => {
     setSearchResults(null);
   };
 
-  const handleSearch = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSearch = async (e?: React.FormEvent, forcedQuery?: string) => {
+    e?.preventDefault();
     if (loading) return;
-    const trimmedQuery = searchQuery.trim();
+    const trimmedQuery = (forcedQuery ?? searchQuery).trim();
     if (!trimmedQuery) return;
 
     const requestedPage = 1;
@@ -2797,7 +2797,11 @@ const App: React.FC = () => {
               {showCdrMap && cdrResult && !cdrLoading && cdrResult.total > 0 && (
                 <CdrMap
                   points={cdrResult.path}
-                  onIdentifyNumber={(num) => setSearchQuery(num)}
+                  onIdentifyNumber={(num) => {
+                    setSearchQuery(num);
+                    setCurrentPage('search');
+                    handleSearch(undefined, num);
+                  }}
                 />
               )}
               {linkDiagram && (


### PR DESCRIPTION
## Summary
- allow identifying numbers to automatically trigger searches
- navigate to search page and run query when selecting a number from CDR map

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8019433dc832682c8c55dac724a65