### PR TITLE
feat: modernize map controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3390,7 +3390,7 @@ useEffect(() => {
                 <>
                   <div className="fixed inset-0 z-0 flex">
                     {renderCdrSearchForm()}
-                    <div className="flex-1 relative">
+                    <div className="flex-1 relative h-screen">
                       <CdrMap
                         points={cdrResult.path}
                         showRoute={cdrItinerary}


### PR DESCRIPTION
## Summary
- make map occupy full screen and move legend higher
- add bottom control icons for approximate location, layer toggle and zoom

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c58affb1ec8326901e80c290445591