### PR TITLE
Fix hide elements button to immediately hide base markers

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -774,17 +774,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
     hiddenLocations
   ]);
 
-  const showBaseMarkers = useMemo(
-    () =>
-      !(
-        activeInfo === 'recent' ||
-        activeInfo === 'popular' ||
-        showMeetingPoints ||
-        showSimilar
-      ) ||
-      showOthers,
-    [activeInfo, showMeetingPoints, showSimilar, showOthers]
-  );
+  const showBaseMarkers = useMemo(() => showOthers, [showOthers]);
 
   const routePositions = useMemo(() => {
     if (!showRoute) return [];


### PR DESCRIPTION
## Summary
- ensure the "Masquer les éléments" control directly toggles base marker visibility
- prevent the hide elements toggle from depending on the selected info tab

## Testing
- npm run lint *(fails: missing @eslint/js package)*

------
https://chatgpt.com/codex/tasks/task_e_68c926187bf08326b5ed7ab10c5c2053