### PR TITLE
feat: allow renaming attachments and archive toggle

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -144,6 +144,20 @@ class ProfileService {
     return this.withAttachments(updated);
   }
 
+  async setArchiveStatus(id, archived, user) {
+    const existing = await Profile.findById(id);
+    if (!existing) throw new Error('Profil non trouvé');
+    const isAdmin = user.admin === 1 || user.admin === '1' || user.admin === true;
+    if (!isAdmin && existing.user_id !== user.id) {
+      throw new Error('Accès refusé');
+    }
+    const updateData = {
+      archived_at: archived ? new Date() : null
+    };
+    const updated = await Profile.update(id, updateData);
+    return this.withAttachments(updated);
+  }
+
   async delete(id, user) {
     const existing = await Profile.findById(id);
     if (!existing) throw new Error('Profil non trouvé');


### PR DESCRIPTION
## Summary
- allow users to rename new attachments before uploading in the profile form and show the computed filename
- add archive/désarchiver controls in the profile list with status highlighting and preview badge
- expose a backend endpoint to persist archive state and update the service logic accordingly

## Testing
- npm run lint *(fails: missing @eslint/js because packages cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9e6e4fcc8326b0b068f9e4d1fae3