### PR TITLE
Add profile subtitle and enlarge link diagram text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3205,9 +3205,10 @@ useEffect(() => {
               <PageHeader icon={<FileText className="h-6 w-6" />} title="Fiches de profil" />
             {showProfileForm ? (
               <div className="bg-white shadow rounded-lg p-6">
-                <h2 className="text-2xl font-bold mb-6 text-gray-800">
+                <h2 className="text-2xl font-bold text-center text-gray-800">
                   {editingProfileId ? 'Modifier la fiche de profil' : 'Créer une fiche de profil'}
                 </h2>
+                <p className="mb-6 text-center text-gray-500">Vegata</p>
                 <ProfileForm
                   initialValues={profileDefaults}
                   profileId={editingProfileId || undefined}

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -124,7 +124,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
               const end = link.target;
               if (typeof start !== 'object' || typeof end !== 'object') return;
               const label = `${link.callCount} appels / ${link.smsCount} SMS`;
-              const fontSize = 10 / globalScale;
+              const fontSize = 14 / globalScale;
               const textX = (start.x + end.x) / 2;
               const textY = (start.y + end.y) / 2;
               const isDarkMode = document.documentElement.classList.contains('dark');


### PR DESCRIPTION
## Summary
- center Vegata subtitle in profile form header
- increase font size for call/SMS info on link diagram

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bec74f31948326b6b7cc6fe081f332