### PR TITLE
chore: specify postcss source

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,4 +3,10 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
   },
+  // Specify the source filename to avoid PostCSS warnings about missing `from`
+  // when processing CSS. Using `undefined` tells PostCSS not to expect a file
+  // path and suppresses the warning.
+  options: {
+    from: undefined,
+  },
 };


### PR DESCRIPTION
## Summary
- avoid PostCSS `from` warnings by explicitly setting `from: undefined` in `postcss.config.js`

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found; dependency installation blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e9bf30388326ba996195b56a14fd