### PR TITLE
Rebrand to Dvine Intelligence with red theme

### DIFF
--- a/server/config/database.cjs
+++ b/server/config/database.cjs
@@ -5,6 +5,7 @@ const fs = require('fs');
 class DatabaseManager {
   constructor() {
     this.dbPath = path.join(__dirname, '../../data/dvine-intelligence.db');
+    this.legacyDbPath = path.join(__dirname, '../../data/vegeta.db');
     this.db = null;
     this.init();
   }
@@ -15,6 +16,17 @@ class DatabaseManager {
       const dataDir = path.dirname(this.dbPath);
       if (!fs.existsSync(dataDir)) {
         fs.mkdirSync(dataDir, { recursive: true });
+      }
+
+      // Migrer automatiquement l'ancienne base de données si nécessaire
+      if (!fs.existsSync(this.dbPath) && fs.existsSync(this.legacyDbPath)) {
+        try {
+          fs.renameSync(this.legacyDbPath, this.dbPath);
+          console.log('➡️  Base de données migrée de vegeta.db vers dvine-intelligence.db');
+        } catch (err) {
+          console.error('❌ Échec de la migration de la base de données existante:', err);
+          throw err;
+        }
       }
 
       // Initialiser la base SQLite


### PR DESCRIPTION
## Summary
- migrate existing SQLite database file when rebranding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bdb145ff348326a531fa344c5f63cc