### PR TITLE
feat: refresh notifications UI and style request button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1567,7 +1567,10 @@ useEffect(() => {
   // Vérifier si l'utilisateur est admin
   const isAdmin = currentUser && (currentUser.admin === 1 || currentUser.admin === "1");
 
-  const notificationCount = requests.filter(r => r.status === 'identified' && !readNotifications.includes(r.id)).length;
+  const notificationCount = requests.filter(
+    (r) => r.status === 'identified' && !readNotifications.includes(r.id)
+  ).length;
+  const totalNotifications = requests.filter((r) => r.status === 'identified').length;
 
   useEffect(() => {
     if (currentPage === 'requests') {
@@ -2035,34 +2038,39 @@ useEffect(() => {
       {/* Main content */}
         <div className="flex-1 overflow-auto">
           <div className="p-8">
-            <div className="flex justify-end mb-4 relative">
-              <button
-                onClick={handleNotificationClick}
-                className="relative p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <Bell className="h-6 w-6" />
-                {notificationCount > 0 && (
-                  <span className="absolute -top-1 -right-1 bg-red-600 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
-                    {notificationCount}
-                  </span>
-                )}
-              </button>
-              {showNotifications && (
-                <div className="absolute right-0 mt-10 w-64 bg-white border rounded-md shadow-lg z-50">
-                  {requests.filter(r => r.status === 'identified').length === 0 ? (
-                    <div className="p-2 text-sm text-gray-500">Aucune notification</div>
-                  ) : (
-                    requests
-                      .filter(r => r.status === 'identified')
-                      .map(r => (
-                        <div key={r.id} className="p-2 text-sm border-b last:border-b-0">
-                          {r.phone} a été identifié par l'administrateur
-                        </div>
-                      ))
+              <div className="flex justify-end mb-4 relative">
+                <button
+                  onClick={handleNotificationClick}
+                  className="relative p-2 rounded-full hover:bg-blue-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+                >
+                  <Bell className="h-6 w-6" />
+                  {notificationCount > 0 && (
+                    <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center shadow">
+                      {notificationCount}
+                    </span>
                   )}
-                </div>
-              )}
-            </div>
+                </button>
+                {showNotifications && (
+                  <div className="absolute right-0 mt-2 w-72 bg-white dark:bg-gray-800 rounded-xl shadow-xl ring-1 ring-black ring-opacity-5 z-50 overflow-hidden">
+                    <div className="px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-700">
+                      Notifications ({totalNotifications})
+                    </div>
+                    <div className="max-h-60 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700">
+                      {totalNotifications === 0 ? (
+                        <div className="p-4 text-sm text-gray-500 dark:text-gray-400">Aucune notification</div>
+                      ) : (
+                        requests
+                          .filter(r => r.status === 'identified')
+                          .map(r => (
+                            <div key={r.id} className="p-4 text-sm hover:bg-gray-50 dark:hover:bg-gray-700">
+                              {r.phone} a été identifié par l'administrateur
+                            </div>
+                          ))
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
           {currentPage === 'search' && (
             <div className="space-y-8">
               {/* Header */}
@@ -2166,14 +2174,14 @@ useEffect(() => {
                         <p className="text-gray-500">
                           Essayez avec d'autres termes de recherche ou vérifiez l'orthographe.
                         </p>
-                        {canRequestIdentification && (
+                          {canRequestIdentification && (
                           <button
                             onClick={handleRequestIdentification}
-                            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+                            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                           >
                             Demander identification
                           </button>
-                        )}
+                          )}
                       </div>
                     ) : viewMode === 'list' ? (
                       <div className="p-8 bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-700">


### PR DESCRIPTION
## Summary
- modernize notification dropdown and show notification count
- style identification request button with blue theme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68beac5edcd883269080dfa0546b9c20