### PR TITLE
feat: modernize CDR case list with pagination

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,9 @@ import {
   ExternalLink,
   UserCircle,
   List,
-  Loader2
+  Loader2,
+  ChevronLeft,
+  ChevronRight
 } from 'lucide-react';
 import { Line, Bar, Doughnut } from 'react-chartjs-2';
 import {
@@ -470,6 +472,18 @@ const App: React.FC = () => {
   const [cdrCaseName, setCdrCaseName] = useState('');
   const [cdrCaseMessage, setCdrCaseMessage] = useState('');
   const [cases, setCases] = useState<CdrCase[]>([]);
+  const [casePage, setCasePage] = useState(1);
+  const CASES_PER_PAGE = 20;
+  const totalCasePages = Math.ceil(cases.length / CASES_PER_PAGE);
+  const paginatedCases = cases.slice(
+    (casePage - 1) * CASES_PER_PAGE,
+    casePage * CASES_PER_PAGE
+  );
+  useEffect(() => {
+    if (casePage > totalCasePages) {
+      setCasePage(totalCasePages || 1);
+    }
+  }, [casePage, totalCasePages]);
   const [showCdrMap, setShowCdrMap] = useState(false);
   const [selectedCase, setSelectedCase] = useState<CdrCase | null>(null);
   const [caseFiles, setCaseFiles] = useState<CaseFile[]>([]);
@@ -2592,37 +2606,60 @@ const App: React.FC = () => {
 
               <div>
                 <h3 className="font-semibold text-gray-900 dark:text-gray-100">Liste des CASES</h3>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
-                  {cases.map((c) => (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-4">
+                  {paginatedCases.map((c) => (
                     <div
                       key={c.id}
-                      className="p-4 rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md transition-transform transform hover:-translate-y-0.5"
+                      className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-md overflow-hidden transition-transform transform hover:scale-105"
                     >
-                      <h4 className="font-semibold mb-2 text-gray-900 dark:text-gray-100">{c.name}</h4>
-                      <div className="flex space-x-2">
-                        <button
-                          className="px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-                          onClick={() => {
-                            setSelectedCase(c);
-                            setCdrResult(null);
-                            setShowCdrMap(false);
-                            setCdrUploadMessage('');
-                            setCdrUploadError('');
-                            setCurrentPage('cdr-case');
-                          }}
-                        >
-                          Traiter
-                        </button>
-                        <button
-                          className="px-2 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
-                          onClick={() => handleDeleteCase(c.id)}
-                        >
-                          Supprimer
-                        </button>
+                      <div className="p-6 flex flex-col h-full">
+                        <h4 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">{c.name}</h4>
+                        <div className="mt-auto flex space-x-2">
+                          <button
+                            className="flex-1 px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                            onClick={() => {
+                              setSelectedCase(c);
+                              setCdrResult(null);
+                              setShowCdrMap(false);
+                              setCdrUploadMessage('');
+                              setCdrUploadError('');
+                              setCurrentPage('cdr-case');
+                            }}
+                          >
+                            Traiter
+                          </button>
+                          <button
+                            className="flex-1 px-3 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                            onClick={() => handleDeleteCase(c.id)}
+                          >
+                            Supprimer
+                          </button>
+                        </div>
                       </div>
                     </div>
                   ))}
                 </div>
+                {totalCasePages > 1 && (
+                  <div className="flex justify-center items-center mt-6 space-x-4">
+                    <button
+                      className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 disabled:opacity-50"
+                      onClick={() => setCasePage((p) => p - 1)}
+                      disabled={casePage === 1}
+                    >
+                      <ChevronLeft className="h-5 w-5" />
+                    </button>
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                      Page {casePage} / {totalCasePages}
+                    </span>
+                    <button
+                      className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 disabled:opacity-50"
+                      onClick={() => setCasePage((p) => p + 1)}
+                      disabled={casePage === totalCasePages}
+                    >
+                      <ChevronRight className="h-5 w-5" />
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- modern list design for CDR cases
- add client-side pagination for case list (20 items per page)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b942a676b88326a5f67f2539184af5