### PR TITLE
fix: avoid syntax error when adding active column

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -65,10 +65,16 @@ class DatabaseManager {
       `);
 
       if (!hasActive) {
-        await this.query(`
-          ALTER TABLE autres.users
-          ADD COLUMN active TINYINT(1) DEFAULT 1 AFTER admin
-        `);
+        try {
+          await this.pool.execute(`
+            ALTER TABLE autres.users
+            ADD COLUMN active TINYINT(1) DEFAULT 1 AFTER admin
+          `);
+        } catch (error) {
+          if (error.code !== 'ER_DUP_FIELDNAME') {
+            throw error;
+          }
+        }
       }
 
       // Créer la table search_logs


### PR DESCRIPTION
## Summary
- safeguard adding `active` column to `users` table by checking existing schema
- swallow duplicate-column errors so initialization works on older MySQL versions

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fef9e04083268b0b654464e7c5bb