### PR TITLE
Remove zone creation button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3379,7 +3379,6 @@ useEffect(() => {
                         onToggleMeetingPoints={() => setShowMeetingPoints((v) => !v)}
                         zoneMode={zoneMode}
                         onZoneCreated={() => setZoneMode(false)}
-                        onToggleZoneMode={() => setZoneMode((z) => !z)}
                       />
                     </div>
                   </div>

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -96,7 +96,6 @@ interface Props {
   onToggleMeetingPoints?: () => void;
   zoneMode?: boolean;
   onZoneCreated?: () => void;
-  onToggleZoneMode?: () => void;
 }
 
 const parseDurationToSeconds = (duration: string): number => {
@@ -408,7 +407,7 @@ const MeetingPointMarker: React.FC<{
   );
 });
 
-const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggleMeetingPoints, zoneMode, onZoneCreated, onToggleZoneMode }) => {
+const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggleMeetingPoints, zoneMode, onZoneCreated }) => {
   if (!points || points.length === 0) return null;
 
   const first = points[0];
@@ -1727,17 +1726,6 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
                 className="w-24"
               />
             </div>
-          </div>
-        )}
-
-        {onToggleZoneMode && (
-          <div className="pointer-events-none absolute bottom-4 left-1/2 transform -translate-x-1/2 z-[1000]">
-            <button
-              onClick={onToggleZoneMode}
-              className="pointer-events-auto px-4 py-2 bg-white/90 backdrop-blur rounded-full shadow border border-gray-300 text-sm font-medium hover:bg-gray-100 transition-colors"
-            >
-              {zoneMode ? 'Annuler' : 'Créer zone'}
-            </button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- remove "Créer zone" button and related toggle prop from CdrMap
- update App to stop passing unused toggle callback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c7c27a70388326bea2329acd3220f1