### PR TITLE
chore: define postcss source

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,10 +3,8 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
   },
-  // Specify the source filename to avoid PostCSS warnings about missing `from`
-  // when processing CSS. Using `undefined` tells PostCSS not to expect a file
-  // path and suppresses the warning.
-  options: {
-    from: undefined,
-  },
+  // Specify the source filename to avoid PostCSS warnings about missing
+  // `from` when processing CSS. Using `undefined` tells PostCSS not to expect
+  // a file path and suppresses the warning.
+  from: undefined,
 };


### PR DESCRIPTION
## Summary
- specify PostCSS `from` option to silence warning about missing source

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install -D @eslint/js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eb78168083269f946cb8f3adf1fd