### PR TITLE
Use environment application name in PDF footer

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -86,6 +86,7 @@ class ProfileService {
       const doc = new PDFDocument({ margin: 50 });
       const chunks = [];
 
+      const appName = process.env.APP_NAME || 'VEGETA';
       const addFooter = () => {
         const pageWidth = doc.page.width;
         const footerY = doc.page.height - 40;
@@ -94,7 +95,7 @@ class ProfileService {
           .font('Helvetica-Bold')
           .fontSize(12)
           .fillColor('#4F46E5')
-          .text('VEGETA', 0, footerY, { width: pageWidth, align: 'center' });
+          .text(appName, 0, footerY, { width: pageWidth, align: 'center' });
         doc.restore();
       };
 


### PR DESCRIPTION
## Summary
- Load application name from `APP_NAME` env var when generating profile PDFs
- Render application name in footer on every page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68bec38abe148326931cf554298c59fe