### PR TITLE
Limit location tables to top 10 entries

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -279,15 +279,17 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints }) => {
       }))
       .sort((a, b) => b.total - a.total);
 
-    const locations: LocationStat[] = Array.from(locationMap.values()).sort(
-      (a, b) => b.count - a.count
-    );
+    const locations: LocationStat[] = Array.from(locationMap.values())
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
 
-    const recent: LocationStat[] = Array.from(locationMap.values()).sort(
-      (a, b) =>
-        new Date(b.lastDate || 0).getTime() -
-        new Date(a.lastDate || 0).getTime()
-    );
+    const recent: LocationStat[] = Array.from(locationMap.values())
+      .sort(
+        (a, b) =>
+          new Date(b.lastDate || 0).getTime() -
+          new Date(a.lastDate || 0).getTime()
+      )
+      .slice(0, 10);
 
     return { topContacts: contacts, topLocations: locations, recentLocations: recent, total: points.length };
   }, [points]);


### PR DESCRIPTION
## Summary
- Restrict popular and recent location stats to top 10 items for concise display

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a42373e88326b0d58f7f1edc6626