### PR TITLE
Refine map UI and CDR search layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pdfkit": "^0.13.0",
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
-    "react-leaflet-cluster": "^4.0.0",
+    "react-leaflet-cluster": "3.0.0",
     "xlsx": "^0.18.5",
     "force-graph": "^1.45.0",
     "react-force-graph-2d": "^1.25.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -597,7 +597,6 @@ const App: React.FC = () => {
     }
   }, [casePage, totalCasePages]);
   const [showCdrMap, setShowCdrMap] = useState(false);
-  const [mapPanelOpen, setMapPanelOpen] = useState(true);
   const [selectedCase, setSelectedCase] = useState<CdrCase | null>(null);
   const [caseFiles, setCaseFiles] = useState<CaseFile[]>([]);
   const [linkDiagram, setLinkDiagram] = useState<LinkDiagramData | null>(null);
@@ -2097,23 +2096,9 @@ useEffect(() => {
     );
     if (showCdrMap) {
       return (
-        <aside
-          className={`fixed top-0 left-0 z-[1000] w-80 h-full bg-white/90 backdrop-blur shadow-lg transform transition-transform duration-300 ${
-            mapPanelOpen ? 'translate-x-0' : '-translate-x-full'
-          }`}
-        >
-          <div className="relative h-full overflow-y-auto p-4 space-y-4">
-            <button
-              type="button"
-              onClick={() => setMapPanelOpen(false)}
-              className="absolute top-2 right-2 p-2 bg-white rounded-full shadow"
-              aria-label="Replier le panneau"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </button>
-            {formContent}
-          </div>
-        </aside>
+        <div className="fixed bottom-4 left-4 z-[1000] w-80 max-h-[80vh] overflow-y-auto bg-white/90 backdrop-blur rounded-lg shadow-lg p-4 space-y-4">
+          {formContent}
+        </div>
       );
     }
     return (
@@ -3409,15 +3394,7 @@ useEffect(() => {
                   >
                     <X className="w-5 h-5" />
                   </button>
-                  {!mapPanelOpen && (
-                    <button
-                      onClick={() => setMapPanelOpen(true)}
-                      className="fixed top-4 left-4 z-[1000] bg-white/90 backdrop-blur rounded-full p-2 shadow"
-                      aria-label="Ouvrir le panneau de recherche"
-                    >
-                      <Menu className="w-5 h-5" />
-                    </button>
-                  )}
+                  
                 </>
               )}
               {linkDiagram && (

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1561,10 +1561,10 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
         ))}
         </MapContainer>
 
-        <div className="pointer-events-none absolute bottom-4 left-4 z-[1000] flex flex-col gap-2">
+        <div className="pointer-events-none absolute top-4 left-2 z-[1000] flex flex-col gap-2">
           <button
             onClick={handleTriangulation}
-            className={`pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors ${
+            className={`pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors border border-gray-300 ${
               triangulationZones.length > 0 ? 'text-blue-600' : 'text-gray-700'
             }`}
             title="Localisation approximative de la personne"
@@ -1573,7 +1573,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
           </button>
           <button
             onClick={() => setIsSatellite((s) => !s)}
-            className={`pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors ${
+            className={`pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors border border-gray-300 ${
               isSatellite ? 'text-blue-600' : 'text-gray-700'
             }`}
             title="Changer l'affichage"
@@ -1582,14 +1582,14 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
           </button>
           <button
             onClick={() => mapRef.current?.zoomIn()}
-            className="pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors"
+            className="pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors border border-gray-300"
             title="Zoomer"
           >
             <Plus className="w-5 h-5" />
           </button>
           <button
             onClick={() => mapRef.current?.zoomOut()}
-            className="pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors"
+            className="pointer-events-auto p-2 rounded-full shadow bg-white/90 hover:bg-gray-100 transition-colors border border-gray-300"
             title="Dézoomer"
           >
             <Minus className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- Set `react-leaflet-cluster` dependency to version 3.0.0
- Move CDR search form to a bottom-left panel on the map
- Reposition map controls to the top-left with bordered buttons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c59cd776a8832689b4fb1b46bfd588