### PR TITLE
feat: refine map visibility and pdf footer

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -103,8 +103,9 @@ class ProfileService {
         const addFooter = () => {
           doc
             .fontSize(10)
-            .fillColor('#6B7280')
+            .fillColor('#4F46E5')
             .text('SORA', 0, doc.page.height - 40, {
+              width: pageWidth,
               align: 'center',
               lineBreak: false
             });

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1789,8 +1789,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
                   </li>
                 ))
               ) : selectedSource === null &&
-                sourceNumbers.length > 1 &&
-                (activeInfo === 'recent' || activeInfo === 'popular') ? (
+                sourceNumbers.length > 1 ? (
                 sourceNumbers.map((n) => (
                   <li key={n} className="flex items-center space-x-2">
                     <span


### PR DESCRIPTION
## Summary
- show source visibility toggles without depending on recent or popular map filters
- center and color PDF profile footer with platform theme

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7f061d18c83269ba5fdd02b4d5130