### PR TITLE
feat: allow admin to edit identified numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ La plateforme supporte plusieurs opérateurs :
 - `POST /api/users` : Créer un utilisateur
 - `PATCH /api/users/:id` : Modifier un utilisateur
 
+### Numéros identifiés (ADMIN)
+- `GET /api/identified-numbers/:phone` : Récupérer les informations d'un numéro identifié
+- `PATCH /api/identified-numbers/:phone` : Modifier les informations d'un numéro identifié
+
 ## Sécurité
 
 - **Rate limiting** : 100 requêtes/15min pour la recherche

--- a/server/app.js
+++ b/server/app.js
@@ -19,6 +19,7 @@ import vehiculesRoutes from './routes/vehicules.js';
 import profilesRoutes from './routes/profiles.js';
 import casesRoutes from './routes/cases.js';
 import requestsRoutes from './routes/requests.js';
+import identifiedNumbersRoutes from './routes/identified-numbers.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -63,6 +64,7 @@ app.use('/api/vehicules', vehiculesRoutes);
 app.use('/api/profiles', profilesRoutes);
 app.use('/api/cases', casesRoutes);
 app.use('/api/requests', requestsRoutes);
+app.use('/api/identified-numbers', identifiedNumbersRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/models/IdentifiedNumber.js
+++ b/server/models/IdentifiedNumber.js
@@ -9,6 +9,21 @@ class IdentifiedNumber {
       [phone, JSON.stringify(data)]
     );
   }
+
+  static async findByPhone(phone) {
+    const row = await database.queryOne(
+      `SELECT * FROM autres.identified_numbers WHERE phone = ?`,
+      [phone]
+    );
+    if (!row) return null;
+    return {
+      id: row.id,
+      phone: row.phone,
+      data: row.data ? JSON.parse(row.data) : null,
+      created_at: row.created_at,
+      updated_at: row.updated_at
+    };
+  }
 }
 
 export default IdentifiedNumber;

--- a/server/routes/identified-numbers.js
+++ b/server/routes/identified-numbers.js
@@ -1,0 +1,39 @@
+import express from 'express';
+import { authenticate, requireAdmin } from '../middleware/auth.js';
+import IdentifiedNumber from '../models/IdentifiedNumber.js';
+
+const router = express.Router();
+
+router.use(authenticate);
+router.use(requireAdmin);
+
+router.get('/:phone', async (req, res) => {
+  try {
+    const number = await IdentifiedNumber.findByPhone(req.params.phone);
+    if (!number) {
+      return res.status(404).json({ error: 'Numéro non trouvé' });
+    }
+    res.json({ number });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.patch('/:phone', async (req, res) => {
+  try {
+    let { data } = req.body;
+    if (!data) {
+      return res.status(400).json({ error: 'Données requises' });
+    }
+    if (typeof data === 'string') {
+      try { data = JSON.parse(data); } catch (_) {}
+    }
+    await IdentifiedNumber.upsert(req.params.phone, data);
+    const number = await IdentifiedNumber.findByPhone(req.params.phone);
+    res.json({ number });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `IdentifiedNumber.findByPhone` model utility
- expose admin-only routes to view and edit identified numbers
- document new identified numbers API endpoints

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bed338979c83269743018243333d15