### PR TITLE
fix: proxy profile media without bearer token leakage

### DIFF
--- a/src/hooks/useProtectedFileUrl.ts
+++ b/src/hooks/useProtectedFileUrl.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+const normalizePath = (relativePath: string) =>
+  relativePath.startsWith('/') ? relativePath : `/${relativePath}`;
+
+export const useProtectedFileUrl = (relativePath?: string | null) => {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isActive = true;
+    let currentUrl: string | null = null;
+
+    const load = async () => {
+      if (!relativePath) {
+        setObjectUrl(null);
+        return;
+      }
+
+      const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+      if (!token) {
+        setObjectUrl(null);
+        return;
+      }
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`
+      };
+
+      try {
+        const res = await fetch(normalizePath(relativePath), { headers });
+        if (!res.ok) {
+          throw new Error('Failed to fetch protected asset');
+        }
+        const blob = await res.blob();
+        if (!isActive) {
+          return;
+        }
+        currentUrl = URL.createObjectURL(blob);
+        setObjectUrl(currentUrl);
+      } catch (error) {
+        if (currentUrl) {
+          URL.revokeObjectURL(currentUrl);
+          currentUrl = null;
+        }
+        if (isActive) {
+          setObjectUrl(null);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      isActive = false;
+      if (currentUrl) {
+        URL.revokeObjectURL(currentUrl);
+      }
+    };
+  }, [relativePath]);
+
+  return objectUrl;
+};
+
+export default useProtectedFileUrl;

--- a/src/utils/protectedAssets.ts
+++ b/src/utils/protectedAssets.ts
@@ -1,0 +1,38 @@
+const normalizePath = (relativePath: string) =>
+  relativePath.startsWith('/') ? relativePath : `/${relativePath}`;
+
+const getAuthHeaders = () => {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+};
+
+export const fetchProtectedBlob = async (relativePath: string) => {
+  const headers = getAuthHeaders();
+  if (!headers.Authorization) {
+    throw new Error('Missing authentication token');
+  }
+  const res = await fetch(normalizePath(relativePath), { headers });
+  if (!res.ok) {
+    throw new Error('Unable to fetch protected asset');
+  }
+  return res.blob();
+};
+
+export const downloadProtectedAsset = async (relativePath: string, suggestedName?: string | null) => {
+  const blob = await fetchProtectedBlob(relativePath);
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  const fallbackName = normalizePath(relativePath).split('/').pop() || 'download';
+  anchor.download = suggestedName || fallbackName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};
+
+export default downloadProtectedAsset;


### PR DESCRIPTION
## Summary
- load protected profile photos through authenticated fetches instead of leaking the bearer token in query strings
- add a reusable hook plus helpers for creating object URLs and downloading protected assets
- update profile attachments to fetch-and-download on demand so links no longer expose credentials

## Testing
- npm run lint *(fails: missing @eslint/js package)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9f85db44832682410ef9a47a9c5f