### PR TITLE
Prevent page reload on toggle switch

### DIFF
--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -7,6 +7,12 @@ interface ToggleSwitchProps {
 }
 
 const ToggleSwitch: React.FC<ToggleSwitchProps> = ({ label, checked, onChange }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onChange(e.target.checked);
+  };
+
   return (
     <label className="flex items-center justify-between cursor-pointer">
       <span className="flex items-center gap-2 mr-3">{label}</span>
@@ -14,7 +20,7 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({ label, checked, onChange })
         type="checkbox"
         className="sr-only peer"
         checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
+        onChange={handleChange}
       />
       <div className="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 dark:bg-gray-700 peer-checked:bg-blue-600">
         <div className="absolute top-[2px] left-[2px] h-5 w-5 bg-white rounded-full border border-gray-300 transition peer-checked:translate-x-full peer-checked:border-white"></div>


### PR DESCRIPTION
## Summary
- Stop toggle switch clicks from triggering form submissions by preventing default behavior and event propagation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c302c8b30c8326aeae715c643c2e06