### PR TITLE
feat: confirm deletions and track page views in logs

### DIFF
--- a/server/routes/logs.js
+++ b/server/routes/logs.js
@@ -17,6 +17,22 @@ router.get('/', authenticate, async (req, res) => {
   res.json({ logs: rows, total });
 });
 
+router.post('/', authenticate, async (req, res) => {
+  const { action, details, duration_ms } = req.body;
+  try {
+    await UserLog.create({
+      user_id: req.user.id,
+      action,
+      details: details ? JSON.stringify(details) : null,
+      duration_ms: duration_ms || null
+    });
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Erreur création log:', err);
+    res.status(500).json({ error: 'Erreur création log' });
+  }
+});
+
 router.get('/export', authenticate, async (req, res) => {
   const isAdmin = req.user?.admin === 1 || req.user?.admin === '1' || req.user?.admin === true;
   if (!isAdmin) return res.status(403).json({ error: 'Accès refusé' });

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -57,8 +57,10 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
 
   const addCategory = () =>
     setCategories(prev => [...prev, { title: '', fields: [{ key: '', value: '' }] }]);
-  const removeCategory = (idx: number) =>
+  const removeCategory = (idx: number) => {
+    if (!window.confirm('Supprimer cette catégorie ?')) return;
     setCategories(prev => prev.filter((_, i) => i !== idx));
+  };
   const updateCategoryTitle = (idx: number, title: string) => {
     setCategories(prev => {
       const updated = [...prev];
@@ -75,6 +77,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ initialValues = {}, profileId
     });
   };
   const removeField = (catIdx: number, fieldIdx: number) => {
+    if (!window.confirm('Supprimer ce champ ?')) return;
     setCategories(prev => {
       const updated = [...prev];
       updated[catIdx].fields = updated[catIdx].fields.filter((_, i) => i !== fieldIdx);

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -62,6 +62,7 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit }) => {
   }, [load]);
 
   const remove = async (id: number) => {
+    if (!window.confirm('Supprimer ce profil ?')) return;
     const token = localStorage.getItem('token');
     await fetch(`/api/profiles/${id}`, {
       method: 'DELETE',


### PR DESCRIPTION
## Summary
- add confirmation dialogs to profile deletion actions
- log page visits and expose page/profile info in admin logs
- allow viewing profiles directly from log entries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c7e2c786bc83268d58d6420c6918b0