### PR TITLE
Update profile editor header and refresh branding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ import ProfileList from './components/ProfileList';
 import ProfileForm from './components/ProfileForm';
 import CdrMap from './components/CdrMap';
 import LinkDiagram from './components/LinkDiagram';
+import SoraLogo from './components/SoraLogo';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip, Legend);
 
@@ -2062,8 +2063,8 @@ useEffect(() => {
           <div className="bg-white shadow-2xl rounded-2xl overflow-hidden">
             <div className="bg-gradient-to-r from-blue-600 to-blue-700 px-8 py-6">
               <div className="text-center">
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-white/20 rounded-full mb-4">
-                  <Database className="h-8 w-8 text-white" />
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-white/20 rounded-full mb-4 text-white">
+                  <SoraLogo className="h-10 w-10" />
                 </div>
                 <h2 className="text-2xl font-bold text-white">SORA</h2>
                 <p className="text-blue-100 mt-1">Solution Opérationnelle de Recherche Avancée</p>
@@ -2298,8 +2299,8 @@ useEffect(() => {
         <div className="p-6 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between">
             <div className={`flex items-center ${!sidebarOpen && 'justify-center'}`}>
-              <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-600 to-blue-700 rounded-lg">
-                <Database className="h-6 w-6 text-white" />
+              <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-blue-600 to-blue-700 rounded-lg text-white">
+                <SoraLogo className="h-7 w-7" />
               </div>
               {sidebarOpen && (
                 <div className="ml-3">
@@ -3755,7 +3756,6 @@ useEffect(() => {
                 <h2 className="text-2xl font-bold text-center text-gray-800">
                   {editingProfileId ? 'Modifier la fiche de profil' : 'Créer une fiche de profil'}
                 </h2>
-                <p className="mb-6 text-center text-gray-500">Vegata</p>
                 <ProfileForm
                   initialValues={profileDefaults}
                   profileId={editingProfileId || undefined}

--- a/src/components/SoraLogo.tsx
+++ b/src/components/SoraLogo.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface SoraLogoProps {
+  className?: string;
+}
+
+const SoraLogo: React.FC<SoraLogoProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 64 64"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path
+      d="M16 24 L44 12"
+      stroke="currentColor"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+    <path
+      d="M16 24 L48 48"
+      stroke="currentColor"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+    <path
+      d="M44 12 L48 48"
+      stroke="currentColor"
+      strokeWidth="4"
+      strokeLinecap="round"
+    />
+    <circle cx="16" cy="24" r="6" fill="currentColor" />
+    <circle cx="44" cy="12" r="6" fill="currentColor" />
+    <circle cx="48" cy="48" r="6" fill="currentColor" />
+  </svg>
+);
+
+export default SoraLogo;


### PR DESCRIPTION
## Summary
- add a reusable SoraLogo SVG component to mirror the new branding icon
- replace the database icon with the Sora logo in the authentication view and sidebar header
- remove the obsolete "Vegata" subtitle from the profile form header

## Testing
- `npm install` *(fails: 403 Forbidden when downloading @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68c9746bda8c8326aa2a1689f35c5508