### PR TITLE
feat: add blacklist management and UI updates

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -20,6 +20,7 @@ import profilesRoutes from './routes/profiles.js';
 import casesRoutes from './routes/cases.js';
 import requestsRoutes from './routes/requests.js';
 import identifiedNumbersRoutes from './routes/identified-numbers.js';
+import blacklistRoutes from './routes/blacklist.js';
 
 // Initialisation de la base de données
 import database from './config/database.js';
@@ -56,6 +57,7 @@ app.use('/api/profiles', profilesRoutes);
 app.use('/api/cases', casesRoutes);
 app.use('/api/requests', requestsRoutes);
 app.use('/api/identified-numbers', identifiedNumbersRoutes);
+app.use('/api/blacklist', blacklistRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -162,6 +162,14 @@ class DatabaseManager {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
       `);
 
+      await this.query(`
+        CREATE TABLE IF NOT EXISTS autres.blacklist (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          number VARCHAR(50) NOT NULL UNIQUE,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
       // Table des dossiers CDR
       await this.query(`
         CREATE TABLE IF NOT EXISTS autres.cdr_cases (

--- a/server/models/Blacklist.js
+++ b/server/models/Blacklist.js
@@ -1,0 +1,22 @@
+import database from '../config/database.js';
+
+class Blacklist {
+  static async list() {
+    return database.query('SELECT id, number, created_at FROM autres.blacklist ORDER BY created_at DESC');
+  }
+
+  static async add(number) {
+    await database.query('INSERT IGNORE INTO autres.blacklist (number) VALUES (?)', [number]);
+  }
+
+  static async remove(id) {
+    await database.query('DELETE FROM autres.blacklist WHERE id = ?', [id]);
+  }
+
+  static async exists(number) {
+    const rows = await database.query('SELECT id FROM autres.blacklist WHERE number = ?', [number]);
+    return rows.length > 0;
+  }
+}
+
+export default Blacklist;

--- a/server/routes/blacklist.js
+++ b/server/routes/blacklist.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import { authenticate } from '../middleware/auth.js';
+import Blacklist from '../models/Blacklist.js';
+
+const router = express.Router();
+
+router.get('/', authenticate, async (req, res) => {
+  const isAdmin = req.user?.admin === 1 || req.user?.admin === '1' || req.user?.admin === true;
+  if (!isAdmin) return res.status(403).json({ error: 'Accès refusé' });
+  const list = await Blacklist.list();
+  res.json(list);
+});
+
+router.post('/', authenticate, async (req, res) => {
+  const isAdmin = req.user?.admin === 1 || req.user?.admin === '1' || req.user?.admin === true;
+  if (!isAdmin) return res.status(403).json({ error: 'Accès refusé' });
+  const { number } = req.body;
+  if (!number || !String(number).trim()) {
+    return res.status(400).json({ error: 'Numéro requis' });
+  }
+  await Blacklist.add(String(number).trim());
+  const list = await Blacklist.list();
+  res.json(list);
+});
+
+router.delete('/:id', authenticate, async (req, res) => {
+  const isAdmin = req.user?.admin === 1 || req.user?.admin === '1' || req.user?.admin === true;
+  if (!isAdmin) return res.status(403).json({ error: 'Accès refusé' });
+  const id = parseInt(req.params.id, 10);
+  if (!id) {
+    return res.status(400).json({ error: 'ID invalide' });
+  }
+  await Blacklist.remove(id);
+  const list = await Blacklist.list();
+  res.json(list);
+});
+
+export default router;

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { authenticate } from '../middleware/auth.js';
 import CaseService from '../services/CaseService.js';
+import Blacklist from '../models/Blacklist.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -78,6 +79,9 @@ router.get('/:id/search', authenticate, async (req, res) => {
     const identifier = req.query.phone || req.query.imei;
     if (!identifier) {
       return res.status(400).json({ error: 'Paramètre phone ou imei requis' });
+    }
+    if (await Blacklist.exists(String(identifier).trim())) {
+      return res.status(403).json({ error: 'Numéro blacklisté' });
     }
     const { start, end, startTime, endTime, direction = 'both', type = 'both', location } = req.query;
     const isValidDate = (str) => {

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -86,8 +86,6 @@ class ProfileService {
       const doc = new PDFDocument({ margin: 50 });
       const chunks = [];
 
-      // Removed application name footer to keep PDF layout clean
-
       return await new Promise(async (resolve, reject) => {
         doc.on('data', chunk => chunks.push(chunk));
         doc.on('end', () => resolve(Buffer.concat(chunks)));
@@ -98,6 +96,17 @@ class ProfileService {
         const headerHeight = 80;
         const margin = doc.page.margins.left;
         const innerWidth = pageWidth - margin * 2;
+
+        const addFooter = () => {
+          doc
+            .fontSize(10)
+            .fillColor('#6B7280')
+            .text('Vegeta', 0, doc.page.height - 40, { align: 'center' });
+          doc.fillColor('black');
+        };
+        addFooter();
+        doc.on('pageAdded', addFooter);
+
         doc.rect(0, 0, pageWidth, headerHeight).fill('#4F46E5');
         doc
           .fillColor('white')
@@ -215,6 +224,7 @@ class ProfileService {
             .text(String(profile.comment), textX, y, { width: textWidth });
         }
 
+        addFooter();
         doc.end();
       });
     } catch (error) {

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -32,8 +32,7 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
           <div className="bg-gradient-to-r from-blue-500 to-blue-700 p-4 flex items-center">
             <User className="w-8 h-8 text-white mr-3" />
             <div>
-              <h3 className="text-xl font-semibold text-white">{hit.table}</h3>
-              <p className="text-blue-100 text-sm">{hit.database}</p>
+              <h3 className="text-xl font-semibold text-white">Résultat {idx + 1}</h3>
             </div>
             <span className="ml-auto inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white/20 text-white">
               <Activity className="w-3 h-3 mr-1" />


### PR DESCRIPTION
## Summary
- rename CDR cases to "Opérations" and drop Liens Utiles menu
- add admin-only Black List management and block searches for blacklisted numbers
- show app name on profile PDFs and hide source tables in search results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d44d1e1483268e12e11564804d39