### PR TITLE
Rename platform to SORA and improve PDF export

### DIFF
--- a/server/config/database.cjs
+++ b/server/config/database.cjs
@@ -4,7 +4,20 @@ const fs = require('fs');
 
 class DatabaseManager {
   constructor() {
-    this.dbPath = path.join(__dirname, '../../data/sora.db');
+    const dataDir = path.join(__dirname, '../../data');
+    const newDbPath = path.join(dataDir, 'sora.db');
+    const oldDbPath = path.join(dataDir, 'vegeta.db');
+
+    // Preserve existing data by migrating the old database file if needed
+    if (fs.existsSync(oldDbPath) && !fs.existsSync(newDbPath)) {
+      try {
+        fs.renameSync(oldDbPath, newDbPath);
+      } catch (err) {
+        console.error('❌ Erreur lors de la migration de la base de données:', err);
+      }
+    }
+
+    this.dbPath = newDbPath;
     this.db = null;
     this.init();
   }


### PR DESCRIPTION
## Summary
- rename platform references from VEGETA to SORA and update database file name
- prevent PDF export stack overflow and rename footer
- require confirmation before removing a blacklisted number
- migrate existing SQLite database files to preserve data

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node - <<'NODE'` *(fails: Cannot find module 'pdfkit')*


------
https://chatgpt.com/codex/tasks/task_e_68c7ec54b2408326a8df69ac13035e96