### PR TITLE
feat: add identification request workflow

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -18,6 +18,7 @@ import ongRoutes from './routes/ong.js';
 import vehiculesRoutes from './routes/vehicules.js';
 import profilesRoutes from './routes/profiles.js';
 import casesRoutes from './routes/cases.js';
+import requestsRoutes from './routes/requests.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -61,6 +62,7 @@ app.use('/api/ong', ongRoutes);
 app.use('/api/vehicules', vehiculesRoutes);
 app.use('/api/profiles', profilesRoutes);
 app.use('/api/cases', casesRoutes);
+app.use('/api/requests', requestsRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -139,6 +139,19 @@ class DatabaseManager {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
       `);
 
+      await this.query(`
+        CREATE TABLE IF NOT EXISTS autres.identification_requests (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          user_id INT NOT NULL,
+          phone VARCHAR(50) NOT NULL,
+          status ENUM('pending','identified') DEFAULT 'pending',
+          profile_id INT DEFAULT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          INDEX idx_user_id (user_id),
+          FOREIGN KEY (user_id) REFERENCES autres.users(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
       // Table des dossiers CDR
       await this.query(`
         CREATE TABLE IF NOT EXISTS autres.cdr_cases (

--- a/server/models/IdentificationRequest.js
+++ b/server/models/IdentificationRequest.js
@@ -1,0 +1,40 @@
+import database from '../config/database.js';
+
+class IdentificationRequest {
+  static async create(data) {
+    const { user_id, phone } = data;
+    const result = await database.query(
+      `INSERT INTO autres.identification_requests (user_id, phone, status) VALUES (?, ?, 'pending')`,
+      [user_id, phone]
+    );
+    return { id: result.insertId, user_id, phone, status: 'pending' };
+  }
+
+  static async findAll() {
+    return database.query(
+      `SELECT r.*, u.login as user_login FROM autres.identification_requests r
+       LEFT JOIN autres.users u ON r.user_id = u.id
+       ORDER BY r.created_at DESC`
+    );
+  }
+
+  static async findByUser(user_id) {
+    return database.query(
+      `SELECT * FROM autres.identification_requests WHERE user_id = ? ORDER BY created_at DESC`,
+      [user_id]
+    );
+  }
+
+  static async updateStatus(id, status, profile_id = null) {
+    await database.query(
+      `UPDATE autres.identification_requests SET status = ?, profile_id = ? WHERE id = ?`,
+      [status, profile_id, id]
+    );
+    return database.queryOne(
+      `SELECT * FROM autres.identification_requests WHERE id = ?`,
+      [id]
+    );
+  }
+}
+
+export default IdentificationRequest;

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -1,0 +1,56 @@
+import express from 'express';
+import { authenticate, requireAdmin } from '../middleware/auth.js';
+import IdentificationRequest from '../models/IdentificationRequest.js';
+
+const router = express.Router();
+
+// Créer une nouvelle demande d'identification
+router.post('/', authenticate, async (req, res) => {
+  const { phone } = req.body;
+  if (!phone) {
+    return res.status(400).json({ error: 'Numéro requis' });
+  }
+  try {
+    const request = await IdentificationRequest.create({
+      user_id: req.user.id,
+      phone
+    });
+    res.json(request);
+  } catch (error) {
+    console.error('Erreur création demande:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// Liste des demandes
+router.get('/', authenticate, async (req, res) => {
+  try {
+    let requests;
+    if (req.user.admin === 1 || req.user.admin === '1') {
+      requests = await IdentificationRequest.findAll();
+    } else {
+      requests = await IdentificationRequest.findByUser(req.user.id);
+    }
+    res.json(requests);
+  } catch (error) {
+    console.error('Erreur récupération demandes:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// Mise à jour du statut d'une demande (admin)
+router.patch('/:id', authenticate, requireAdmin, async (req, res) => {
+  const { status, profile_id } = req.body;
+  if (!status) {
+    return res.status(400).json({ error: 'Statut requis' });
+  }
+  try {
+    const updated = await IdentificationRequest.updateStatus(req.params.id, status, profile_id);
+    res.json(updated);
+  } catch (error) {
+    console.error('Erreur mise à jour demande:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add API and database table for identification requests
- show request button when search by 77/78 number yields no result
- list identification requests for users and admins

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68be8b23d8448326a87d387849be4947