### PR TITLE
fix: remove dangling map panel effect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -624,10 +624,6 @@ const App: React.FC = () => {
     setCdrIdentifiers(cdrIdentifiers.filter((_, i) => i !== index));
   };
 
-  useEffect(() => {
-    if (showCdrMap) setMapPanelOpen(true);
-  }, [showCdrMap]);
-
   // Vérification de l'authentification au démarrage
   useEffect(() => {
     const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- remove obsolete effect that referenced deleted `setMapPanelOpen`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c59e511c208326b6e2c3b0dadb408d