### PR TITLE
Fix meeting point visibility toggle in contact table

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1153,6 +1153,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
     const isActive = showMeetingPoints && activeMeetingNumber === number;
     if (isActive) {
       setActiveMeetingNumber(null);
+      onToggleMeetingPoints?.();
     } else {
       setActiveMeetingNumber(number);
       if (!showMeetingPoints) {


### PR DESCRIPTION
## Summary
- Hide all meeting points when a contact's visibility is toggled off
- Show only relevant meeting points for selected contact from the contact list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c57064e3648326bcb1b5857333fade