### PR TITLE
Fix PDF footer and adjust link diagram colors

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -88,28 +88,13 @@ class ProfileService {
 
       const addFooter = () => {
         const pageWidth = doc.page.width;
-        const margin = doc.page.margins.left;
-        const logoSize = 20;
-        const footerY = doc.page.height - margin + (margin - logoSize) / 2;
-        const text = 'VEGETA';
-
+        const footerY = doc.page.height - 40;
         doc.save();
-        doc.font('Helvetica-Bold').fontSize(12);
-        const textWidth = doc.widthOfString(text);
-        const totalWidth = logoSize + 6 + textWidth;
-        const startX = (pageWidth - totalWidth) / 2;
-
         doc
-          .circle(startX + logoSize / 2, footerY + logoSize / 2, logoSize / 2)
-          .fill('#4F46E5');
-        doc
-          .fillColor('white')
-          .fontSize(logoSize * 0.6)
-          .text('V', startX, footerY + logoSize * 0.2, { width: logoSize, align: 'center' });
-        doc
-          .fillColor('#4F46E5')
+          .font('Helvetica-Bold')
           .fontSize(12)
-          .text(text, startX + logoSize + 6, footerY + logoSize * 0.2);
+          .fillColor('#4F46E5')
+          .text('VEGETA', 0, footerY, { width: pageWidth, align: 'center' });
         doc.restore();
       };
 

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -102,6 +102,16 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
               ctx.fillStyle = color;
               ctx.fill();
             }}
+            linkColor={() =>
+              document.documentElement.classList.contains('dark')
+                ? '#93c5fd'
+                : '#2563eb'
+            }
+            linkDirectionalArrowColor={() =>
+              document.documentElement.classList.contains('dark')
+                ? '#93c5fd'
+                : '#2563eb'
+            }
             linkWidth={(link: any) => 1 + Math.log(link.callCount + link.smsCount)}
             linkDirectionalParticles={2}
             linkDirectionalParticleSpeed={0.005}


### PR DESCRIPTION
## Summary
- Place application name centered at bottom of generated profile PDFs
- Use distinct blue for link diagram lines and arrows for dark and light themes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --no-save --no-package-lock @eslint/js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bec16230ec8326afac5b8c62b45c7b