### PR TITLE
Add Orange identifier lookup

### DIFF
--- a/server/routes/orange.js
+++ b/server/routes/orange.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { authenticate } from '../middleware/auth.js';
 
 const router = express.Router();
 
@@ -8,7 +9,7 @@ const HEADERS = {
   'Content-Type': 'application/x-www-form-urlencoded'
 };
 
-router.post('/identify', async (req, res) => {
+router.post('/identify', authenticate, async (req, res) => {
   const { msisdn } = req.body;
   if (!msisdn) {
     return res.status(400).json({ error: 'msisdn is required' });

--- a/src/components/OrangeIdentifier.tsx
+++ b/src/components/OrangeIdentifier.tsx
@@ -14,9 +14,13 @@ const OrangeIdentifier: React.FC = () => {
     setError(null);
     setResult(null);
     try {
+      const token = localStorage.getItem('token');
       const resp = await fetch('/api/orange/identify', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: token ? `Bearer ${token}` : ''
+        },
         body: JSON.stringify({ msisdn })
       });
       if (!resp.ok) {


### PR DESCRIPTION
## Summary
- add Express route for Orange prepaid lookup
- create UI and menu entry for "Identificateur Orange"
- protect Orange lookup route with authentication
- send auth token from Orange identifier UI

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b958a819048326a177e33f092a44d3