### PR TITLE
Remove app name footer and adjust link diagram arrows

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -86,21 +86,7 @@ class ProfileService {
       const doc = new PDFDocument({ margin: 50 });
       const chunks = [];
 
-      const appName = process.env.APP_NAME || 'VEGETA';
-      const addFooter = () => {
-        const pageWidth = doc.page.width;
-        const footerY = doc.page.height - 40;
-        doc.save();
-        doc
-          .font('Helvetica-Bold')
-          .fontSize(12)
-          .fillColor('#4F46E5')
-          .text(appName, 0, footerY, { width: pageWidth, align: 'center' });
-        doc.restore();
-      };
-
-      addFooter();
-      doc.on('pageAdded', addFooter);
+      // Removed application name footer to keep PDF layout clean
 
       return await new Promise(async (resolve, reject) => {
         doc.on('data', chunk => chunks.push(chunk));

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -116,7 +116,8 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
             linkDirectionalParticles={2}
             linkDirectionalParticleSpeed={0.005}
             linkDirectionalArrowLength={6}
-            linkDirectionalArrowRelPos={0.5}
+            // Position arrows near targets so call/SMS labels remain unobstructed
+            linkDirectionalArrowRelPos={0.9}
             linkCanvasObjectMode={() => 'after'}
             linkCanvasObject={(link: any, ctx, globalScale) => {
               const start = link.source;


### PR DESCRIPTION
## Summary
- Clean up generated profile PDFs by removing application name footer
- Reposition link diagram arrows so call/SMS labels remain clear

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bec51e1f2883268df9995b071914a5