### PR TITLE
Add dropdown and read-tracking for notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1578,8 +1578,10 @@ useEffect(() => {
   }, [currentPage, requests]);
 
   const handleNotificationClick = () => {
-    setShowNotifications(prev => !prev);
-    if (!showNotifications) {
+    const nextState = !showNotifications;
+    setShowNotifications(nextState);
+    if (nextState) {
+      fetchRequests();
       const ids = requests.filter(r => r.status === 'identified').map(r => r.id);
       setReadNotifications(prev => Array.from(new Set([...prev, ...ids])));
     }


### PR DESCRIPTION
## Summary
- Refresh requests when notification dropdown opens to keep notifications up to date

## Testing
- `apt-get update` (fails: The repository is not signed / 403 Forbidden)
- `npm test` (fails: command not found: npm)
- `npm run lint` (fails: command not found: npm)


------
https://chatgpt.com/codex/tasks/task_e_68bea5711b48832690843a0d7cb017c9