### PR TITLE
Remove SORA logo tagline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2067,7 +2067,6 @@ useEffect(() => {
                   <SoraLogo className="h-10 w-10" />
                 </div>
                 <h2 className="text-2xl font-bold text-white">SORA</h2>
-                <p className="text-blue-100 mt-1">Solution Opérationnelle de Recherche Avancée</p>
               </div>
             </div>
             
@@ -2305,7 +2304,6 @@ useEffect(() => {
               {sidebarOpen && (
                 <div className="ml-3">
                   <h1 className="text-xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-700 bg-clip-text text-transparent">SORA</h1>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">Solution Opérationnelle de Recherche Avancée</p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- remove the "Solution Opérationnelle de Recherche Avancée" tagline from the login card logo
- remove the tagline from the sidebar logo to match the new branding

## Testing
- npm install *(fails: 403 Forbidden when downloading @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68c97cf5e90c832693b6ef448919bbdd