### PR TITLE
Fix add-field button when identifying phone numbers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import {
   Search,
   Database,
@@ -351,6 +351,18 @@ const App: React.FC = () => {
   const [identifyingRequest, setIdentifyingRequest] = useState<IdentificationRequest | null>(null);
   const [readNotifications, setReadNotifications] = useState<number[]>([]);
   const [showNotifications, setShowNotifications] = useState(false);
+
+  const identifyingInitialValues = useMemo(
+    () => ({
+      extra_fields: [
+        {
+          title: 'Informations',
+          fields: [{ key: 'Téléphone', value: identifyingRequest?.phone || '' }]
+        }
+      ]
+    }),
+    [identifyingRequest?.phone]
+  );
 
   // États d'authentification
   const [loginData, setLoginData] = useState({ login: '', password: '' });
@@ -3100,14 +3112,7 @@ useEffect(() => {
                 <div className="bg-white rounded-lg shadow p-6">
                   <h3 className="text-xl font-semibold mb-4">Identifier {identifyingRequest.phone}</h3>
                   <ProfileForm
-                    initialValues={{
-                      extra_fields: [
-                        {
-                          title: 'Informations',
-                          fields: [{ key: 'Téléphone', value: identifyingRequest.phone }]
-                        }
-                      ]
-                    }}
+                    initialValues={identifyingInitialValues}
                     onSaved={handleProfileSaved}
                   />
                   <div className="mt-4 text-right">


### PR DESCRIPTION
## Summary
- memoize initial ProfileForm values for identification requests

## Testing
- `npm test` *(fails: Missing script "test" with npm warn Unknown env config "http-proxy".)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --no-save @eslint/js` *(fails: 403 Forbidden)
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb9bf70c08326ab999699e61c3b1b