### PR TITLE
fix: resolve Tailwind circular dependency

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer utilities {
+@layer components {
   .dark .text-gray-900 { @apply text-gray-100; }
   .dark .text-gray-600 { @apply text-gray-300; }
   .dark .text-gray-700 { @apply text-gray-300; }


### PR DESCRIPTION
## Summary
- move dark mode overrides to the components layer to avoid Tailwind circular dependency errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8614b72b88326a818091191a490cf