### PR TITLE
fix: ensure admin account active and update tagline

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -59,11 +59,18 @@ class DatabaseManager {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
       `);
 
-      await this.query(`
-        ALTER TABLE autres.users
-        ADD COLUMN IF NOT EXISTS active TINYINT(1) DEFAULT 1 AFTER admin
+      const hasActive = await this.queryOne(`
+        SELECT 1 FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = 'autres' AND TABLE_NAME = 'users' AND COLUMN_NAME = 'active'
       `);
-      
+
+      if (!hasActive) {
+        await this.query(`
+          ALTER TABLE autres.users
+          ADD COLUMN active TINYINT(1) DEFAULT 1 AFTER admin
+        `);
+      }
+
       // Créer la table search_logs
       await this.query(`
         CREATE TABLE IF NOT EXISTS autres.search_logs (


### PR DESCRIPTION
## Summary
- add `active` column to users table and ensure admin inserted with active status
- rename tagline to "Solution Opérationnelle de Recherche Avancée"
- check `information_schema.COLUMNS` before altering `users` table for `active` column

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fba2944083269eabcd2a0fa50e4f