### PR TITLE
feat: improve notification badge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1584,6 +1584,7 @@ useEffect(() => {
   const notificationCount = lastNotifications.filter(
     (r) => !readNotifications.includes(r.id)
   ).length;
+  const displayNotificationCount = notificationCount > 99 ? '99+' : notificationCount;
   const totalNotifications = lastNotifications.length;
 
   useEffect(() => {
@@ -2066,8 +2067,8 @@ useEffect(() => {
                 >
                   <Bell className="h-6 w-6" />
                   {notificationCount > 0 && (
-                    <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center shadow">
-                      {notificationCount}
+                    <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-xs min-w-[20px] h-5 px-1 flex items-center justify-center shadow">
+                      {displayNotificationCount}
                     </span>
                   )}
                 </button>


### PR DESCRIPTION
## Summary
- adjust notification badge sizing and cap count at 99+

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bebc2a88d88326b57af8d100b7c970