### PR TITLE
Align form and stats around enlarged map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1878,7 +1878,7 @@ useEffect(() => {
     <div
       className={`${
         showCdrMap
-          ? 'absolute top-4 left-4 z-[1000] w-full max-w-md bg-white/90 backdrop-blur rounded-lg shadow p-4 space-y-4'
+          ? 'fixed top-4 left-4 z-[1000] w-full max-w-md bg-white/90 backdrop-blur rounded-lg shadow p-4 space-y-4'
           : 'bg-white rounded-lg shadow p-6 space-y-4 max-h-[60vh] overflow-y-auto'
       }`}
     >

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -533,7 +533,7 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber, showRoute, showMeet
           </div>
         )}
 
-        <div className="absolute top-2 left-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-4 text-sm space-y-4 z-[1000]">
+        <div className="absolute top-2 right-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-4 text-sm space-y-4 z-[1000]">
           <p className="font-semibold">Total : {total}</p>
           {topContacts && topContacts.length > 0 && (
             <div>


### PR DESCRIPTION
## Summary
- Fix search form to left side when map is expanded
- Move top contact and top location tables to right side of map view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')


------
https://chatgpt.com/codex/tasks/task_e_68c03951ecd083269de8c072440f48e9