### PR TITLE
feat: brand profile PDFs with Vegeta footer

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -86,6 +86,36 @@ class ProfileService {
       const doc = new PDFDocument({ margin: 50 });
       const chunks = [];
 
+      const addFooter = () => {
+        const pageWidth = doc.page.width;
+        const margin = doc.page.margins.left;
+        const logoSize = 20;
+        const footerY = doc.page.height - margin + (margin - logoSize) / 2;
+        const text = 'VEGETA';
+
+        doc.save();
+        doc.font('Helvetica-Bold').fontSize(12);
+        const textWidth = doc.widthOfString(text);
+        const totalWidth = logoSize + 6 + textWidth;
+        const startX = (pageWidth - totalWidth) / 2;
+
+        doc
+          .circle(startX + logoSize / 2, footerY + logoSize / 2, logoSize / 2)
+          .fill('#4F46E5');
+        doc
+          .fillColor('white')
+          .fontSize(logoSize * 0.6)
+          .text('V', startX, footerY + logoSize * 0.2, { width: logoSize, align: 'center' });
+        doc
+          .fillColor('#4F46E5')
+          .fontSize(12)
+          .text(text, startX + logoSize + 6, footerY + logoSize * 0.2);
+        doc.restore();
+      };
+
+      addFooter();
+      doc.on('pageAdded', addFooter);
+
       return await new Promise(async (resolve, reject) => {
         doc.on('data', chunk => chunks.push(chunk));
         doc.on('end', () => resolve(Buffer.concat(chunks)));


### PR DESCRIPTION
## Summary
- add centered footer with Vegeta logo and name to profile PDFs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bebe9e626c8326a418bbe36cf41bcf