### PR TITLE
feat: manage identification requests

### DIFF
--- a/server/models/IdentificationRequest.js
+++ b/server/models/IdentificationRequest.js
@@ -11,17 +11,92 @@ class IdentificationRequest {
   }
 
   static async findAll() {
-    return database.query(
-      `SELECT r.*, u.login as user_login FROM autres.identification_requests r
-       LEFT JOIN autres.users u ON r.user_id = u.id
-       ORDER BY r.created_at DESC`
+    const rows = await database.query(
+      `SELECT r.*, u.login as user_login,
+              p.first_name as profile_first_name,
+              p.last_name as profile_last_name,
+              p.phone as profile_phone,
+              p.email as profile_email,
+              p.comment as profile_comment,
+              p.extra_fields as profile_extra_fields,
+              p.photo_path as profile_photo_path
+         FROM autres.identification_requests r
+         LEFT JOIN autres.users u ON r.user_id = u.id
+         LEFT JOIN autres.profiles p ON r.profile_id = p.id
+         ORDER BY r.created_at DESC`
     );
+    return rows.map(row => ({
+      id: row.id,
+      user_id: row.user_id,
+      phone: row.phone,
+      status: row.status,
+      profile_id: row.profile_id,
+      created_at: row.created_at,
+      user_login: row.user_login,
+      profile: row.profile_id ? {
+        id: row.profile_id,
+        first_name: row.profile_first_name,
+        last_name: row.profile_last_name,
+        phone: row.profile_phone,
+        email: row.profile_email,
+        comment: row.profile_comment,
+        extra_fields: row.profile_extra_fields
+          ? JSON.parse(row.profile_extra_fields)
+          : [],
+        photo_path: row.profile_photo_path
+      } : null
+    }));
   }
 
   static async findByUser(user_id) {
-    return database.query(
-      `SELECT * FROM autres.identification_requests WHERE user_id = ? ORDER BY created_at DESC`,
+    const rows = await database.query(
+      `SELECT r.*,
+              p.first_name as profile_first_name,
+              p.last_name as profile_last_name,
+              p.phone as profile_phone,
+              p.email as profile_email,
+              p.comment as profile_comment,
+              p.extra_fields as profile_extra_fields,
+              p.photo_path as profile_photo_path
+         FROM autres.identification_requests r
+         LEFT JOIN autres.profiles p ON r.profile_id = p.id
+         WHERE r.user_id = ?
+         ORDER BY r.created_at DESC`,
       [user_id]
+    );
+    return rows.map(row => ({
+      id: row.id,
+      user_id: row.user_id,
+      phone: row.phone,
+      status: row.status,
+      profile_id: row.profile_id,
+      created_at: row.created_at,
+      profile: row.profile_id ? {
+        id: row.profile_id,
+        first_name: row.profile_first_name,
+        last_name: row.profile_last_name,
+        phone: row.profile_phone,
+        email: row.profile_email,
+        comment: row.profile_comment,
+        extra_fields: row.profile_extra_fields
+          ? JSON.parse(row.profile_extra_fields)
+          : [],
+        photo_path: row.profile_photo_path
+      } : null
+    }));
+  }
+
+  static async findById(id) {
+    return database.queryOne(
+      `SELECT * FROM autres.identification_requests WHERE id = ?`,
+      [id]
+    );
+  }
+
+  static async delete(id) {
+    await database.query(
+      `DELETE FROM autres.identification_requests WHERE id = ?`,
+      [id]
     );
   }
 

--- a/server/routes/requests.js
+++ b/server/routes/requests.js
@@ -53,4 +53,23 @@ router.patch('/:id', authenticate, requireAdmin, async (req, res) => {
   }
 });
 
+// Supprimer une demande
+router.delete('/:id', authenticate, async (req, res) => {
+  try {
+    const request = await IdentificationRequest.findById(req.params.id);
+    if (!request) {
+      return res.status(404).json({ error: 'Demande non trouvée' });
+    }
+    const isAdmin = req.user.admin === 1 || req.user.admin === '1';
+    if (!isAdmin && request.user_id !== req.user.id) {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    await IdentificationRequest.delete(req.params.id);
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Erreur suppression demande:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
 export default router;

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -19,7 +19,7 @@ interface InitialValues {
 interface ProfileFormProps {
   initialValues?: InitialValues;
   profileId?: number | null;
-  onSaved?: () => void;
+  onSaved?: (profileId?: number) => void;
 }
 
 const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
@@ -117,6 +117,9 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
     e.preventDefault();
     const form = new FormData();
     let email = '';
+    let phone = '';
+    let first_name = '';
+    let last_name = '';
     const formatted = categories.map(cat => ({
       title: cat.title,
       fields: cat.fields.map(f => ({ key: f.key, value: f.value }))
@@ -125,9 +128,15 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
       cat.fields.forEach(f => {
         const lower = f.key.trim().toLowerCase();
         if (lower === 'email') email = f.value;
+        if (['téléphone', 'telephone', 'phone'].includes(lower)) phone = f.value;
+        if (['prénom', 'prenom', 'first name'].includes(lower)) first_name = f.value;
+        if (['nom', 'last name'].includes(lower)) last_name = f.value;
       });
     });
     form.append('email', email);
+    if (phone) form.append('phone', phone);
+    if (first_name) form.append('first_name', first_name);
+    if (last_name) form.append('last_name', last_name);
     form.append('comment', comment);
     form.append('extra_fields', JSON.stringify(formatted));
     if (photo) form.append('photo', photo);
@@ -144,7 +153,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
     const data = await res.json();
     if (res.ok) {
       setMessage('Profil enregistré avec succès');
-      if (onSaved) onSaved();
+      if (onSaved) onSaved(data.profile?.id);
     } else {
       setMessage(data.error || 'Erreur lors de la sauvegarde');
     }


### PR DESCRIPTION
## Summary
- allow deletion of identification requests
- enable admins to create profiles when identifying a phone number
- redesign request list with modern cards showing profile data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be96adb3508326b9db33b03af8eff9