### PR TITLE
Include similar trajectory view in map visibility toggle

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -566,9 +566,14 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
 
   const showBaseMarkers = useMemo(
     () =>
-      !(activeInfo === 'recent' || activeInfo === 'popular' || showMeetingPoints) ||
+      !(
+        activeInfo === 'recent' ||
+        activeInfo === 'popular' ||
+        showMeetingPoints ||
+        showSimilar
+      ) ||
       showOthers,
-    [activeInfo, showMeetingPoints, showOthers]
+    [activeInfo, showMeetingPoints, showSimilar, showOthers]
   );
 
   const routePositions = useMemo(() => {
@@ -1226,7 +1231,10 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
                 <span>Points de rencontre</span>
               </button>
             )}
-            {(activeInfo === 'recent' || activeInfo === 'popular' || showMeetingPoints) && (
+            {(activeInfo === 'recent' ||
+              activeInfo === 'popular' ||
+              showMeetingPoints ||
+              showSimilar) && (
               <button
                 onClick={() => setShowOthers((s) => !s)}
                 className={`px-4 py-2 text-sm font-medium transition-colors ${


### PR DESCRIPTION
## Summary
- allow hiding other map elements when displaying similar trajectories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c40859db388326a2ffd8efb0d71362