### PR TITLE
fix: filter invalid location markers for top locations

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -279,11 +279,18 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints }) => {
       }))
       .sort((a, b) => b.total - a.total);
 
-    const locations: LocationStat[] = Array.from(locationMap.values())
+    const allLocations = Array.from(locationMap.values()).filter(
+      (loc) =>
+        !isNaN(parseFloat(loc.latitude)) && !isNaN(parseFloat(loc.longitude))
+    );
+
+    const locations: LocationStat[] = allLocations
+      .slice()
       .sort((a, b) => b.count - a.count)
       .slice(0, 10);
 
-    const recent: LocationStat[] = Array.from(locationMap.values())
+    const recent: LocationStat[] = allLocations
+      .slice()
       .sort(
         (a, b) =>
           new Date(b.lastDate || 0).getTime() -


### PR DESCRIPTION
## Summary
- ensure top and recent locations only include points with valid coordinates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c2d52093dc8326983280504c4917fa