### PR TITLE
fix: make leaflet container overflow visible

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -159,4 +159,5 @@
   position: relative;
   width: 100%;
   height: 100%;
+  overflow: visible;
 }


### PR DESCRIPTION
## Summary
- ensure Leaflet map container overflow is visible

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c5d2fe33488326961da27bf0e33ef7