### PR TITLE
Allow administrators to reset passwords and disable accounts

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -10,9 +10,9 @@ export const authenticate = async (req, res, next) => {
   try {
     const decoded = User.verifyToken(token);
     const user = await User.findById(decoded.id);
-    
-    if (!user) {
-      return res.status(401).json({ error: 'Utilisateur non trouvé' });
+
+    if (!user || user.active !== 1) {
+      return res.status(401).json({ error: 'Utilisateur non trouvé ou désactivé' });
     }
 
     req.user = user;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -4,19 +4,20 @@ import database from '../config/database.js';
 
 class User {
   static async create(userData) {
-    const { login, mdp, admin = 0 } = userData;
+    const { login, mdp, admin = 0, active = 1 } = userData;
     const hashedPassword = await bcrypt.hash(mdp, 12);
-    
+
     const result = await database.query(
-      'INSERT INTO autres.users (login, mdp, admin) VALUES (?, ?, ?)',
-      [login, hashedPassword, admin]
+      'INSERT INTO autres.users (login, mdp, admin, active) VALUES (?, ?, ?, ?)',
+      [login, hashedPassword, admin, active]
     );
-    
-    return { 
-      id: result.insertId, 
-      login, 
-      mdp: hashedPassword, 
-      admin 
+
+    return {
+      id: result.insertId,
+      login,
+      mdp: hashedPassword,
+      admin,
+      active
     };
   }
 
@@ -62,7 +63,7 @@ class User {
 
   static async findAll() {
     return await database.query(
-      'SELECT id, login, admin FROM autres.users ORDER BY id DESC'
+      'SELECT id, login, admin, active FROM autres.users ORDER BY id DESC'
     );
   }
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -20,6 +20,10 @@ router.post('/login', async (req, res) => {
       return res.status(401).json({ error: 'Identifiants invalides' });
     }
 
+    if (user.active !== 1) {
+      return res.status(403).json({ error: 'Compte désactivé' });
+    }
+
     const isValidPassword = await User.validatePassword(password, user.mdp);
 
     if (!isValidPassword) {
@@ -75,7 +79,7 @@ router.get('/verify', async (req, res) => {
     const decoded = User.verifyToken(token);
     const user = await User.findById(decoded.id);
 
-    if (!user) {
+    if (!user || user.active !== 1) {
       return res.status(401).json({ error: 'Utilisateur non trouvé' });
     }
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -87,7 +87,7 @@ router.post('/', authenticate, requireAdmin, async (req, res) => {
 router.patch('/:id', authenticate, requireAdmin, async (req, res) => {
   try {
     const userId = parseInt(req.params.id);
-    const { login, admin } = req.body;
+    const { login, admin, password, active } = req.body;
 
     if (isNaN(userId)) {
       return res.status(400).json({ error: 'ID utilisateur invalide' });
@@ -96,6 +96,13 @@ router.patch('/:id', authenticate, requireAdmin, async (req, res) => {
     const updates = {};
     if (login !== undefined) updates.login = login;
     if (admin !== undefined) updates.admin = admin;
+    if (active !== undefined) updates.active = active ? 1 : 0;
+    if (password !== undefined) {
+      if (password.length < 8) {
+        return res.status(400).json({ error: 'Le mot de passe doit contenir au moins 8 caractères' });
+      }
+      updates.mdp = password;
+    }
 
     if (Object.keys(updates).length === 0) {
       return res.status(400).json({ error: 'Aucune mise à jour fournie' });


### PR DESCRIPTION
## Summary
- allow admin to reset user passwords and update account status
- prevent disabled users from authenticating

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c7f751adb883269d585796ba1e0dda