### PR TITLE
Adjust top-0 utility offset

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -163,6 +163,7 @@
 }
 
 @layer utilities {
+  .top-0 { top: 18px; }
   .space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --tw-space-y-reverse: 1;
     margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));


### PR DESCRIPTION
## Summary
- Override Tailwind's `.top-0` utility to use `top: 18px` for a consistent offset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; attempted installation but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c13f1d848326bcc180f714a506c8