### PR TITLE
Fix close button color in link diagram

### DIFF
--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -55,7 +55,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
         <div className="flex items-center justify-between p-4 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white">
           <h2 className="text-lg font-semibold">Diagramme des liens</h2>
           <button
-            className="text-white hover:text-gray-200"
+            className="text-black hover:text-gray-800 dark:text-white dark:hover:text-gray-200"
             onClick={onClose}
           >
             <X className="w-6 h-6" />


### PR DESCRIPTION
## Summary
- ensure link diagram close button is black in light mode and white in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b806e746c48326b6c9257e207c3bd2