### PR TITLE
feat: add location filter to CDR search

### DIFF
--- a/server/models/Cdr.js
+++ b/server/models/Cdr.js
@@ -81,6 +81,7 @@ class Cdr {
     endDate = null,
     startTime = null,
     endTime = null,
+    location = null,
     tableName
   ) {
     const table = this.escapeIdentifier(tableName);
@@ -109,10 +110,21 @@ class Cdr {
       query += ` AND heure_debut <= ?`;
       params.push(endTime);
     }
+    if (location) {
+      query += ` AND nom_localisation = ?`;
+      params.push(location);
+    }
 
     query += ' ORDER BY date_debut, heure_debut';
 
     return await database.query(query, params);
+  }
+
+  static async listLocations(tableName) {
+    const table = this.escapeIdentifier(tableName);
+    return await database.query(
+      `SELECT DISTINCT nom_localisation FROM ${table} WHERE nom_localisation IS NOT NULL AND nom_localisation <> '' ORDER BY nom_localisation`
+    );
   }
 
   static async deleteTable(tableName) {

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -79,7 +79,7 @@ router.get('/:id/search', authenticate, async (req, res) => {
     if (!identifier) {
       return res.status(400).json({ error: 'Paramètre phone ou imei requis' });
     }
-    const { start, end, startTime, endTime, direction = 'both', type = 'both' } = req.query;
+    const { start, end, startTime, endTime, direction = 'both', type = 'both', location } = req.query;
     const isValidDate = (str) => {
       if (!str) return false;
       const regex = /^\d{4}-\d{2}-\d{2}$/;
@@ -103,6 +103,7 @@ router.get('/:id/search', authenticate, async (req, res) => {
     const validTypes = ['call', 'sms', 'both'];
     const dirParam = typeof direction === 'string' && validDirections.includes(direction) ? direction : 'both';
     const typeParam = typeof type === 'string' && validTypes.includes(type) ? type : 'both';
+    const locParam = typeof location === 'string' && location.trim() ? location.trim() : null;
     const result = await caseService.search(caseId, identifier, {
       startDate: start || null,
       endDate: end || null,
@@ -110,6 +111,7 @@ router.get('/:id/search', authenticate, async (req, res) => {
       endTime: endTime || null,
       direction: dirParam,
       type: typeParam,
+      location: locParam,
     }, req.user);
     res.json(result);
   } catch (err) {
@@ -130,6 +132,17 @@ router.post('/:id/link-diagram', authenticate, async (req, res) => {
   } catch (err) {
     console.error('Erreur diagramme des liens:', err);
     res.status(500).json({ error: 'Erreur diagramme des liens' });
+  }
+});
+
+router.get('/:id/locations', authenticate, async (req, res) => {
+  try {
+    const caseId = parseInt(req.params.id, 10);
+    const locations = await caseService.listLocations(caseId, req.user);
+    res.json(locations);
+  } catch (err) {
+    console.error('Erreur liste localisations case:', err);
+    res.status(500).json({ error: 'Erreur récupération localisations' });
   }
 });
 

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -98,6 +98,14 @@ class CaseService {
     return await Case.listFiles(caseId);
   }
 
+  async listLocations(caseId, user) {
+    const existingCase = await this.getCaseById(caseId, user);
+    if (!existingCase) {
+      throw new Error('Case not found');
+    }
+    return await this.cdrService.listLocations(existingCase.name);
+  }
+
   async deleteFile(caseId, fileId, user) {
     const existingCase = await this.getCaseById(caseId, user);
     if (!existingCase) {

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -125,6 +125,7 @@ class CdrService {
       endDate = null,
       startTime = null,
       endTime = null,
+      location = null,
       caseName,
       direction = 'both',
       type = 'both',
@@ -136,6 +137,7 @@ class CdrService {
       endDate,
       startTime,
       endTime,
+      location,
       caseName
     );
     const contactsMap = {};
@@ -320,6 +322,11 @@ class CdrService {
     }
 
     return { nodes, links };
+  }
+
+  async listLocations(caseName) {
+    const rows = await Cdr.listLocations(caseName);
+    return rows.map((r) => r.nom_localisation);
   }
 
   async deleteTable(caseName) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -547,6 +547,8 @@ const App: React.FC = () => {
   const [cdrEndTime, setCdrEndTime] = useState('');
   const [cdrDirection, setCdrDirection] = useState('both');
   const [cdrType, setCdrType] = useState('both');
+  const [cdrLocation, setCdrLocation] = useState('all');
+  const [cdrLocations, setCdrLocations] = useState<string[]>([]);
   const [cdrResult, setCdrResult] = useState<CdrSearchResult | null>(null);
   const [cdrLoading, setCdrLoading] = useState(false);
   const [cdrError, setCdrError] = useState('');
@@ -1390,6 +1392,7 @@ useEffect(() => {
       if (cdrEndTime) params.append('endTime', cdrEndTime);
       if (cdrDirection !== 'both') params.append('direction', cdrDirection);
       if (cdrType !== 'both') params.append('type', cdrType);
+      if (cdrLocation !== 'all') params.append('location', cdrLocation);
       const res = await fetch(`/api/cases/${selectedCase.id}/search?${params.toString()}`, {
         headers: { Authorization: token ? `Bearer ${token}` : '' }
       });
@@ -1493,6 +1496,21 @@ useEffect(() => {
     }
   };
 
+  const fetchCaseLocations = async (caseId: number) => {
+    try {
+      const token = localStorage.getItem('token');
+      const res = await fetch(`/api/cases/${caseId}/locations`, {
+        headers: { Authorization: token ? `Bearer ${token}` : '' }
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setCdrLocations(data);
+      }
+    } catch (err) {
+      console.error('Erreur chargement localisations:', err);
+    }
+  };
+
   const handleDeleteFile = async (fileId: number) => {
     if (!selectedCase) return;
     if (!window.confirm('Supprimer ce fichier ?')) return;
@@ -1511,8 +1529,11 @@ useEffect(() => {
   useEffect(() => {
     if (!selectedCase) {
       setCaseFiles([]);
+      setCdrLocations([]);
+      setCdrLocation('all');
     } else {
       fetchCaseFiles(selectedCase.id);
+      fetchCaseLocations(selectedCase.id);
     }
   }, [selectedCase]);
 
@@ -3160,6 +3181,16 @@ useEffect(() => {
                         <option value="sms">Seulement SMS</option>
                       </select>
                     </div>
+                    <select
+                      value={cdrLocation}
+                      onChange={(e) => setCdrLocation(e.target.value)}
+                      className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      <option value="all">Toutes les localisations</option>
+                      {cdrLocations.map((loc) => (
+                        <option key={loc} value={loc}>{loc}</option>
+                      ))}
+                    </select>
                     <div className="flex gap-2">
                       <button
                         type="submit"


### PR DESCRIPTION
## Summary
- add backend support for filtering CDR searches by location
- expose case locations endpoint
- include location dropdown on CDR search page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bfef1dc0fc832689b15cb36b82d6f0