### PR TITLE
fix: guard against null JSON in SearchResultProfiles

### DIFF
--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -47,16 +47,28 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
               if (key === 'data') {
                 try {
                   const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-                  return Object.entries(parsed).map(([k, v]) => (
-                    <div key={`${key}-${k}`} className="flex flex-col">
+                  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                    return Object.entries(parsed).map(([k, v]) => (
+                      <div key={`${key}-${k}`} className="flex flex-col">
+                        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                          {k.replace(/_/g, ' ')}
+                        </span>
+                        <span className="text-sm text-gray-900 dark:text-gray-100 break-words">
+                          {String(v)}
+                        </span>
+                      </div>
+                    ));
+                  }
+                  return (
+                    <div key={key} className="flex flex-col">
                       <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                        {k.replace(/_/g, ' ')}
+                        {key.replace(/_/g, ' ')}
                       </span>
                       <span className="text-sm text-gray-900 dark:text-gray-100 break-words">
-                        {String(v)}
+                        {String(parsed)}
                       </span>
                     </div>
-                  ));
+                  );
                 } catch {
                   // Si le parsing échoue, afficher la valeur brute
                   return (


### PR DESCRIPTION
## Summary
- handle null and non-object `data` values safely when rendering search results

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68beab8245948326a5191a7d58211d68