### PR TITLE
Ensure Leaflet container overflow remains visible

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -159,5 +159,5 @@
   position: relative;
   width: 100%;
   height: 100%;
-  overflow: visible;
+  overflow: visible !important;
 }


### PR DESCRIPTION
## Summary
- Use `overflow: visible !important` in Leaflet container to prevent content from being clipped

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d4da0af08326afeace7681cd6948