### PR TITLE
Ensure identification notifications reach requesting user

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,6 +173,7 @@ interface ProfileData {
 
 interface IdentificationRequest {
   id: number;
+  user_id?: number;
   phone: string;
   status: string;
   user_login?: string;
@@ -1958,7 +1959,11 @@ useEffect(() => {
         });
       }
 
-      if (!isCurrentAdmin && request.user_login === currentUser.login && request.status === 'identified') {
+      if (
+        !isCurrentAdmin &&
+        request.status === 'identified' &&
+        (request.user_id === currentUser.id || request.user_login === currentUser.login)
+      ) {
         items.push({
           id: `user-${request.id}`,
           requestId: request.id,


### PR DESCRIPTION
## Summary
- include the request owner's identifier in the identification request type
- treat identified requests as user notifications when either the id or login matches the current user

## Testing
- npm run lint *(fails: missing dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8800d3148326a88ec6193d115cf9