### PR TITLE
Fix grouped popup visibility in dark mode

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -507,18 +507,18 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints }) => {
               )}
             >
               <Popup>
-                <div className="space-y-2 text-sm max-h-60 overflow-y-auto pr-1">
+                <div className="space-y-2 text-sm max-h-60 overflow-y-auto pr-1 bg-white dark:bg-white text-gray-900 dark:!text-gray-900">
                   <p className="font-semibold text-blue-600">{first.nom || 'Localisation'}</p>
                   {group.events.map((loc, i) => (
-                    <div key={i} className="mt-2 p-2 bg-gray-50 rounded-lg shadow">
+                    <div key={i} className="mt-2 p-2 bg-gray-50 dark:!bg-white rounded-lg shadow text-gray-900 dark:!text-gray-900">
                       <p className="font-semibold">{loc.source || 'N/A'}</p>
                       <div className="flex items-center space-x-1">
-                        <PhoneOutgoing size={16} className="text-gray-700" />
+                        <PhoneOutgoing size={16} className="text-gray-700 dark:!text-gray-700" />
                         <span>Appelant: {loc.caller || 'N/A'}</span>
                       </div>
                       {loc.type !== 'web' && (
                         <div className="flex items-center space-x-1">
-                          <PhoneIncoming size={16} className="text-gray-700" />
+                          <PhoneIncoming size={16} className="text-gray-700 dark:!text-gray-700" />
                           <span>Appelé: {loc.callee || 'N/A'}</span>
                         </div>
                       )}


### PR DESCRIPTION
## Summary
- ensure grouped position popups keep a white background and dark text in dark theme
- keep popup icons dark for better contrast

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c178c8df008326a591f8869c5bef03