### PR TITLE
Handle HH:MM durations in call totals

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -96,8 +96,14 @@ const parseDurationToSeconds = (duration: string): number => {
       return h * 3600 + m * 60 + s;
     }
     if (parts.length === 2) {
-      const [m, s] = parts;
-      return m * 60 + s;
+      const [first, second] = parts;
+      // Support both HH:MM and MM:SS formats. Values with an hour field
+      // (either <= 23 or >= 60) are treated as hours:minutes; otherwise
+      // assume minutes:seconds.
+      if (first >= 60 || first <= 23) {
+        return first * 3600 + second * 60;
+      }
+      return first * 60 + second;
     }
     if (parts.length === 1) {
       return parts[0];


### PR DESCRIPTION
## Summary
- Distinguish between `HH:MM` and `MM:SS` when parsing call durations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56ca96cec8326b899f9b1b7c6b2b3