### PR TITLE
fix: clamp request page when results shrink

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -376,6 +376,13 @@ const App: React.FC = () => {
     [filteredRequests, requestPage]
   );
 
+  // Ensure the current request page is within bounds when the filtered
+  // results change. Otherwise, a shrinking dataset can leave the user on an
+  // out-of-range page with no navigation controls.
+  useEffect(() => {
+    setRequestPage(p => Math.min(p, Math.max(totalRequestPages, 1)));
+  }, [totalRequestPages]);
+
   const identifyingInitialValues = useMemo(
     () => ({
       extra_fields: [


### PR DESCRIPTION
## Summary
- clamp request page within bounds when filtered results shrink

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed1ed9e908326910f6a4bc78e96fc