### PR TITLE
Replace unavailable CarFront icon with Car

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import {
   Phone,
   Building2,
   Globe,
-  CarFront,
+  Car,
   Ban,
   UserCircle,
   List,
@@ -2241,7 +2241,7 @@ useEffect(() => {
           <ToggleSwitch
             label={
               <>
-                <CarFront className="w-4 h-4 text-indigo-500" />
+                <Car className="w-4 h-4 text-indigo-500" />
                 <span>Itinéraire</span>
               </>
             }
@@ -2405,7 +2405,7 @@ useEffect(() => {
                   : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-blue-600 dark:hover:text-white dark:active:bg-blue-600 dark:active:text-white'
               } ${!sidebarOpen && 'justify-center'}`}
             >
-              <CarFront className="h-5 w-5" />
+              <Car className="h-5 w-5" />
               {sidebarOpen && <span className="ml-3">Véhicules</span>}
             </button>
 
@@ -3242,7 +3242,7 @@ useEffect(() => {
 
           {currentPage === 'vehicules' && (
             <div className="space-y-6">
-              <PageHeader icon={<CarFront className="h-6 w-6" />} title="Véhicules" />
+              <PageHeader icon={<Car className="h-6 w-6" />} title="Véhicules" />
               <input
                 type="text"
                 placeholder="Rechercher..."

--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -17,7 +17,7 @@ import {
   MessageSquare,
   MapPin,
   ArrowRight,
-  CarFront,
+  Car,
   Layers,
   Users,
   Clock,
@@ -1007,7 +1007,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
           boxShadow: '0 12px 24px rgba(79, 70, 229, 0.3)'
         }}
       >
-        <CarFront size={18} className="text-white" />
+        <Car size={18} className="text-white" />
       </div>
     );
     return L.divIcon({
@@ -1727,7 +1727,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
         {showBaseMarkers && showRoute && (
           <div className="pointer-events-none absolute bottom-12 left-0 right-0 z-[1000] flex justify-center">
             <div className="pointer-events-auto flex items-center gap-2 bg-white/90 backdrop-blur rounded-full shadow px-4 py-2">
-              <CarFront className="w-4 h-4 text-indigo-500" />
+              <Car className="w-4 h-4 text-indigo-500" />
               <label htmlFor="speed" className="font-semibold text-sm">
                 {speed}x
               </label>


### PR DESCRIPTION
## Summary
- replace lucide-react CarFront icon imports with the widely available Car icon
- update all component usages to reference the Car icon instead of CarFront

## Testing
- npm install *(fails: registry returned 403 Forbidden for @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7758a03083268c77edc91b73f625