### PR TITLE
feat: modernize map legend layout

### DIFF
--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -2,32 +2,23 @@ import React from 'react';
 import { PhoneIncoming, PhoneOutgoing, MessageSquare, MapPin } from 'lucide-react';
 
 const MapLegend: React.FC = () => {
+  const legendItems = [
+    { icon: PhoneIncoming, label: 'Appel entrant', color: 'bg-green-600' },
+    { icon: PhoneOutgoing, label: 'Appel sortant', color: 'bg-blue-600' },
+    { icon: MessageSquare, label: 'SMS', color: 'bg-green-600' },
+    { icon: MapPin, label: 'Position web', color: 'bg-red-600' }
+  ];
+
   return (
-    <div className="absolute bottom-4 right-4 bg-white/90 dark:bg-gray-800/90 p-3 rounded shadow space-y-2 text-gray-800 dark:text-gray-200 text-xs md:text-sm">
-      <div className="flex items-center space-x-2">
-        <div className="w-4 h-4 rounded-full flex items-center justify-center bg-green-600 text-white">
-          <PhoneIncoming size={12} />
+    <div className="absolute bottom-4 right-4 bg-white/80 dark:bg-gray-900/80 backdrop-blur-md px-4 py-2 rounded-lg shadow-lg flex items-center space-x-4 text-gray-800 dark:text-gray-200 text-sm md:text-base">
+      {legendItems.map(({ icon: Icon, label, color }) => (
+        <div key={label} className="flex items-center space-x-2">
+          <div className={`w-5 h-5 rounded-full flex items-center justify-center ${color} text-white`}>
+            <Icon size={14} />
+          </div>
+          <span className="whitespace-nowrap font-medium">{label}</span>
         </div>
-        <span>Appel entrant</span>
-      </div>
-      <div className="flex items-center space-x-2">
-        <div className="w-4 h-4 rounded-full flex items-center justify-center bg-blue-600 text-white">
-          <PhoneOutgoing size={12} />
-        </div>
-        <span>Appel sortant</span>
-      </div>
-      <div className="flex items-center space-x-2">
-        <div className="w-4 h-4 rounded-full flex items-center justify-center bg-green-600 text-white">
-          <MessageSquare size={12} />
-        </div>
-        <span>SMS</span>
-      </div>
-      <div className="flex items-center space-x-2">
-        <div className="w-4 h-4 rounded-full flex items-center justify-center bg-red-600 text-white">
-          <MapPin size={12} />
-        </div>
-        <span>Position web</span>
-      </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- update map legend to display horizontally in the bottom-right corner
- modernize legend styling with clearer icons and text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c5bc94d418832690400e42bf39f0d2