### PR TITLE
Fix PDF footer placement to prevent infinite page addition

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -101,10 +101,11 @@ class ProfileService {
         const innerWidth = pageWidth - margin * 2;
 
         const addFooter = () => {
+          const footerY = doc.page.height - doc.page.margins.bottom - 10;
           doc
             .fontSize(10)
             .fillColor('#4F46E5')
-            .text('SORA', 0, doc.page.height - 40, {
+            .text('SORA', 0, footerY, {
               width: pageWidth,
               align: 'center',
               lineBreak: false


### PR DESCRIPTION
## Summary
- avoid writing the footer outside page bounds in generated profile PDFs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c7f2139ecc8326a2b1450aafb286ba