### PR TITLE
feat: expand CDR map and add position filter

### DIFF
--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -99,8 +99,8 @@ router.get('/:id/search', authenticate, async (req, res) => {
     if (start && end && new Date(start) > new Date(end)) {
       return res.status(400).json({ error: 'La date de début doit précéder la date de fin' });
     }
-    const validDirections = ['incoming', 'outgoing', 'both'];
-    const validTypes = ['call', 'sms', 'both'];
+    const validDirections = ['incoming', 'outgoing', 'position', 'both'];
+    const validTypes = ['call', 'sms', 'web', 'both'];
     const dirParam = typeof direction === 'string' && validDirections.includes(direction) ? direction : 'both';
     const typeParam = typeof type === 'string' && validTypes.includes(type) ? type : 'both';
     const locParam = typeof location === 'string' && location.trim() ? location.trim() : null;

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -154,11 +154,17 @@ class CdrService {
       const isSms = typeStr.includes('sms');
       const eventType = isWeb ? 'web' : isSms ? 'sms' : 'call';
 
-      if (direction !== 'both' && !isWeb && directionRecord !== direction) {
-        continue;
-      }
-      if (type !== 'both' && type !== eventType) {
-        continue;
+      if (direction === 'position') {
+        if (!isWeb) {
+          continue;
+        }
+      } else {
+        if (direction !== 'both' && !isWeb && directionRecord !== direction) {
+          continue;
+        }
+        if (type !== 'both' && type !== eventType) {
+          continue;
+        }
       }
 
       if (!isWeb && other) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3058,8 +3058,8 @@ useEffect(() => {
                 &larr; Retour
               </button>
 
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div className="bg-white rounded-lg shadow p-6 space-y-4">
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                  <div className="bg-white rounded-lg shadow p-6 space-y-4">
                   <h3 className="text-lg font-semibold text-gray-700">Importation CDR</h3>
                   <form onSubmit={handleCdrUpload} className="space-y-4">
                     <input
@@ -3125,7 +3125,7 @@ useEffect(() => {
                   )}
                 </div>
 
-                <div className="bg-white rounded-lg shadow p-6 space-y-4">
+                <div className="bg-white rounded-lg shadow p-6 space-y-4 max-h-[60vh] overflow-y-auto">
                   <h3 className="text-lg font-semibold text-gray-700">Recherche</h3>
                   <form onSubmit={handleCdrSearch} className="space-y-4">
                     <input
@@ -3172,6 +3172,7 @@ useEffect(() => {
                         <option value="both">Appels entrants et sortants</option>
                         <option value="incoming">Uniquement entrants</option>
                         <option value="outgoing">Uniquement sortants</option>
+                        <option value="position">Position</option>
                       </select>
                       <select
                         value={cdrType}

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
 import L from 'leaflet';
-import { PhoneIncoming, PhoneOutgoing, MessageSquare, ArrowRight, MapPin, Navigation } from 'lucide-react';
+import { PhoneIncoming, PhoneOutgoing, MessageSquare, MapPin, Navigation } from 'lucide-react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 interface Point {
@@ -80,7 +80,7 @@ const getArrowIcon = (angle: number) => {
   const size = 16;
   const icon = (
     <div style={{ transform: `rotate(${angle}deg)` }}>
-      <ArrowRight size={size} className="text-red-600" />
+      <Navigation size={size} className="text-red-600" />
     </div>
   );
   return L.divIcon({
@@ -389,12 +389,13 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber, showRoute, showMeet
 
 
   return (
-    <div className="relative rounded-lg overflow-hidden shadow-lg">
-      <MapContainer
-        center={center}
-        zoom={13}
-        className="w-full h-[70vh]"
-      >
+    <> 
+      <div className="relative rounded-lg overflow-hidden shadow-lg">
+        <MapContainer
+          center={center}
+          zoom={13}
+          className="w-full h-[80vh]"
+        >
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -482,14 +483,14 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber, showRoute, showMeet
               interactive={false}
             />
           ))}
-      </MapContainer>
+        </MapContainer>
 
-      {showRoute && (
-        <div className="absolute bottom-2 left-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-2 text-sm z-[1000]">
-          <label htmlFor="speed" className="block font-semibold mb-1">
-            Vitesse : {speed}x
-          </label>
-          <input
+        {showRoute && (
+          <div className="absolute bottom-2 left-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-2 text-sm z-[1000]">
+            <label htmlFor="speed" className="block font-semibold mb-1">
+              Vitesse : {speed}x
+            </label>
+            <input
             id="speed"
             type="range"
             min={1}
@@ -497,11 +498,11 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber, showRoute, showMeet
             value={speed}
             onChange={(e) => setSpeed(Number(e.target.value))}
           />
-        </div>
-      )}
+          </div>
+        )}
 
-      {showMeetingPoints && colorMap.size > 0 && (
-        <div className="absolute bottom-2 right-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-2 text-sm z-[1000]">
+        {showMeetingPoints && colorMap.size > 0 && (
+          <div className="absolute bottom-2 right-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-2 text-sm z-[1000]">
           <p className="font-semibold mb-1">Légende</p>
           {Array.from(colorMap.entries()).map(([num, color]) => (
             <div key={num} className="flex items-center space-x-2">
@@ -526,62 +527,92 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber, showRoute, showMeet
               <span>Position</span>
             </div>
           </div>
+          </div>
+        )}
+
+        <div className="absolute top-2 left-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-4 text-sm space-y-4 z-[1000]">
+          <p className="font-semibold">Total : {total}</p>
+          {topContacts && topContacts.length > 0 && (
+            <div>
+              <p className="font-semibold mb-2">Top contacts</p>
+              <table className="min-w-full border-collapse">
+                <thead>
+                  <tr className="text-left">
+                    <th className="pr-4">Numéro</th>
+                    <th className="pr-4">Appels</th>
+                    <th className="pr-4">SMS</th>
+                    <th>Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topContacts.map((c, i) => (
+                    <tr
+                      key={c.number}
+                      className={`${i === 0 ? 'font-bold text-blue-600' : ''} border-t`}
+                    >
+                      <td className="pr-4">{c.number}</td>
+                      <td className="pr-4">{c.callCount}</td>
+                      <td className="pr-4">{c.smsCount}</td>
+                      <td>{c.total}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {topLocations && topLocations.length > 0 && (
+            <div>
+              <p className="font-semibold mb-2">Top lieux</p>
+              <table className="min-w-full border-collapse">
+                <thead>
+                  <tr className="text-left">
+                    <th className="pr-4">Lieu</th>
+                    <th>Occurrences</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topLocations.map((l, i) => (
+                    <tr key={i} className="border-t">
+                      <td className="pr-4">{l.nom || `${l.latitude},${l.longitude}`}</td>
+                      <td>{l.count}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showMeetingPoints && meetingPoints.length > 0 && (
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full text-sm text-gray-700">
+            <thead>
+              <tr className="text-left">
+                <th className="px-2 py-1">Point</th>
+                <th className="px-2 py-1">Numéro</th>
+                <th className="px-2 py-1">Événements</th>
+                <th className="px-2 py-1">Début</th>
+                <th className="px-2 py-1">Fin</th>
+                <th className="px-2 py-1">Durée</th>
+              </tr>
+            </thead>
+            <tbody>
+              {meetingPoints.map((m, i) => (
+                <tr key={i} className="border-t">
+                  <td className="px-2 py-1">{m.nom || `${m.lat},${m.lng}`}</td>
+                  <td className="px-2 py-1">{m.number || '-'}</td>
+                  <td className="px-2 py-1">{m.events.length}</td>
+                  <td className="px-2 py-1">{m.start}</td>
+                  <td className="px-2 py-1">{m.end}</td>
+                  <td className="px-2 py-1">{m.duration}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
-
-      <div className="absolute top-2 left-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-4 text-sm space-y-4 z-[1000]">
-        <p className="font-semibold">Total : {total}</p>
-        {topContacts && topContacts.length > 0 && (
-          <div>
-            <p className="font-semibold mb-2">Top contacts</p>
-            <table className="min-w-full border-collapse">
-              <thead>
-                <tr className="text-left">
-                  <th className="pr-4">Numéro</th>
-                  <th className="pr-4">Appels</th>
-                  <th className="pr-4">SMS</th>
-                  <th>Total</th>
-                </tr>
-              </thead>
-              <tbody>
-                {topContacts.map((c, i) => (
-                  <tr
-                    key={c.number}
-                    className={`${i === 0 ? 'font-bold text-blue-600' : ''} border-t`}
-                  >
-                    <td className="pr-4">{c.number}</td>
-                    <td className="pr-4">{c.callCount}</td>
-                    <td className="pr-4">{c.smsCount}</td>
-                    <td>{c.total}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-        {topLocations && topLocations.length > 0 && (
-          <div>
-            <p className="font-semibold mb-2">Top lieux</p>
-            <table className="min-w-full border-collapse">
-              <thead>
-                <tr className="text-left">
-                  <th className="pr-4">Lieu</th>
-                  <th>Occurrences</th>
-                </tr>
-              </thead>
-              <tbody>
-                {topLocations.map((l, i) => (
-                  <tr key={i} className="border-t">
-                    <td className="pr-4">{l.nom || `${l.latitude},${l.longitude}`}</td>
-                    <td>{l.count}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- enlarge CDR map view and shrink search panel
- add position option to direction filter and server handling
- display meeting points table and modern route arrows

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden for @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68c024f4bb648326885c9bc30fc78f3e