### PR TITLE
Move zone creation button to top of map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3364,6 +3364,7 @@ useEffect(() => {
                       onToggleMeetingPoints={() => setShowMeetingPoints((v) => !v)}
                       zoneMode={zoneMode}
                       onZoneCreated={() => setZoneMode(false)}
+                      onToggleZoneMode={() => setZoneMode((z) => !z)}
                     />
                   </div>
                   <button
@@ -3374,14 +3375,6 @@ useEffect(() => {
                     <X className="w-5 h-5" />
                   </button>
                   {renderCdrSearchForm()}
-                  <div className="fixed bottom-4 left-4 z-[1000] space-y-2">
-                    <button
-                      onClick={() => setZoneMode((z) => !z)}
-                      className="px-4 py-2 bg-blue-600 text-white rounded-full shadow"
-                    >
-                      {zoneMode ? 'Annuler' : 'Créer une Zone'}
-                    </button>
-                  </div>
                 </>
               )}
               {linkDiagram && (

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -14,7 +14,8 @@ import {
   Flame,
   Eye,
   EyeOff,
-  Activity
+  Activity,
+  Square
 } from 'lucide-react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -81,6 +82,7 @@ interface Props {
   onToggleMeetingPoints?: () => void;
   zoneMode?: boolean;
   onZoneCreated?: () => void;
+  onToggleZoneMode?: () => void;
 }
 
 const getPointColor = (type: string, direction?: string) => {
@@ -260,7 +262,7 @@ const MeetingPointMarker: React.FC<{
   );
 });
 
-const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggleMeetingPoints, zoneMode, onZoneCreated }) => {
+const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggleMeetingPoints, zoneMode, onZoneCreated, onToggleZoneMode }) => {
   if (!points || points.length === 0) return null;
 
   const first = points[0];
@@ -1245,6 +1247,17 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
               >
                 <MapPin className="w-4 h-4" />
                 <span>Points de rencontre</span>
+              </button>
+            )}
+            {onToggleZoneMode && (
+              <button
+                onClick={onToggleZoneMode}
+                className={`flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors ${
+                  zoneMode ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'
+                }`}
+              >
+                <Square className="w-4 h-4" />
+                <span>{zoneMode ? 'Annuler' : 'Créer une zone'}</span>
               </button>
             )}
             {(activeInfo === 'recent' ||


### PR DESCRIPTION
## Summary
- Position the “Créer une zone” toggle beside the “Points de rencontre” control on the map
- Allow map component to toggle zone mode via new `onToggleZoneMode` prop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c4178b73448326a0f8a1289d1f98e2