### PR TITLE
Restore VEGETA branding and blue theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Dvine Intelligence - Plateforme de recherche professionnelle multi-bases
+# VEGETA - Plateforme de recherche professionnelle multi-bases
 
 ## Description
 
-Dvine Intelligence est une plateforme Web professionnelle permettant des recherches ultra-rapides sur de grands volumes de données multi-tables avec des fonctionnalités avancées de filtrage, statistiques et gestion des utilisateurs.
+VEGETA est une plateforme Web professionnelle permettant des recherches ultra-rapides sur de grands volumes de données multi-tables avec des fonctionnalités avancées de filtrage, statistiques et gestion des utilisateurs.
 
 ## Fonctionnalités principales
 
@@ -33,7 +33,7 @@ Dvine Intelligence est une plateforme Web professionnelle permettant des recherc
 
 1. **Créer la base de données MySQL** :
 ```sql
-CREATE DATABASE dvine-intelligence CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE DATABASE vegeta CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ```
 
 2. **Configuration MySQL recommandée** :
@@ -57,7 +57,7 @@ Le fichier `.env` est déjà configuré avec :
 DB_HOST=localhost
 DB_USERNAME=root
 DB_PASSWORD=
-DB_DATABASE=dvine-intelligence
+DB_DATABASE=vegeta
 DB_CHARSET=utf8mb4
 DB_COLLATION=utf8mb4_unicode_ci
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dvine Intelligence - Plateforme de recherche professionnelle multi-bases</title>
+    <title>VEGETA - Plateforme de recherche professionnelle multi-bases</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dvine-intelligence-search-platform",
+  "name": "vegeta-search-platform",
   "private": true,
   "version": "1.0.0",
   "type": "module",

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dvine Intelligence - Plateforme de recherche professionnelle</title>
+    <title>VEGETA - Plateforme de recherche professionnelle</title>
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -33,11 +33,11 @@
 </head>
 <body class="bg-light">
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-danger shadow-sm">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
         <div class="container-fluid">
             <a class="navbar-brand fw-bold" href="#" onclick="showPage('home')">
                 <i data-lucide="database" class="me-2"></i>
-                Dvine Intelligence
+                VEGETA
             </a>
             
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -88,8 +88,8 @@
             <div class="row justify-content-center">
                 <div class="col-md-4">
                     <div class="card shadow">
-                        <div class="card-header bg-danger text-white text-center">
-                            <h4><i data-lucide="lock" class="me-2"></i>Connexion Dvine Intelligence</h4>
+                        <div class="card-header bg-primary text-white text-center">
+                            <h4><i data-lucide="lock" class="me-2"></i>Connexion VEGETA</h4>
                         </div>
                         <div class="card-body">
                             <form id="loginForm">
@@ -101,7 +101,7 @@
                                     <label for="password" class="form-label">Mot de passe</label>
                                     <input type="password" class="form-control" id="password" required>
                                 </div>
-                                <button type="submit" class="btn btn-danger w-100">
+                                <button type="submit" class="btn btn-primary w-100">
                                     <i data-lucide="log-in" class="me-2"></i>
                                     Se connecter
                                 </button>
@@ -120,8 +120,8 @@
                     <div class="card shadow-sm">
                         <div class="card-body">
                             <h2 class="text-center mb-4">
-                                <i data-lucide="search" class="me-2 text-danger"></i>
-                                Recherche Unifiée Dvine Intelligence
+                                <i data-lucide="search" class="me-2 text-primary"></i>
+                                Recherche Unifiée VEGETA
                             </h2>
                             
                             <!-- Barre de recherche principale -->
@@ -134,7 +134,7 @@
                                                id="searchQuery"
                                                placeholder="Entrez votre recherche (CNI, nom, téléphone, immatriculation...)"
                                                autocomplete="off">
-                                        <button class="btn btn-danger rounded-pill position-absolute top-50 end-0 translate-middle-y me-2 px-4" type="button" id="searchBtn">
+                                        <button class="btn btn-primary rounded-pill position-absolute top-50 end-0 translate-middle-y me-2 px-4" type="button" id="searchBtn">
                                             Rechercher
                                         </button>
                                     </div>
@@ -172,13 +172,13 @@
                             <div class="card-header d-flex justify-content-between align-items-center">
                                 <h6 class="mb-0">
                                     <i data-lucide="list" class="me-2"></i>
-                                    Résultats <span id="resultsCount" class="badge bg-danger ms-2"></span>
+                                    Résultats <span id="resultsCount" class="badge bg-primary ms-2"></span>
                                 </h6>
                                 <div>
-                                    <button class="btn btn-sm btn-outline-danger" onclick="exportResults('csv')">
+                                    <button class="btn btn-sm btn-outline-primary" onclick="exportResults('csv')">
                                         <i data-lucide="download" class="me-1"></i>CSV
                                     </button>
-                                    <button class="btn btn-sm btn-outline-danger" onclick="exportResults('excel')">
+                                    <button class="btn btn-sm btn-outline-primary" onclick="exportResults('excel')">
                                         <i data-lucide="download" class="me-1"></i>Excel
                                     </button>
                                 </div>
@@ -207,14 +207,14 @@
         <!-- Page Dashboard -->
         <div id="statsPage" class="page-content" style="display: none;">
             <h2 class="mb-4">
-                <i data-lucide="bar-chart-3" class="me-2 text-danger"></i>
+                <i data-lucide="bar-chart-3" class="me-2 text-primary"></i>
                 Tableau de bord statistiques
             </h2>
             
             <!-- Métriques principales -->
             <div class="row mb-4">
                 <div class="col-lg-3 col-md-6 mb-3">
-                    <div class="card text-white bg-danger">
+                    <div class="card text-white bg-primary">
                         <div class="card-body">
                             <div class="d-flex justify-content-between">
                                 <div>
@@ -312,7 +312,7 @@
         <!-- Page Upload (ADMIN seulement) -->
         <div id="uploadPage" class="page-content" style="display: none;">
             <h2 class="mb-4">
-                <i data-lucide="upload" class="me-2 text-danger"></i>
+                <i data-lucide="upload" class="me-2 text-primary"></i>
                 Gestion des données
             </h2>
             
@@ -351,7 +351,7 @@
                                     </select>
                                 </div>
                                 
-                                <button type="submit" class="btn btn-danger">
+                                <button type="submit" class="btn btn-primary">
                                     <i data-lucide="upload" class="me-2"></i>
                                     Commencer l'upload
                                 </button>
@@ -379,10 +379,10 @@
         <div id="usersPage" class="page-content" style="display: none;">
             <div class="d-flex justify-content-between align-items-center mb-4">
                 <h2>
-                    <i data-lucide="users" class="me-2 text-danger"></i>
+                    <i data-lucide="users" class="me-2 text-primary"></i>
                     Gestion des utilisateurs
                 </h2>
-                <button class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#userModal">
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#userModal">
                     <i data-lucide="user-plus" class="me-2"></i>
                     Nouvel utilisateur
                 </button>
@@ -459,7 +459,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                        <button type="submit" class="btn btn-danger">Créer</button>
+                        <button type="submit" class="btn btn-primary">Créer</button>
                     </div>
                 </form>
             </div>
@@ -468,7 +468,7 @@
 
     <!-- Loading overlay -->
     <div id="loadingOverlay" class="loading-overlay" style="display: none;">
-        <div class="spinner-border text-danger" role="status">
+        <div class="spinner-border text-primary" role="status">
             <span class="visually-hidden">Chargement...</span>
         </div>
     </div>

--- a/server/app.cjs
+++ b/server/app.cjs
@@ -75,14 +75,14 @@ app.use((req, res) => {
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-  console.log(`🚀 Serveur Dvine Intelligence démarré sur le port ${PORT}`);
+  console.log(`🚀 Serveur VEGETA démarré sur le port ${PORT}`);
   console.log(`📊 Base de données: MySQL (${process.env.DB_DATABASE})`);
   console.log(`🔒 Mode: ${process.env.NODE_ENV || 'development'}`);
 });
 
 // Gestion propre de l'arrêt
 process.on('SIGINT', () => {
-  console.log('Arrêt du serveur Dvine Intelligence...');
+  console.log('Arrêt du serveur VEGETA...');
   db.close().then(() => {
     console.log('✅ Connexions fermées');
     process.exit(0);

--- a/server/app.js
+++ b/server/app.js
@@ -74,7 +74,7 @@ app.get('/api/health', (req, res) => {
 
 // Servir l'application React pour toutes les autres routes
 app.get('*', (req, res) => {
-  res.json({ message: 'API Dvine Intelligence - Utilisez /api/* pour les endpoints' });
+  res.json({ message: 'API VEGETA - Utilisez /api/* pour les endpoints' });
 });
 
 // Gestionnaire d'erreurs global
@@ -90,7 +90,7 @@ app.use((error, req, res, next) => {
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-  console.log(`🚀 Serveur Dvine Intelligence démarré sur le port ${PORT}`);
+  console.log(`🚀 Serveur VEGETA démarré sur le port ${PORT}`);
   console.log(`📊 Base de données: MySQL`);
   console.log(`🔒 Mode: ${process.env.NODE_ENV || 'development'}`);
   
@@ -102,7 +102,7 @@ app.listen(PORT, () => {
 
 // Gestion propre de l'arrêt
 process.on('SIGINT', () => {
-  console.log('Arrêt du serveur Dvine Intelligence...');
+  console.log('Arrêt du serveur VEGETA...');
   database.close().then(() => {
     console.log('✅ Connexions fermées');
     process.exit(0);

--- a/server/config/database.cjs
+++ b/server/config/database.cjs
@@ -4,8 +4,7 @@ const fs = require('fs');
 
 class DatabaseManager {
   constructor() {
-    this.dbPath = path.join(__dirname, '../../data/dvine-intelligence.db');
-    this.legacyDbPath = path.join(__dirname, '../../data/vegeta.db');
+    this.dbPath = path.join(__dirname, '../../data/vegeta.db');
     this.db = null;
     this.init();
   }
@@ -16,17 +15,6 @@ class DatabaseManager {
       const dataDir = path.dirname(this.dbPath);
       if (!fs.existsSync(dataDir)) {
         fs.mkdirSync(dataDir, { recursive: true });
-      }
-
-      // Migrer automatiquement l'ancienne base de données si nécessaire
-      if (!fs.existsSync(this.dbPath) && fs.existsSync(this.legacyDbPath)) {
-        try {
-          fs.renameSync(this.legacyDbPath, this.dbPath);
-          console.log('➡️  Base de données migrée de vegeta.db vers dvine-intelligence.db');
-        } catch (err) {
-          console.error('❌ Échec de la migration de la base de données existante:', err);
-          throw err;
-        }
       }
 
       // Initialiser la base SQLite

--- a/server/routes/stats.cjs
+++ b/server/routes/stats.cjs
@@ -80,7 +80,7 @@ router.get('/export', authenticate, authorize(['ADMIN', 'ANALYSTE']), async (req
     const format = req.query.format || 'csv';
     const exportData = await statsService.exportStats(format);
 
-    const filename = `dvine-intelligence-stats-${new Date().toISOString().split('T')[0]}.${format}`;
+    const filename = `vegeta-stats-${new Date().toISOString().split('T')[0]}.${format}`;
 
     if (format === 'csv') {
       res.setHeader('Content-Type', 'text/csv');

--- a/server/services/StatsService.cjs
+++ b/server/services/StatsService.cjs
@@ -217,7 +217,7 @@ class StatsService {
   }
 
   generateCSVExport(stats) {
-    let csv = 'Statistiques Dvine Intelligence\n\n';
+    let csv = 'Statistiques VEGETA\n\n';
 
     csv += 'Recherches totales,' + stats.total_searches + '\n';
     csv += '\nTop termes\n';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -733,7 +733,7 @@ const App: React.FC = () => {
       
       const timestamp = new Date().toISOString().slice(0, 19).replace(/:/g, '-');
       const searchTerm = searchQuery.slice(0, 20).replace(/[^a-zA-Z0-9]/g, '_');
-      link.setAttribute('download', `dvine-intelligence-export-${searchTerm}-${timestamp}.csv`);
+      link.setAttribute('download', `vegeta-export-${searchTerm}-${timestamp}.csv`);
       
       document.body.appendChild(link);
       link.click();
@@ -1541,18 +1541,18 @@ const App: React.FC = () => {
         className={`min-h-screen flex items-center justify-center p-4 ${
           theme === 'dark'
             ? 'bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100'
-            : 'bg-gradient-to-br from-red-50 via-white to-red-50'
+            : 'bg-gradient-to-br from-blue-50 via-white to-blue-50'
         }`}
       >
         <div className="max-w-md w-full">
           <div className="bg-white shadow-2xl rounded-2xl overflow-hidden">
-            <div className="bg-gradient-to-r from-red-600 to-red-700 px-8 py-6">
+            <div className="bg-gradient-to-r from-blue-600 to-blue-700 px-8 py-6">
               <div className="text-center">
                 <div className="inline-flex items-center justify-center w-16 h-16 bg-white/20 rounded-full mb-4">
                   <Database className="h-8 w-8 text-white" />
                 </div>
-                <h2 className="text-2xl font-bold text-white">Dvine Intelligence</h2>
-                <p className="text-red-100 mt-1">Plateforme de recherche professionnelle</p>
+                <h2 className="text-2xl font-bold text-white">VEGETA</h2>
+                <p className="text-blue-100 mt-1">Plateforme de recherche professionnelle</p>
               </div>
             </div>
             
@@ -1566,7 +1566,7 @@ const App: React.FC = () => {
                     id="login"
                     type="text"
                     required
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-all"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                     placeholder="Entrez votre nom d'utilisateur"
                     value={loginData.login}
                     onChange={(e) => setLoginData({ ...loginData, login: e.target.value })}
@@ -1580,7 +1580,7 @@ const App: React.FC = () => {
                     id="password"
                     type="password"
                     required
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-all"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                     placeholder="Entrez votre mot de passe"
                     value={loginData.password}
                     onChange={(e) => setLoginData({ ...loginData, password: e.target.value })}
@@ -1596,7 +1596,7 @@ const App: React.FC = () => {
                 <button
                   type="submit"
                   disabled={loading}
-                  className="w-full bg-red-600 text-white py-3 px-4 rounded-lg font-semibold hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 transition-all"
+                  className="w-full bg-blue-600 text-white py-3 px-4 rounded-lg font-semibold hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-all"
                 >
                   {loading ? (
                     <div className="flex items-center justify-center">
@@ -1629,12 +1629,12 @@ const App: React.FC = () => {
         <div className="p-6 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between">
             <div className={`flex items-center ${!sidebarOpen && 'justify-center'}`}>
-              <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-red-600 to-red-700 rounded-lg">
+              <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-600 to-blue-700 rounded-lg">
                 <Database className="h-6 w-6 text-white" />
               </div>
               {sidebarOpen && (
                 <div className="ml-3">
-                  <h1 className="text-xl font-extrabold bg-gradient-to-r from-red-600 to-red-700 bg-clip-text text-transparent">Dvine Intelligence</h1>
+                  <h1 className="text-xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-700 bg-clip-text text-transparent">VEGETA</h1>
                   <p className="text-xs text-gray-500 dark:text-gray-400">Recherche Pro</p>
                 </div>
               )}
@@ -1670,7 +1670,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('dashboard')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'dashboard'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1682,7 +1682,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('search')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'search'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1694,7 +1694,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('annuaire')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'annuaire'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1706,7 +1706,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('ong')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'ong'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1718,7 +1718,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('entreprises')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'entreprises'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1730,7 +1730,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('vehicules')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'vehicules'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1742,7 +1742,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('cdr')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'cdr'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1758,7 +1758,7 @@ const App: React.FC = () => {
               }}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'profiles'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1770,7 +1770,7 @@ const App: React.FC = () => {
               onClick={() => setCurrentPage('links')}
               className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                 currentPage === 'links'
-                  ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                  ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
             >
@@ -1783,7 +1783,7 @@ const App: React.FC = () => {
                 onClick={() => setCurrentPage('users')}
                 className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                   currentPage === 'users'
-                    ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                    ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                     : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
                 } ${!sidebarOpen && 'justify-center'}`}
               >
@@ -1797,7 +1797,7 @@ const App: React.FC = () => {
                 onClick={() => setCurrentPage('upload')}
                 className={`w-full flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                   currentPage === 'upload'
-                    ? 'bg-red-600 text-white shadow-lg dark:bg-red-600 dark:text-white'
+                    ? 'bg-blue-600 text-white shadow-lg dark:bg-blue-600 dark:text-white'
                     : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-100'
               } ${!sidebarOpen && 'justify-center'}`}
               >
@@ -1824,7 +1824,7 @@ const App: React.FC = () => {
                       Admin
                     </span>
                   ) : (
-                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                       <UserCheck className="w-3 h-3 mr-1" />
                       Utilisateur
                     </span>
@@ -1871,14 +1871,14 @@ const App: React.FC = () => {
                     <input
                       type="text"
                       placeholder="Entrez votre recherche (CNI, nom, téléphone, immatriculation...)"
-                      className="w-full pl-12 pr-40 py-4 text-lg bg-gray-50 border border-gray-200 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-red-500 transition-all"
+                      className="w-full pl-12 pr-40 py-4 text-lg bg-gray-50 border border-gray-200 rounded-full shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
                     />
                       <button
                         type="submit"
                         disabled={loading}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 px-6 py-2 bg-red-600 text-white rounded-full hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 transition-all flex items-center"
+                        className="absolute right-3 top-1/2 -translate-y-1/2 px-6 py-2 bg-blue-600 text-white rounded-full hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-all flex items-center"
                       >
                         {loading ? (
                           <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
@@ -1910,7 +1910,7 @@ const App: React.FC = () => {
               {/* Résultats */}
               {searchResults && (
                 <div className="bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg shadow-2xl rounded-3xl border border-gray-200 dark:border-gray-700 overflow-hidden">
-                  <div className="px-8 py-6 border-b border-gray-200 dark:border-gray-700 bg-gradient-to-r from-red-600 to-red-700 text-white">
+                  <div className="px-8 py-6 border-b border-gray-200 dark:border-gray-700 bg-gradient-to-r from-blue-600 to-blue-700 text-white">
                     <div className="flex justify-between items-center">
                       <div>
                         <h2 className="text-xl font-bold">Résultats de recherche</h2>
@@ -1968,12 +1968,12 @@ const App: React.FC = () => {
                           {searchResults.hits.map((result, index) => (
                             <div
                               key={index}
-                              className="group relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 rounded-2xl p-6 hover:shadow-xl hover:border-red-300 dark:hover:border-red-500 transform transition-all duration-300 hover:-translate-y-1"
+                              className="group relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 rounded-2xl p-6 hover:shadow-xl hover:border-blue-300 dark:hover:border-blue-500 transform transition-all duration-300 hover:-translate-y-1"
                             >
                               {/* Header de la carte */}
                               <div className="flex justify-between items-start mb-4">
                                 <div className="flex items-center space-x-3">
-                                  <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-red-500 to-red-700 rounded-xl text-white shadow-md">
+                                  <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-500 to-blue-700 rounded-xl text-white shadow-md">
                                     <Database className="w-5 h-5" />
                                   </div>
                                   <div>
@@ -1982,7 +1982,7 @@ const App: React.FC = () => {
                                   </div>
                                 </div>
                                 <div className="flex items-center space-x-2">
-                                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-red-50 text-red-700">
+                                  <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700">
                                     <Activity className="w-3 h-3 mr-1" />
                                     Score: {result.score.toFixed(1)}
                                   </span>
@@ -1997,7 +1997,7 @@ const App: React.FC = () => {
                                   return (
                                     <div
                                       key={key}
-                                      className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-lg p-3 border border-transparent group-hover:border-red-200 dark:group-hover:border-red-500 transition-colors"
+                                      className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-lg p-3 border border-transparent group-hover:border-blue-200 dark:group-hover:border-blue-500 transition-colors"
                                       >
                                       <div className="flex flex-col">
                                         <span className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-1">
@@ -2035,7 +2035,7 @@ const App: React.FC = () => {
                                     navigator.clipboard.writeText(dataText);
                                     alert('Données copiées dans le presse-papier !');
                                   }}
-                                  className="inline-flex items-center px-3 py-1 text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900 rounded-md hover:bg-red-100 dark:hover:bg-red-800 transition-colors"
+                                  className="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900 rounded-md hover:bg-blue-100 dark:hover:bg-blue-800 transition-colors"
                                 >
                                   <User className="w-3 h-3 mr-1" />
                                   Copier
@@ -2046,7 +2046,7 @@ const App: React.FC = () => {
                         </div>
                         <div className="mt-8 text-center">
                           <button
-                            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+                            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
                             onClick={() => {
                               const combined: Record<string, any> = {};
                               searchResults.hits.forEach(h => {
@@ -2084,7 +2084,7 @@ const App: React.FC = () => {
                         <button
                           onClick={loadMoreResults}
                           disabled={loading}
-                          className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+                          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
                         >
                           Charger plus
                         </button>
@@ -2103,7 +2103,7 @@ const App: React.FC = () => {
                 placeholder="Rechercher..."
                 value={gendarmerieSearch}
                 onChange={(e) => setGendarmerieSearch(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               <div className="overflow-x-auto bg-white shadow rounded-lg dark:bg-gray-800">
                 {gendarmerieLoading ? (
@@ -2113,7 +2113,7 @@ const App: React.FC = () => {
                 ) : (
                   <>
                     <table className="min-w-full divide-y divide-gray-200">
-                      <thead className="bg-red-600">
+                      <thead className="bg-blue-600">
                         <tr>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">ID</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Libellé</th>
@@ -2164,7 +2164,7 @@ const App: React.FC = () => {
                               onClick={() => setGendarmeriePage(page)}
                               className={`px-3 py-1 rounded-md border text-sm font-medium ${
                                 gendarmeriePage === page
-                                  ? 'bg-red-600 text-white'
+                                  ? 'bg-blue-600 text-white'
                                   : 'bg-white text-gray-700 hover:bg-gray-50'
                               }`}
                             >
@@ -2202,7 +2202,7 @@ const App: React.FC = () => {
                   setOngSearch(e.target.value);
                   setOngPage(1);
                 }}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               <div className="overflow-x-auto bg-white shadow rounded-lg">
                 {ongLoading ? (
@@ -2212,7 +2212,7 @@ const App: React.FC = () => {
                 ) : (
                   <>
                     <table className="min-w-full divide-y divide-gray-200">
-                      <thead className="bg-red-600">
+                      <thead className="bg-blue-600">
                         <tr>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">ID</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">OrganizationName</th>
@@ -2262,7 +2262,7 @@ const App: React.FC = () => {
                               onClick={() => setOngPage(page)}
                               className={`px-3 py-1 rounded-md border text-sm font-medium ${
                                 ongPage === page
-                                  ? 'bg-red-600 text-white'
+                                  ? 'bg-blue-600 text-white'
                                   : 'bg-white text-gray-700 hover:bg-gray-50'
                               }`}
                             >
@@ -2300,7 +2300,7 @@ const App: React.FC = () => {
                   setEntreprisesSearch(e.target.value);
                   setEntreprisesPage(1);
                 }}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               <div className="overflow-x-auto bg-white shadow rounded-lg">
                 {entreprisesLoading ? (
@@ -2310,7 +2310,7 @@ const App: React.FC = () => {
                 ) : (
                   <>
                     <table className="min-w-full divide-y divide-gray-200">
-                      <thead className="bg-red-600">
+                      <thead className="bg-blue-600">
                         <tr>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">ninea_ninet</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">cuci</th>
@@ -2410,7 +2410,7 @@ const App: React.FC = () => {
                               onClick={() => setEntreprisesPage(page)}
                               className={`px-3 py-1 rounded-md border text-sm font-medium ${
                                 entreprisesPage === page
-                                  ? 'bg-red-600 text-white'
+                                  ? 'bg-blue-600 text-white'
                                   : 'bg-white text-gray-700 hover:bg-gray-50'
                               }`}
                             >
@@ -2448,7 +2448,7 @@ const App: React.FC = () => {
                   setVehiculesSearch(e.target.value);
                   setVehiculesPage(1);
                 }}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               <div className="overflow-x-auto bg-white shadow rounded-lg">
                 {vehiculesLoading ? (
@@ -2458,7 +2458,7 @@ const App: React.FC = () => {
                 ) : (
                   <>
                     <table className="min-w-full divide-y divide-gray-200">
-                      <thead className="bg-red-600">
+                      <thead className="bg-blue-600">
                         <tr>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">ID</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-white uppercase tracking-wider">Numero_Immatriculation</th>
@@ -2558,7 +2558,7 @@ const App: React.FC = () => {
                               onClick={() => setVehiculesPage(page)}
                               className={`px-3 py-1 rounded-md border text-sm font-medium ${
                                 vehiculesPage === page
-                                  ? 'bg-red-600 text-white'
+                                  ? 'bg-blue-600 text-white'
                                   : 'bg-white text-gray-700 hover:bg-gray-50'
                               }`}
                             >
@@ -2595,11 +2595,11 @@ const App: React.FC = () => {
                   placeholder="Nom du CASE"
                   value={cdrCaseName}
                   onChange={(e) => setCdrCaseName(e.target.value)}
-                  className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                  className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
                 <button
                   type="submit"
-                  className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 active:scale-95 transition-transform"
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 active:scale-95 transition-transform"
                 >
                   Créer
                 </button>
@@ -2621,7 +2621,7 @@ const App: React.FC = () => {
                         <h4 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">{c.name}</h4>
                         <div className="mt-auto flex space-x-2">
                           <button
-                            className="flex-1 px-3 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                            className="flex-1 px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
                             onClick={() => {
                               setSelectedCase(c);
                               setCdrResult(null);
@@ -2677,7 +2677,7 @@ const App: React.FC = () => {
                   setCurrentPage('cdr');
                   setSelectedCase(null);
                 }}
-                className="text-red-600"
+                className="text-blue-600"
               >
                 &larr; Retour
               </button>
@@ -2697,12 +2697,12 @@ const App: React.FC = () => {
                       type="file"
                       accept=".csv"
                       onChange={(e) => setCdrFile(e.target.files?.[0] || null)}
-                      className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-red-50 file:text-red-700 hover:file:bg-red-100"
+                      className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
                     />
                       <button
                         type="submit"
                         disabled={cdrUploading || !cdrFile || !cdrNumber}
-                        className="flex items-center justify-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md disabled:opacity-50"
+                        className="flex items-center justify-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md disabled:opacity-50"
                       >
                         {cdrUploading ? (
                           <Loader2 className="h-5 w-5 animate-spin" />
@@ -2757,20 +2757,20 @@ const App: React.FC = () => {
                       placeholder="Numéro(s) ou IMEI (séparés par des virgules)"
                       value={cdrIdentifier}
                       onChange={(e) => setCdrIdentifier(e.target.value)}
-                      className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                     />
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                       <input
                         type="date"
                         value={cdrStart}
                         onChange={(e) => setCdrStart(e.target.value)}
-                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                       />
                       <input
                         type="date"
                         value={cdrEnd}
                         onChange={(e) => setCdrEnd(e.target.value)}
-                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                       />
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -2778,20 +2778,20 @@ const App: React.FC = () => {
                         type="time"
                         value={cdrStartTime}
                         onChange={(e) => setCdrStartTime(e.target.value)}
-                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                       />
                       <input
                         type="time"
                         value={cdrEndTime}
                         onChange={(e) => setCdrEndTime(e.target.value)}
-                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                       />
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                       <select
                         value={cdrDirection}
                         onChange={(e) => setCdrDirection(e.target.value)}
-                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                       >
                         <option value="both">Appels entrants et sortants</option>
                         <option value="incoming">Uniquement entrants</option>
@@ -2800,7 +2800,7 @@ const App: React.FC = () => {
                       <select
                         value={cdrType}
                         onChange={(e) => setCdrType(e.target.value)}
-                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                       >
                         <option value="both">Appels et SMS</option>
                         <option value="call">Seulement appels</option>
@@ -2811,14 +2811,14 @@ const App: React.FC = () => {
                       <button
                         type="submit"
                         disabled={cdrLoading}
-                        className="px-6 py-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-full hover:from-red-700 hover:to-red-800 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 transition-transform transform hover:scale-105 active:scale-95"
+                        className="px-6 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-full hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-transform transform hover:scale-105 active:scale-95"
                       >
                         Rechercher
                       </button>
                         {caseFiles.filter(f => f.cdr_number).length >= 2 && (
                           <button
                             type="button"
-                            className="px-6 py-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-full hover:from-red-700 hover:to-red-800 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-transform transform hover:scale-105 active:scale-95"
+                            className="px-6 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-full hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-transform transform hover:scale-105 active:scale-95"
                             onClick={handleLinkDiagram}
                           >
                             Diagramme des liens
@@ -2896,10 +2896,10 @@ const App: React.FC = () => {
                     className="group p-6 bg-white rounded-xl shadow hover:shadow-lg transition-shadow border border-gray-100"
                   >
                     <div className="flex items-center justify-between">
-                      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-red-600">
+                      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600">
                         {link.title}
                       </h2>
-                      <ExternalLink className="h-5 w-5 text-gray-400 group-hover:text-red-600" />
+                      <ExternalLink className="h-5 w-5 text-gray-400 group-hover:text-blue-600" />
                     </div>
                     <p className="mt-2 text-sm text-gray-500 break-all">{link.url}</p>
                   </a>
@@ -2915,7 +2915,7 @@ const App: React.FC = () => {
                 <PageHeader icon={<User className="h-6 w-6" />} title="Gestion des utilisateurs" subtitle="Créez et gérez les comptes utilisateurs" />
                 <button
                   onClick={openCreateModal}
-                  className="flex items-center px-6 py-3 bg-red-600 text-white rounded-xl hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-all shadow-lg"
+                  className="flex items-center px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all shadow-lg"
                 >
                   <Plus className="w-5 h-5 mr-2" />
                   Nouvel utilisateur
@@ -2933,7 +2933,7 @@ const App: React.FC = () => {
                     </p>
                     <button
                       onClick={openCreateModal}
-                      className="inline-flex items-center px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                      className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
                     >
                       <Plus className="w-4 h-4 mr-2" />
                       Créer le premier utilisateur
@@ -2963,7 +2963,7 @@ const App: React.FC = () => {
                           <tr key={user.id} className="hover:bg-gray-50 transition-colors">
                             <td className="px-6 py-4 whitespace-nowrap">
                               <div className="flex items-center">
-                                <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-red-500 to-red-700 rounded-full">
+                                <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-500 to-blue-700 rounded-full">
                                   <User className="h-5 w-5 text-white" />
                                 </div>
                                 <div className="ml-4">
@@ -2979,7 +2979,7 @@ const App: React.FC = () => {
                                   Administrateur
                                 </span>
                               ) : (
-                                <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                                <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                                   <UserCheck className="w-3 h-3 mr-1" />
                                   Utilisateur
                                 </span>
@@ -2996,7 +2996,7 @@ const App: React.FC = () => {
                               <div className="flex space-x-3">
                                 <button
                                   onClick={() => openEditModal(user)}
-                                  className="text-red-600 hover:text-red-900 transition-colors"
+                                  className="text-blue-600 hover:text-blue-900 transition-colors"
                                   title="Modifier l'utilisateur"
                                 >
                                   <Edit className="w-4 h-4" />
@@ -3032,21 +3032,21 @@ const App: React.FC = () => {
           {currentPage === 'dashboard' && (
             <div className="space-y-8">
               {/* Header */}
-              <PageHeader icon={<BarChart3 className="h-6 w-6" />} title="Dashboard" subtitle="Analyse complète de l'utilisation de la plateforme Dvine Intelligence" />
+              <PageHeader icon={<BarChart3 className="h-6 w-6" />} title="Dashboard" subtitle="Analyse complète de l'utilisation de la plateforme VEGETA" />
 
               {loadingStats ? (
                 <div className="flex items-center justify-center py-16">
-                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-red-600"></div>
+                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
                   <span className="ml-4 text-lg text-gray-600">Chargement des statistiques...</span>
                 </div>
               ) : (
                 <>
                   {/* Métriques principales */}
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
-                    <div className="bg-gradient-to-br from-red-500 to-red-600 rounded-2xl p-6 text-white shadow-xl">
+                    <div className="bg-gradient-to-br from-blue-500 to-blue-600 rounded-2xl p-6 text-white shadow-xl">
                       <div className="flex items-center justify-between">
                         <div>
-                          <p className="text-red-100 text-sm font-medium">Recherches totales</p>
+                          <p className="text-blue-100 text-sm font-medium">Recherches totales</p>
                           <p className="text-3xl font-bold">{statsData?.total_searches || 0}</p>
                         </div>
                         <div className="bg-white/20 rounded-full p-3">
@@ -3109,7 +3109,7 @@ const App: React.FC = () => {
                     {/* Graphique des recherches par jour */}
                     <div className="bg-white rounded-2xl shadow-xl p-6">
                       <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4 flex items-center">
-                        <BarChart3 className="h-6 w-6 mr-2 text-red-600" />
+                        <BarChart3 className="h-6 w-6 mr-2 text-blue-600" />
                         Recherches des 7 derniers jours
                       </h3>
                       <div className="h-80">
@@ -3255,7 +3255,7 @@ const App: React.FC = () => {
                     <div className="lg:col-span-2">
                       <div className="bg-white rounded-2xl shadow-xl p-6">
                         <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4 flex items-center">
-                          <FileText className="h-6 w-6 mr-2 text-red-600" />
+                          <FileText className="h-6 w-6 mr-2 text-blue-600" />
                           Logs de recherche
                         </h3>
                         {isAdmin && (
@@ -3265,11 +3265,11 @@ const App: React.FC = () => {
                               value={logUserFilter}
                               onChange={(e) => setLogUserFilter(e.target.value)}
                               placeholder="Filtrer par utilisateur"
-                              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                             />
                             <button
                               onClick={loadStatistics}
-                              className="ml-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+                              className="ml-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
                             >
                               Rechercher
                             </button>
@@ -3281,8 +3281,8 @@ const App: React.FC = () => {
                               <div key={index} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
                                 <div className="flex-1">
                                   <div className="flex items-center space-x-3">
-                                    <div className="flex items-center justify-center w-8 h-8 bg-red-100 rounded-full">
-                                      <User className="h-4 w-4 text-red-600" />
+                                    <div className="flex items-center justify-center w-8 h-8 bg-blue-100 rounded-full">
+                                      <User className="h-4 w-4 text-blue-600" />
                                     </div>
                                     <div>
                                       <p className="font-medium text-gray-900 dark:text-gray-100">{log.username || 'Utilisateur inconnu'}</p>
@@ -3295,7 +3295,7 @@ const App: React.FC = () => {
                                     <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
                                       {log.results_count || 0} résultats
                                     </span>
-                                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                                       {log.execution_time_ms || 0}ms
                                     </span>
                                   </div>
@@ -3324,14 +3324,14 @@ const App: React.FC = () => {
                     </h3>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                       {statsData?.top_search_terms?.slice(0, 9).map((term, index) => (
-                        <div key={index} className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl hover:from-red-50 hover:to-red-100 transition-all dark:from-gray-800 dark:to-gray-700 dark:hover:from-red-900 dark:hover:to-red-800">
+                        <div key={index} className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl hover:from-blue-50 hover:to-blue-100 transition-all dark:from-gray-800 dark:to-gray-700 dark:hover:from-blue-900 dark:hover:to-blue-800">
                           <div className="flex items-center space-x-3">
-                            <div className="flex items-center justify-center w-8 h-8 bg-red-100 rounded-full text-red-600 font-bold text-sm dark:bg-red-900 dark:text-red-200">
+                            <div className="flex items-center justify-center w-8 h-8 bg-blue-100 rounded-full text-blue-600 font-bold text-sm dark:bg-blue-900 dark:text-blue-200">
                               {index + 1}
                             </div>
                             <span className="font-medium text-gray-900 truncate max-w-xs dark:text-gray-100">"{term.search_term}"</span>
                           </div>
-                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
+                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
                             {term.search_count} fois
                           </span>
                         </div>
@@ -3353,7 +3353,7 @@ const App: React.FC = () => {
               <div className="w-full max-w-2xl">
                 <div className="bg-white rounded-2xl shadow-xl p-8">
                   <div className="text-center mb-8">
-                    <UploadCloud className="h-12 w-12 mx-auto text-red-600" />
+                    <UploadCloud className="h-12 w-12 mx-auto text-blue-600" />
                     <PageHeader icon={<UploadCloud className="h-6 w-6" />} title="Charger des données" />
                     <p className="mt-2 text-gray-600">Importez un fichier CSV dans la table de votre choix.</p>
                   </div>
@@ -3363,7 +3363,7 @@ const App: React.FC = () => {
                       <input
                         type="text"
                         required
-                        className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500"
+                        className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                         value={uploadTable}
                         onChange={(e) => setUploadTable(e.target.value)}
                       />
@@ -3375,13 +3375,13 @@ const App: React.FC = () => {
                         accept=".csv"
                         required
                         onChange={(e) => setUploadFile(e.target.files?.[0] || null)}
-                        className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-red-50 file:text-red-700 hover:file:bg-red-100"
+                        className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
                       />
                     </div>
                     <button
                       type="submit"
                       disabled={loading}
-                      className="w-full px-4 py-3 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg disabled:opacity-50 transition-colors"
+                      className="w-full px-4 py-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 transition-colors"
                     >
                       {loading ? (
                         <Loader2 className="mx-auto h-5 w-5 animate-spin" />
@@ -3445,7 +3445,7 @@ const App: React.FC = () => {
                 <input
                   type="text"
                   required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   value={userFormData.login}
                   onChange={(e) => setUserFormData({ ...userFormData, login: e.target.value })}
                 />
@@ -3458,7 +3458,7 @@ const App: React.FC = () => {
                     type="password"
                     required
                     minLength={6}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     value={userFormData.password}
                     onChange={(e) => setUserFormData({ ...userFormData, password: e.target.value })}
                   />
@@ -3469,7 +3469,7 @@ const App: React.FC = () => {
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Rôle</label>
                 <select
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   value={userFormData.admin}
                   onChange={(e) => setUserFormData({ ...userFormData, admin: parseInt(e.target.value) })}
                 >
@@ -3493,7 +3493,7 @@ const App: React.FC = () => {
                 <button
                   type="submit"
                   disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg disabled:opacity-50 transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 transition-colors"
                 >
                   {loading ? 'Enregistrement...' : (editingUser ? 'Modifier' : 'Créer')}
                 </button>
@@ -3521,7 +3521,7 @@ const App: React.FC = () => {
                     <input
                       type={showPasswords.current ? 'text' : 'password'}
                       required
-                      className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                      className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       value={passwordFormData.currentPassword}
                       onChange={(e) => setPasswordFormData({ ...passwordFormData, currentPassword: e.target.value })}
                     />
@@ -3543,7 +3543,7 @@ const App: React.FC = () => {
                     type={showPasswords.new ? 'text' : 'password'}
                     required
                     minLength={6}
-                    className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                    className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     value={passwordFormData.newPassword}
                     onChange={(e) => setPasswordFormData({ ...passwordFormData, newPassword: e.target.value })}
                   />
@@ -3565,7 +3565,7 @@ const App: React.FC = () => {
                     type={showPasswords.confirm ? 'text' : 'password'}
                     required
                     minLength={6}
-                    className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                    className="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     value={passwordFormData.confirmPassword}
                     onChange={(e) => setPasswordFormData({ ...passwordFormData, confirmPassword: e.target.value })}
                   />
@@ -3595,7 +3595,7 @@ const App: React.FC = () => {
                 <button
                   type="submit"
                   disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg disabled:opacity-50 transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 transition-colors"
                 >
                   {loading ? 'Modification...' : 'Changer le mot de passe'}
                 </button>

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -47,7 +47,7 @@ const getIcon = (type: string, direction: string) => {
   } else {
     icon =
       direction === 'outgoing' ? (
-        <PhoneOutgoing size={size} className="text-red-600" />
+        <PhoneOutgoing size={size} className="text-blue-600" />
       ) : (
         <PhoneIncoming size={size} className="text-green-600" />
       );
@@ -117,12 +117,12 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber }) => {
           >
             <Popup>
               <div className="space-y-2 text-sm">
-                <p className="font-semibold text-red-600">{loc.nom || 'Localisation'}</p>
+                <p className="font-semibold text-blue-600">{loc.nom || 'Localisation'}</p>
                 {loc.number && (
                   <div className="flex items-center justify-between">
                     <span className="text-black">Numéro: {loc.number}</span>
                     <button
-                      className="ml-2 px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700"
+                      className="ml-2 px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
                       onClick={() => {
                         const cleaned = loc.number.replace(/^221/, '');
                         navigator.clipboard.writeText(cleaned);
@@ -165,7 +165,7 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber }) => {
                 {topContacts.map((c, i) => (
                   <tr
                     key={c.number}
-                    className={`${i === 0 ? 'font-bold text-red-600' : ''} border-t`}
+                    className={`${i === 0 ? 'font-bold text-blue-600' : ''} border-t`}
                   >
                     <td className="pr-4">{c.number}</td>
                     <td className="pr-4">{c.callCount}</td>

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -20,7 +20,7 @@ interface LinkDiagramProps {
 }
 
 const typePalette = [
-  '#ef4444',
+  '#3b82f6',
   '#10b981',
   '#f59e0b',
   '#ef4444',
@@ -52,7 +52,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-11/12 h-5/6 relative flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between p-4 bg-red-500 text-white">
+        <div className="flex items-center justify-between p-4 bg-blue-500 text-white">
           <h2 className="text-lg font-semibold">Diagramme des liens</h2>
           <button
             className="text-black hover:text-gray-800 dark:text-white dark:hover:text-gray-200"

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -3,8 +3,8 @@ import { Bot, Loader2 } from 'lucide-react';
 
 const LoadingSpinner: React.FC = () => (
   <div className="flex flex-col justify-center items-center py-10">
-    <Loader2 className="w-12 h-12 animate-spin text-red-600" />
-    <div className="flex items-center mt-4 text-red-600">
+    <Loader2 className="w-12 h-12 animate-spin text-blue-600" />
+    <div className="flex items-center mt-4 text-blue-600">
       <Bot className="w-5 h-5 mr-2" />
       <span className="text-lg font-medium">Recherche parmi des millions de données...</span>
     </div>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -10,10 +10,10 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, title, subtitle }) => {
   return (
     <div>
       <div className="flex items-center space-x-3">
-        <div className="p-3 rounded-xl bg-gradient-to-br from-red-500 to-red-700 text-white shadow-md">
+        <div className="p-3 rounded-xl bg-gradient-to-br from-blue-500 to-blue-700 text-white shadow-md">
           {icon}
         </div>
-        <h1 className="text-3xl font-extrabold bg-gradient-to-r from-red-600 to-red-700 bg-clip-text text-transparent">
+        <h1 className="text-3xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-700 bg-clip-text text-transparent">
           {title}
         </h1>
       </div>

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -166,7 +166,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
           >
             <div className="flex items-center space-x-3">
               <input
-                className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 placeholder="Titre de la catégorie"
                 value={cat.title}
                 onChange={e => updateCategoryTitle(cIdx, e.target.value)}
@@ -189,13 +189,13 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
                 onDrop={() => handleDrop(cIdx, fIdx)}
               >
                 <input
-                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   placeholder="Nom du champ"
                   value={field.key}
                   onChange={e => updateField(cIdx, fIdx, 'key', e.target.value)}
                 />
                 <input
-                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                  className="flex-1 rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   placeholder="Valeur"
                   value={field.value}
                   onChange={e => updateField(cIdx, fIdx, 'value', e.target.value)}
@@ -211,7 +211,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
             ))}
             <button
               type="button"
-              className="px-4 py-2 bg-red-100 text-red-700 rounded-lg hover:bg-red-200"
+              className="px-4 py-2 bg-blue-100 text-blue-700 rounded-lg hover:bg-blue-200"
               onClick={() => addField(cIdx)}
             >
               Ajouter un champ
@@ -220,7 +220,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
         ))}
         <button
           type="button"
-          className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
           onClick={addCategory}
         >
           Ajouter une catégorie
@@ -229,7 +229,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
       <div>
         <label className="block mb-2 font-medium text-gray-700">Commentaire</label>
         <textarea
-          className="w-full rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
+          className="w-full rounded-lg border-2 border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           value={comment}
           onChange={e => setComment(e.target.value)}
         />
@@ -238,7 +238,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
         <input
           type="file"
           onChange={handlePhoto}
-          className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-red-50 file:text-red-700 hover:file:bg-red-100"
+          className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
         />
         {preview && (
           <img
@@ -250,7 +250,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
       </div>
       <button
         type="submit"
-        className="px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+        className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
       >
         Enregistrer
       </button>

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -95,13 +95,13 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row gap-2 bg-white/80 backdrop-blur-sm p-4 rounded-2xl shadow-lg">
         <input
-          className="border border-gray-300 p-2 rounded-lg flex-1 focus:outline-none focus:ring-2 focus:ring-red-500"
+          className="border border-gray-300 p-2 rounded-lg flex-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
           placeholder="Recherche"
           value={query}
           onChange={e => setQuery(e.target.value)}
         />
         <button
-          className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
           onClick={() => {
             setPage(1);
             load();
@@ -111,7 +111,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
         </button>
         {onCreate && (
           <button
-            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
             onClick={onCreate}
           >
             Créer profil
@@ -153,14 +153,14 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               return (
                 <div
                   key={p.id}
-                  className="bg-white/80 backdrop-blur-sm shadow-md rounded-2xl p-6 flex flex-col border border-red-100 hover:border-red-300 hover:shadow-xl transition-shadow"
+                  className="bg-white/80 backdrop-blur-sm shadow-md rounded-2xl p-6 flex flex-col border border-blue-100 hover:border-blue-300 hover:shadow-xl transition-shadow"
                 >
                   <div className="flex items-center space-x-4">
                     {p.photo_path ? (
                       <img
                         src={`/${p.photo_path}`}
                         alt="profil"
-                        className="w-16 h-16 rounded-full object-cover ring-2 ring-red-500"
+                        className="w-16 h-16 rounded-full object-cover ring-2 ring-blue-500"
                       />
                     ) : (
                       <div className="w-16 h-16 rounded-full bg-gray-200" />
@@ -176,14 +176,14 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
                   </div>
                   <div className="mt-4 flex justify-end space-x-4 text-sm">
                     <button
-                      className="text-red-600 hover:underline"
+                      className="text-blue-600 hover:underline"
                       onClick={() => setSelected(p)}
                     >
                       Aperçu
                     </button>
                     {onEdit && (
                       <button
-                        className="text-red-600 hover:underline"
+                        className="text-blue-600 hover:underline"
                         onClick={() => onEdit(p.id)}
                       >
                         Modifier
@@ -196,7 +196,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
                       Supprimer
                     </button>
                     <button
-                      className="text-red-600 hover:underline"
+                      className="text-blue-600 hover:underline"
                       onClick={() => exportProfile(p.id)}
                     >
                       Exporter Profil
@@ -208,7 +208,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
           </div>
           <div className="flex justify-center items-center space-x-2 mt-4">
             <button
-              className="px-3 py-1 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              className="px-3 py-1 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
               onClick={() => setPage(p => Math.max(1, p - 1))}
               disabled={page === 1}
             >
@@ -218,7 +218,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               Page {page} / {Math.max(1, Math.ceil(total / limit))}
             </span>
             <button
-              className="px-3 py-1 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              className="px-3 py-1 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
               onClick={() => setPage(p => p + 1)}
               disabled={page >= Math.ceil(total / limit)}
             >
@@ -240,7 +240,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
               <img
                 src={`/${selected.photo_path}`}
                 alt="profil"
-                className="mx-auto w-32 h-32 rounded-full object-cover mb-4 ring-2 ring-red-500"
+                className="mx-auto w-32 h-32 rounded-full object-cover mb-4 ring-2 ring-blue-500"
               />
             )}
             <h2 className="text-2xl font-semibold text-center mb-4">Détails du profil</h2>

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -29,11 +29,11 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
     <div className="space-y-8">
       {hits.map((hit, idx) => (
         <div key={idx} className="bg-white shadow-lg rounded-2xl overflow-hidden">
-          <div className="bg-gradient-to-r from-red-500 to-red-700 p-4 flex items-center">
+          <div className="bg-gradient-to-r from-blue-500 to-blue-700 p-4 flex items-center">
             <User className="w-8 h-8 text-white mr-3" />
             <div>
               <h3 className="text-xl font-semibold text-white">{hit.table}</h3>
-              <p className="text-red-100 text-sm">{hit.database}</p>
+              <p className="text-blue-100 text-sm">{hit.database}</p>
             </div>
             <span className="ml-auto inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white/20 text-white">
               <Activity className="w-3 h-3 mr-1" />
@@ -59,7 +59,7 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
       ))}
       <div className="text-center">
         <button
-          className="mt-4 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700"
+          className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
           onClick={() => {
             const combined: Record<string, any> = {};
             hits.forEach(h => {

--- a/src/index.css
+++ b/src/index.css
@@ -27,10 +27,10 @@
   .dark input,
   .dark textarea,
   .dark select {
-    @apply bg-gray-800 text-gray-100 border-2 border-gray-700 rounded-lg placeholder-gray-400 focus:ring-2 focus:ring-red-500;
+    @apply bg-gray-800 text-gray-100 border-2 border-gray-700 rounded-lg placeholder-gray-400 focus:ring-2 focus:ring-blue-500;
   }
   .dark .btn-primary {
-    @apply bg-red-600 text-white;
+    @apply bg-blue-600 text-white;
   }
 }
 
@@ -79,7 +79,7 @@
   left: 0;
   height: 100%;
   width: 100%;
-  background-color: #ef4444;
+  background-color: #3b82f6;
   animation: loading-bar 1.5s linear infinite;
 }
 
@@ -102,12 +102,12 @@
   width: 12px;
   height: 12px;
   border-radius: 9999px;
-  background-color: #ef4444;
+  background-color: #4f46e5;
   animation: thinking-bounce 1.4s infinite both;
 }
 
 .dark .thinking-dot {
-  background-color: #fca5a5;
+  background-color: #818cf8;
 }
 
 .thinking-dot:nth-child(2) {


### PR DESCRIPTION
## Summary
- revert app name and references back to **VEGETA**
- switch UI styling from red back to original blue palette
- update server logs and stats export filenames to use VEGETA branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68be03085a648326b754ef7b2e706432