### PR TITLE
fix: ensure admin account active and update tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SORA - Solution d'Observation et de Recherche Avancée</title>
+    <title>SORA - Solution Opérationnelle de Recherche Avancée</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SORA - Solution d'Observation et de Recherche Avancée</title>
+    <title>SORA - Solution Opérationnelle de Recherche Avancée</title>
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -53,9 +53,15 @@ class DatabaseManager {
           login VARCHAR(255) UNIQUE NOT NULL,
           mdp VARCHAR(255) NOT NULL,
           admin TINYINT(1) DEFAULT 0,
+          active TINYINT(1) DEFAULT 1,
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
           updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
+      await this.query(`
+        ALTER TABLE autres.users
+        ADD COLUMN IF NOT EXISTS active TINYINT(1) DEFAULT 1 AFTER admin
       `);
       
       // Créer la table search_logs

--- a/server/scripts/init-database.js
+++ b/server/scripts/init-database.js
@@ -23,8 +23,8 @@ async function initDatabase() {
     const hashedPassword = await bcrypt.hash('admin123', 12);
     
     await database.query(
-      'INSERT INTO autres.users (login, mdp, admin) VALUES (?, ?, ?)',
-      ['admin', hashedPassword, 1]
+      'INSERT INTO autres.users (login, mdp, admin, active) VALUES (?, ?, ?, ?)',
+      ['admin', hashedPassword, 1, 1]
     );
     
     console.log('✅ Utilisateur admin créé avec succès');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2033,7 +2033,7 @@ useEffect(() => {
                   <Database className="h-8 w-8 text-white" />
                 </div>
                 <h2 className="text-2xl font-bold text-white">SORA</h2>
-                <p className="text-blue-100 mt-1">Solution d'Observation et de Recherche Avancée</p>
+                <p className="text-blue-100 mt-1">Solution Opérationnelle de Recherche Avancée</p>
               </div>
             </div>
             
@@ -2271,7 +2271,7 @@ useEffect(() => {
               {sidebarOpen && (
                 <div className="ml-3">
                   <h1 className="text-xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-700 bg-clip-text text-transparent">SORA</h1>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Solution d'Observation et de Recherche Avancée</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">Solution Opérationnelle de Recherche Avancée</p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- add `active` column to users table and ensure admin inserted with active status
- rename tagline to "Solution Opérationnelle de Recherche Avancée"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found; dependencies missing)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f9907a588326b4809c9fc5cbc9f1