### PR TITLE
style: modernize routes legend and controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import {
   Phone,
   Building2,
   Globe,
-  Car,
+  CarFront,
   Ban,
   UserCircle,
   List,
@@ -41,7 +41,8 @@ import {
   PhoneOutgoing,
   MessageSquare,
   MapPin,
-  AlertTriangle
+  AlertTriangle,
+  Share2
 } from 'lucide-react';
 import ToggleSwitch from './components/ToggleSwitch';
 
@@ -2240,7 +2241,7 @@ useEffect(() => {
           <ToggleSwitch
             label={
               <>
-                <Car className="w-4 h-4" />
+                <CarFront className="w-4 h-4 text-indigo-500" />
                 <span>Itinéraire</span>
               </>
             }
@@ -2249,21 +2250,23 @@ useEffect(() => {
             activeColor="peer-checked:bg-indigo-500 dark:peer-checked:bg-indigo-500"
           />
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-3">
           <button
             type="submit"
             disabled={cdrLoading}
-            className="px-6 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-full hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 transition-transform transform hover:scale-105 active:scale-95"
+            className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-sky-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            Rechercher
+            <Search className="h-4 w-4" />
+            <span>Rechercher</span>
           </button>
           {caseFiles.filter((f) => f.cdr_number).length >= 2 && (
             <button
               type="button"
-              className="px-6 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-full hover:from-blue-700 hover:to-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-transform transform hover:scale-105 active:scale-95"
+              className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-fuchsia-500 via-rose-500 to-orange-400 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-rose-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-fuchsia-500"
               onClick={handleLinkDiagram}
             >
-              Diagramme des liens
+              <Share2 className="h-4 w-4" />
+              <span>Diagramme des liens</span>
             </button>
           )}
         </div>
@@ -2402,7 +2405,7 @@ useEffect(() => {
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-blue-600 dark:hover:text-white dark:active:bg-blue-600 dark:active:text-white'
               } ${!sidebarOpen && 'justify-center'}`}
             >
-              <Car className="h-5 w-5" />
+              <CarFront className="h-5 w-5" />
               {sidebarOpen && <span className="ml-3">Véhicules</span>}
             </button>
 
@@ -3239,7 +3242,7 @@ useEffect(() => {
 
           {currentPage === 'vehicules' && (
             <div className="space-y-6">
-              <PageHeader icon={<Car className="h-6 w-6" />} title="Véhicules" />
+              <PageHeader icon={<CarFront className="h-6 w-6" />} title="Véhicules" />
               <input
                 type="text"
                 placeholder="Rechercher..."

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -17,7 +17,7 @@ import {
   MessageSquare,
   MapPin,
   ArrowRight,
-  Car,
+  CarFront,
   Layers,
   Users,
   Clock,
@@ -175,7 +175,7 @@ const getArrowIcon = (angle: number) => {
   const size = 16;
   const icon = (
     <div style={{ transform: `rotate(${angle}deg)` }}>
-      <ArrowRight size={size} className="text-blue-600" />
+      <ArrowRight size={size} className="text-indigo-500" />
     </div>
   );
   return L.divIcon({
@@ -992,21 +992,22 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
   };
 
   const carIcon = useMemo(() => {
-    const size = 32;
+    const size = 36;
     const icon = (
       <div
         style={{
           transform: `rotate(${carAngle}deg)`,
-          backgroundColor: '#2563eb',
-          borderRadius: '9999px',
+          background: 'linear-gradient(135deg, #312e81, #2563eb, #0ea5e9)',
+          borderRadius: '14px',
           width: size,
           height: size,
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center'
+          justifyContent: 'center',
+          boxShadow: '0 12px 24px rgba(79, 70, 229, 0.3)'
         }}
       >
-        <Car size={16} className="text-white" />
+        <CarFront size={18} className="text-white" />
       </div>
     );
     return L.divIcon({
@@ -1234,7 +1235,16 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
           )}
           <ZoneSelector />
         {drawing && currentPoints.length > 0 && (
-          <Polyline positions={currentPoints} pathOptions={{ color: 'blue' }} />
+          <Polyline
+            positions={currentPoints}
+            pathOptions={{
+              color: '#6366f1',
+              weight: 2,
+              opacity: 0.75,
+              dashArray: '6 3',
+              lineCap: 'round'
+            }}
+          />
         )}
         {zoneShape && (
           <Polygon positions={zoneShape} pathOptions={{ color: 'blue' }} />
@@ -1406,7 +1416,17 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
               <MeetingPointMarker key={`meeting-${idx}`} mp={mp} />
             ))}
         {showBaseMarkers && showRoute && routePositions.length > 1 && (
-          <Polyline positions={routePositions} color="black" />
+          <Polyline
+            positions={routePositions}
+            pathOptions={{
+              color: '#4f46e5',
+              weight: 2.5,
+              opacity: 0.85,
+              dashArray: '10 6',
+              lineJoin: 'round',
+              lineCap: 'round'
+            }}
+          />
         )}
         {showBaseMarkers && showRoute && routePositions.length > 0 && (
           <Marker position={routePositions[0]} icon={startIcon} />
@@ -1436,8 +1456,13 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
                 <Polyline
                   key={`similar-${idx}-${src}`}
                   positions={seg.positions}
-                  color={colorMap.get(src) || '#ef4444'}
-                  weight={4}
+                  pathOptions={{
+                    color: colorMap.get(src) || '#8b5cf6',
+                    weight: 2.5,
+                    opacity: 0.7,
+                    dashArray: '4 8',
+                    lineCap: 'round'
+                  }}
                 />
               ) : null
             )
@@ -1702,7 +1727,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
         {showBaseMarkers && showRoute && (
           <div className="pointer-events-none absolute bottom-12 left-0 right-0 z-[1000] flex justify-center">
             <div className="pointer-events-auto flex items-center gap-2 bg-white/90 backdrop-blur rounded-full shadow px-4 py-2">
-              <Car className="w-4 h-4 text-blue-600" />
+              <CarFront className="w-4 h-4 text-indigo-500" />
               <label htmlFor="speed" className="font-semibold text-sm">
                 {speed}x
               </label>

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { PhoneIncoming, PhoneOutgoing, MessageSquare, MapPin } from 'lucide-react';
+import { PhoneIncoming, PhoneOutgoing, MessageSquare, MapPin, Route } from 'lucide-react';
 
 const MapLegend: React.FC = () => {
   const legendItems = [
     { icon: PhoneIncoming, label: 'Appel entrant', color: 'bg-green-600' },
     { icon: PhoneOutgoing, label: 'Appel sortant', color: 'bg-blue-600' },
     { icon: MessageSquare, label: 'SMS', color: 'bg-green-600' },
-    { icon: MapPin, label: 'Position web', color: 'bg-red-600' }
+    { icon: MapPin, label: 'Position web', color: 'bg-red-600' },
+    { icon: Route, label: 'Trajectoires similaires', color: 'bg-indigo-600' }
   ];
 
     return (


### PR DESCRIPTION
## Summary
- add legend entry for similar itineraries and modernize map routing visuals, including refreshed car marker and route styling
- update itinerary controls and navigation to use the new car icon treatment
- restyle search and link-diagram actions with contemporary gradient buttons and supporting icons

## Testing
- `npm run lint` *(fails: missing @eslint/js package due to restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca70b837a48326b35b043fc3820a87