### PR TITLE
fix: restore X icon import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,8 @@ import {
   MapPin,
   AlertTriangle,
   Share2,
-  LayoutDashboard
+  LayoutDashboard,
+  X
 } from 'lucide-react';
 import ToggleSwitch from './components/ToggleSwitch';
 


### PR DESCRIPTION
## Summary
- restore the X icon import from lucide-react so existing usages compile

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68caa53b9dec832680e53fe21e3b12cf