### PR TITLE
Add Orange identifier lookup

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -18,6 +18,7 @@ import ongRoutes from './routes/ong.js';
 import vehiculesRoutes from './routes/vehicules.js';
 import profilesRoutes from './routes/profiles.js';
 import casesRoutes from './routes/cases.js';
+import orangeRoutes from './routes/orange.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -61,6 +62,7 @@ app.use('/api/ong', ongRoutes);
 app.use('/api/vehicules', vehiculesRoutes);
 app.use('/api/profiles', profilesRoutes);
 app.use('/api/cases', casesRoutes);
+app.use('/api/orange', orangeRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/routes/orange.js
+++ b/server/routes/orange.js
@@ -1,0 +1,56 @@
+import express from 'express';
+
+const router = express.Router();
+
+const URL = 'https://prepaid.orange.sn/recherche.aspx';
+const HEADERS = {
+  'User-Agent': 'Mozilla/5.0',
+  'Content-Type': 'application/x-www-form-urlencoded'
+};
+
+router.post('/identify', async (req, res) => {
+  const { msisdn } = req.body;
+  if (!msisdn) {
+    return res.status(400).json({ error: 'msisdn is required' });
+  }
+  try {
+    const getResp = await fetch(URL, { headers: HEADERS });
+    const getHtml = await getResp.text();
+
+    const viewstateMatch = getHtml.match(/id="__VIEWSTATE" value="([^"]+)"/);
+    const eventvalidationMatch = getHtml.match(/id="__EVENTVALIDATION" value="([^"]+)"/);
+    const viewstategeneratorMatch = getHtml.match(/id="__VIEWSTATEGENERATOR" value="([^"]+)"/);
+    if (!viewstateMatch || !eventvalidationMatch || !viewstategeneratorMatch) {
+      return res.status(500).json({ error: 'Token extraction failed' });
+    }
+
+    const params = new URLSearchParams({
+      '__EVENTTARGET': '',
+      '__EVENTARGUMENT': '',
+      '__VIEWSTATE': viewstateMatch[1],
+      '__VIEWSTATEGENERATOR': viewstategeneratorMatch[1],
+      '__EVENTVALIDATION': eventvalidationMatch[1],
+      'ctl00$ContentPlaceHolder1$numeroCompteTextBox': '',
+      'ctl00$ContentPlaceHolder1$msisdnTextBox': msisdn,
+      'ctl00$ContentPlaceHolder1$simTextBox': '',
+      'ctl00$ContentPlaceHolder1$nomTextBox': '',
+      'ctl00$ContentPlaceHolder1$prenomTextBox': '',
+      'ctl00$ContentPlaceHolder1$paysDropDownList_pm': '-1',
+      'ctl00$ContentPlaceHolder1$dateNaissanceTextBox': '',
+      'ctl00$ContentPlaceHolder1$rechercherButton': 'Rechercher'
+    });
+
+    const postResp = await fetch(URL, {
+      method: 'POST',
+      headers: HEADERS,
+      body: params.toString()
+    });
+    const html = await postResp.text();
+    res.json({ html });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Lookup failed' });
+  }
+});
+
+export default router;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ import ProfileList from './components/ProfileList';
 import ProfileForm from './components/ProfileForm';
 import CdrMap from './components/CdrMap';
 import LinkDiagram from './components/LinkDiagram';
+import OrangeIdentifier from './components/OrangeIdentifier';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip, Legend);
 
@@ -1750,6 +1751,18 @@ const App: React.FC = () => {
             </button>
 
             <button
+              onClick={() => setCurrentPage('orange')}
+              className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
+                currentPage === 'orange'
+                  ? 'bg-blue-600 text-white shadow-lg'
+                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
+              } ${!sidebarOpen && 'justify-center'}`}
+            >
+              <Key className="h-5 w-5" />
+              {sidebarOpen && <span className="ml-3">Identificateur Orange</span>}
+            </button>
+
+            <button
               onClick={() => {
                 setCurrentPage('profiles');
                 setShowProfileForm(false);
@@ -2845,6 +2858,10 @@ const App: React.FC = () => {
                 <LinkDiagram data={linkDiagram} onClose={() => setLinkDiagram(null)} />
               )}
             </div>
+          )}
+
+          {currentPage === 'orange' && (
+            <OrangeIdentifier />
           )}
 
           {currentPage === 'profiles' && (

--- a/src/components/OrangeIdentifier.tsx
+++ b/src/components/OrangeIdentifier.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import PageHeader from './PageHeader';
+import { Key } from 'lucide-react';
+
+const OrangeIdentifier: React.FC = () => {
+  const [msisdn, setMsisdn] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const resp = await fetch('/api/orange/identify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ msisdn })
+      });
+      if (!resp.ok) {
+        throw new Error('Erreur de recherche');
+      }
+      const data = await resp.json();
+      setResult(data.html);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <PageHeader icon={<Key className="h-6 w-6" />} title="Identificateur Orange" />
+      <div className="bg-white shadow-xl rounded-2xl p-8">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <input
+            type="text"
+            placeholder="Numéro à rechercher"
+            value={msisdn}
+            onChange={(e) => setMsisdn(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="px-6 py-2 bg-blue-600 text-white rounded-lg disabled:opacity-50"
+          >
+            {loading ? 'Recherche...' : 'Rechercher'}
+          </button>
+        </form>
+        {error && <p className="text-red-600 mt-4">{error}</p>}
+        {result && (
+          <div className="mt-4">
+            <pre className="whitespace-pre-wrap break-all">{result}</pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OrangeIdentifier;


### PR DESCRIPTION
## Summary
- add Express route for Orange prepaid lookup
- create UI and menu entry for "Identificateur Orange"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b95615fd148326afb9623e4edea1d5