### PR TITLE
feat: persist notification read state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -349,8 +349,23 @@ const App: React.FC = () => {
   const [requests, setRequests] = useState<IdentificationRequest[]>([]);
   const [requestsLoading, setRequestsLoading] = useState(false);
   const [identifyingRequest, setIdentifyingRequest] = useState<IdentificationRequest | null>(null);
-  const [readNotifications, setReadNotifications] = useState<number[]>([]);
+  const [readNotifications, setReadNotifications] = useState<number[]>(() => {
+    try {
+      const saved = localStorage.getItem('readNotifications');
+      return saved ? JSON.parse(saved) : [];
+    } catch {
+      return [];
+    }
+  });
   const [showNotifications, setShowNotifications] = useState(false);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('readNotifications', JSON.stringify(readNotifications));
+    } catch {
+      // Ignore write errors (e.g., private browsing)
+    }
+  }, [readNotifications]);
 
   const [requestSearchInput, setRequestSearchInput] = useState('');
   const [requestSearch, setRequestSearch] = useState('');


### PR DESCRIPTION
## Summary
- persist read notifications in localStorage so badge reflects unread count across sessions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68bee74b9c5883269a3b757ff5e6fe8d