### PR TITLE
Ensure Leaflet map container fills the page

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1221,8 +1221,11 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
             center={center}
             zoom={13}
             zoomControl={false}
-            className="relative w-full h-full"
-            style={{ cursor: zoneMode ? 'url("/pen.svg") 0 24, crosshair' : undefined }}
+            className="w-full h-full"
+            style={{
+              position: 'relative',
+              cursor: zoneMode ? 'url("/pen.svg") 0 24, crosshair' : undefined
+            }}
             whenCreated={(map) => (mapRef.current = map)}
             ref={mapRef}
           >

--- a/src/index.css
+++ b/src/index.css
@@ -153,3 +153,10 @@
   margin-top: 0;
   margin-right: 0.5rem;
 }
+
+/* Ensure the Leaflet map fills the available space */
+.leaflet-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- set MapContainer style to position relative so Leaflet map stretches across the page
- add CSS rule to keep Leaflet container full width and height

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d0cf5fd483269f477c86f9a74477