### PR TITLE
Handle session cookies in Orange lookup

### DIFF
--- a/server/scripts/identify_orange.py
+++ b/server/scripts/identify_orange.py
@@ -12,8 +12,18 @@ from bs4 import BeautifulSoup
 
 URL = "https://prepaid.orange.sn/recherche.aspx"
 HEADERS = {
-    "User-Agent": "Mozilla/5.0",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36"
+    ),
     "Content-Type": "application/x-www-form-urlencoded",
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif," 
+        "image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+    ),
+    "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Origin": "https://prepaid.orange.sn",
+    "Referer": "https://prepaid.orange.sn/recherche.aspx",
 }
 
 def identify_orange(msisdn: str) -> str:


### PR DESCRIPTION
## Summary
- preserve session cookies when querying Orange prepaid search endpoint
- emulate browser headers for both server route and Python helper script

## Testing
- ❌ `npm test` (missing script)
- ⚠️ `npm run lint` (missing `@eslint/js` dependency)


------
https://chatgpt.com/codex/tasks/task_e_68b95a3e17508326b7cc1c70792d030f