### PR TITLE
Reverse space-y-6 spacing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -161,3 +161,11 @@
   height: 100%;
   overflow: visible !important;
 }
+
+@layer utilities {
+  .space-y-6 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 1;
+    margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
+  }
+}


### PR DESCRIPTION
## Summary
- override Tailwind's `space-y-6` utility so vertical spacing uses reverse direction

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; attempted `npm install` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5db8a398883268de7345a833f3825