### PR TITLE
Improve dark mode map visuals and meeting point marker

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -6,9 +6,8 @@ import {
   PhoneOutgoing,
   MessageSquare,
   MapPin,
-  Navigation,
+  ArrowRight,
   Car,
-  XCircle,
   Layers
 } from 'lucide-react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -96,7 +95,7 @@ const getArrowIcon = (angle: number) => {
   const size = 16;
   const icon = (
     <div style={{ transform: `rotate(${angle}deg)` }}>
-      <Navigation size={size} className="text-red-600" />
+      <ArrowRight size={size} className="text-blue-600" />
     </div>
   );
   return L.divIcon({
@@ -163,11 +162,14 @@ const MeetingPointMarker: React.FC<{
       position={[mp.lat, mp.lng]}
       icon={L.divIcon({
         html: renderToStaticMarkup(
-          <XCircle size={32} className="text-red-600" />
+          <div className="relative flex items-center justify-center">
+            <span className="absolute inline-flex h-8 w-8 rounded-full bg-red-400 opacity-75 animate-ping"></span>
+            <span className="relative inline-flex h-4 w-4 rounded-full bg-red-600"></span>
+          </div>
         ),
         className: '',
         iconSize: [32, 32],
-        iconAnchor: [16, 32]
+        iconAnchor: [16, 16]
       })}
     >
       <Popup>

--- a/src/index.css
+++ b/src/index.css
@@ -135,3 +135,15 @@
   background-color: #9ca3af;
   border-radius: 4px;
 }
+
+/* Ensure Leaflet popups remain white even in dark mode */
+.leaflet-popup-content-wrapper,
+.leaflet-popup-tip {
+  background-color: #fff !important;
+  color: #111827 !important;
+}
+.dark .leaflet-popup-content-wrapper,
+.dark .leaflet-popup-tip {
+  background-color: #fff !important;
+  color: #111827 !important;
+}


### PR DESCRIPTION
## Summary
- Keep Leaflet popups white in dark mode
- Use modern direction arrow for route tracking
- Add pulsing meeting point marker design

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c17b262bb883269927e71d887e5b8c