### PR TITLE
fix: white background & centered title for dark grouped popups

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -509,10 +509,10 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints }) => {
               )}
             >
               <Popup>
-                <div className="space-y-2 text-sm max-h-60 overflow-y-auto pr-1 bg-white dark:bg-white text-gray-900 dark:!text-gray-900">
-                  <p className="font-semibold text-blue-600">{first.nom || 'Localisation'}</p>
+                <div className="space-y-2 text-sm max-h-60 overflow-y-auto pr-1 bg-white dark:!bg-white text-gray-900 dark:!text-gray-900">
+                  <p className="font-semibold text-blue-600 text-center">{first.nom || 'Localisation'}</p>
                   {group.events.map((loc, i) => (
-                    <div key={i} className="mt-2 p-2 bg-gray-50 dark:!bg-white rounded-lg shadow text-gray-900 dark:!text-gray-900">
+                    <div key={i} className="mt-2 p-2 bg-white dark:!bg-white rounded-lg shadow text-gray-900 dark:!text-gray-900">
                       <p className="font-semibold">{loc.source || 'N/A'}</p>
                       <div className="flex items-center space-x-1">
                         <PhoneOutgoing size={16} className="text-gray-700 dark:!text-gray-700" />


### PR DESCRIPTION
## Summary
- center location name in grouped popups
- ensure grouped popup background stays white in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18ea8f3c88326887ee31c357294f1