### PR TITLE
feat(map): make map container relative

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1221,7 +1221,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
             center={center}
             zoom={13}
             zoomControl={false}
-            className="w-full h-full"
+            className="relative w-full h-full"
             style={{ cursor: zoneMode ? 'url("/pen.svg") 0 24, crosshair' : undefined }}
             whenCreated={(map) => (mapRef.current = map)}
             ref={mapRef}


### PR DESCRIPTION
## Summary
- make Leaflet map container `relative` so the map fills the entire screen

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c5cdcced888326bff84618f864aeb3