### PR TITLE
Filter 2214 numbers and reposition map elements

### DIFF
--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -147,6 +147,9 @@ class CdrService {
     for (const r of records) {
       const caller = r.numero_intl_appelant;
       const callee = r.numero_intl_appele;
+      if (String(caller || '').startsWith('2214') || String(callee || '').startsWith('2214')) {
+        continue;
+      }
       const isWeb = !callee;
       const other = caller === identifier ? callee : caller;
       const directionRecord = caller === identifier ? 'outgoing' : 'incoming';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1378,7 +1378,7 @@ useEffect(() => {
       const ids = cdrIdentifier
         .split(',')
         .map((i) => i.trim())
-        .filter((i) => i);
+        .filter((i) => i && !i.startsWith('2214'));
 
       const allPaths: CdrPoint[] = [];
 
@@ -1397,6 +1397,7 @@ useEffect(() => {
         if (res.ok) {
           const filtered = Array.isArray(data.path)
             ? data.path.filter((p: CdrPoint) => {
+                if (String(p.number || '').startsWith('2214')) return false;
                 if (p.type === 'web') return cdrPosition;
                 if (p.type === 'sms') return cdrSms;
                 return p.direction === 'incoming'
@@ -1921,7 +1922,7 @@ useEffect(() => {
     <div
       className={`${
         showCdrMap
-          ? 'fixed top-20 left-4 z-[1000] w-full max-w-md bg-white/90 backdrop-blur rounded-lg shadow p-4 space-y-4'
+          ? 'fixed bottom-4 left-4 z-[1000] w-full max-w-md bg-white/90 backdrop-blur rounded-lg shadow p-4 space-y-4'
           : 'bg-white rounded-lg shadow p-6 space-y-4 max-h-[60vh] overflow-y-auto'
       }`}
     >

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -445,7 +445,7 @@ const CdrMap: React.FC<Props> = ({ points, onIdentifyNumber, showRoute, showMeet
         </MapContainer>
 
         {colorMap.size > 1 && (
-          <div className="absolute top-2 left-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-2 text-sm z-[1000] space-y-1">
+          <div className="absolute left-2 top-24 bg-white/90 backdrop-blur rounded-lg shadow-md p-2 text-sm z-[1000] space-y-1">
             <p className="font-semibold">Légende</p>
             {[...colorMap.entries()].map(([num, color]) => (
               <div key={num} className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- ignore CDR numbers starting with 2214 on both client and server
- move CDR search form to bottom-left when map is expanded
- place map legend below zoom controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c14c18482c83268185e9fe959a4710