### PR TITLE
Raise legend and remove top map gap

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1737,7 +1737,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
           </div>
         )}
 
-        <div className="pointer-events-none absolute bottom-4 right-4 z-[1000] max-h-[50vh]">
+        <div className="pointer-events-none absolute bottom-24 right-4 z-[1000] max-h-[50vh]">
           <div className="pointer-events-auto max-h-full overflow-y-auto bg-white/90 backdrop-blur-md rounded-xl border border-gray-200 shadow-lg p-4 text-sm text-gray-700">
             <p className="font-bold text-base mb-3 border-b border-gray-200 pb-2">Légende</p>
             <ul className="space-y-2">

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -10,7 +10,7 @@ const MapLegend: React.FC = () => {
   ];
 
     return (
-      <div className="pointer-events-auto absolute bottom-4 left-1/2 -translate-x-1/2 transform bg-white/80 dark:bg-gray-900/80 backdrop-blur-md px-6 py-3 rounded-full shadow-lg flex flex-wrap items-center justify-center gap-4 text-gray-800 dark:text-gray-200 text-sm md:text-base">
+      <div className="pointer-events-auto absolute bottom-24 left-1/2 -translate-x-1/2 transform bg-white/80 dark:bg-gray-900/80 backdrop-blur-md px-6 py-3 rounded-full shadow-lg flex flex-wrap items-center justify-center gap-4 text-gray-800 dark:text-gray-200 text-sm md:text-base">
         {legendItems.map(({ icon: Icon, label, color }) => (
           <div key={label} className="flex items-center gap-2">
             <div className={`w-5 h-5 rounded-full flex items-center justify-center ${color} text-white`}>

--- a/src/index.css
+++ b/src/index.css
@@ -150,6 +150,6 @@
 
 /* Offset layer control from close button */
 .leaflet-top.leaflet-right {
-  margin-top: 3rem;
+  margin-top: 0;
   margin-right: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- move map legends higher so selected numbers remain visible
- remove extra top spacing so expanded map starts flush at the page top

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c5c327643c8326927eb12e24ebbbfd