### PR TITLE
fix: hide map sidebar when collapsed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2098,7 +2098,7 @@ useEffect(() => {
     if (showCdrMap) {
       return (
         <aside
-          className={`z-[1000] w-80 h-full bg-white/90 backdrop-blur shadow-lg transform transition-transform duration-300 ${
+          className={`fixed top-0 left-0 z-[1000] w-80 h-full bg-white/90 backdrop-blur shadow-lg transform transition-transform duration-300 ${
             mapPanelOpen ? 'translate-x-0' : '-translate-x-full'
           }`}
         >


### PR DESCRIPTION
## Summary
- remove map sidebar from layout when closed using fixed positioning

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5787874dc8326bedef114fbeca396