### PR TITLE
Fix PDF footer placement to prevent overflow

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -101,16 +101,20 @@ class ProfileService {
         const innerWidth = pageWidth - margin * 2;
 
         const addFooter = () => {
-          const footerY = doc.page.height - doc.page.margins.bottom - 10;
-          doc
-            .fontSize(10)
-            .fillColor('#4F46E5')
-            .text('SORA', 0, footerY, {
-              width: pageWidth,
-              align: 'center',
-              lineBreak: false
-            });
-          doc.fillColor('black');
+          const { x, y } = doc;
+          const size = doc._fontSize;
+          const color = doc._fillColor;
+          doc.fontSize(10).fillColor('#4F46E5');
+          const footerY =
+            doc.page.height - doc.page.margins.bottom - doc.currentLineHeight();
+          doc.text('SORA', 0, footerY, {
+            width: pageWidth,
+            align: 'center',
+            lineBreak: false
+          });
+          doc.fontSize(size).fillColor(color);
+          doc.x = x;
+          doc.y = y;
         };
         addFooter();
         doc.on('pageAdded', addFooter);


### PR DESCRIPTION
## Summary
- keep PDF footer within page margins without advancing cursor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c7f6549a3c8326b76feb1964e47c49