### PR TITLE
restore previous link diagram design

### DIFF
--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -20,14 +20,14 @@ interface LinkDiagramProps {
 }
 
 const typePalette = [
-  '#0ea5e9',
+  '#3b82f6',
+  '#10b981',
+  '#f59e0b',
+  '#ef4444',
   '#6366f1',
-  '#22c55e',
-  '#f97316',
-  '#a855f7',
-  '#e11d48',
-  '#14b8a6',
-  '#f59e0b'
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6'
 ];
 
 const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
@@ -52,7 +52,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-11/12 h-5/6 relative flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between p-4 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white">
+        <div className="flex items-center justify-between p-4 bg-blue-500 text-white">
           <h2 className="text-lg font-semibold">Diagramme des liens</h2>
           <button
             className="text-black hover:text-gray-800 dark:text-white dark:hover:text-gray-200"
@@ -80,25 +80,12 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
             nodeCanvasObject={(node: any, ctx, globalScale) => {
               const label = node.id;
               const fontSize = 12 / globalScale;
-              const radius = 10;
+              const radius = 8;
               const isDarkMode = document.documentElement.classList.contains('dark');
-              const gradient = ctx.createRadialGradient(
-                node.x,
-                node.y,
-                0,
-                node.x,
-                node.y,
-                radius
-              );
-              gradient.addColorStop(0, '#ffffff');
-              gradient.addColorStop(1, node.color);
               ctx.beginPath();
               ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI);
-              ctx.fillStyle = gradient;
-              ctx.shadowColor = 'rgba(0,0,0,0.2)';
-              ctx.shadowBlur = 8;
+              ctx.fillStyle = node.color;
               ctx.fill();
-              ctx.shadowBlur = 0;
               ctx.strokeStyle = isDarkMode ? '#374151' : '#e5e7eb';
               ctx.lineWidth = 1;
               ctx.stroke();
@@ -109,7 +96,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
               ctx.fillText(label, node.x, node.y + radius + 4);
             }}
             nodePointerAreaPaint={(node: any, color, ctx) => {
-              const radius = 10;
+              const radius = 8;
               ctx.beginPath();
               ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
               ctx.fillStyle = color;
@@ -117,17 +104,17 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
             }}
             linkColor={() =>
               document.documentElement.classList.contains('dark')
-                ? '#a5b4fc'
-                : '#6366f1'
+                ? '#93c5fd'
+                : '#2563eb'
             }
             linkDirectionalArrowColor={() =>
               document.documentElement.classList.contains('dark')
-                ? '#a5b4fc'
-                : '#6366f1'
+                ? '#93c5fd'
+                : '#2563eb'
             }
             linkWidth={(link: any) => 1 + Math.log(link.callCount + link.smsCount)}
-            linkDirectionalParticles={4}
-            linkDirectionalParticleSpeed={0.006}
+            linkDirectionalParticles={2}
+            linkDirectionalParticleSpeed={0.005}
             linkDirectionalArrowLength={6}
             // Position arrows near targets so call/SMS labels remain unobstructed
             linkDirectionalArrowRelPos={0.9}
@@ -137,7 +124,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
               const end = link.target;
               if (typeof start !== 'object' || typeof end !== 'object') return;
               const label = `${link.callCount} appels / ${link.smsCount} SMS`;
-              const fontSize = 14 / globalScale;
+              const fontSize = 10 / globalScale;
               const textX = (start.x + end.x) / 2;
               const textY = (start.y + end.y) / 2;
               const isDarkMode = document.documentElement.classList.contains('dark');
@@ -148,7 +135,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
               ctx.fillText(label, textX, textY);
             }}
           />
-          <div className="absolute top-4 left-4 bg-white/70 dark:bg-gray-800/70 backdrop-blur-md rounded-md shadow p-2 text-xs space-y-1">
+          <div className="absolute top-4 left-4 bg-white/80 dark:bg-gray-800/80 rounded-md shadow p-2 text-xs space-y-1">
             {nodeTypes.map((type) => (
               <div key={type} className="flex items-center gap-2">
                 <span


### PR DESCRIPTION
## Summary
- revert link diagram to earlier palette and layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68becd0661d083269c098417814aeda6