### PR TITLE
Fix map controls being blocked by toolbar overlay

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1165,8 +1165,8 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
         ))}
         </MapContainer>
 
-        <div className="absolute top-2 left-0 right-0 z-[1000] flex justify-center">
-          <div className="flex bg-white/90 backdrop-blur rounded-full shadow overflow-hidden divide-x divide-gray-200">
+        <div className="pointer-events-none absolute top-2 left-0 right-0 z-[1000] flex justify-center">
+          <div className="pointer-events-auto flex bg-white/90 backdrop-blur rounded-full shadow overflow-hidden divide-x divide-gray-200">
             {sourceNumbers.length >= 2 && (
               <button
                 onClick={() => setShowSimilar((s) => !s)}


### PR DESCRIPTION
## Summary
- prevent map top bar from intercepting pointer events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c4064ad0408326b0b753faf6e9d190