### PR TITLE
Fix overview today search count query

### DIFF
--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -66,7 +66,7 @@ class StatsService {
           userId ? [userId] : []
         ),
         database.queryOne(
-          `SELECT COUNT(*) as count FROM autres.search_logs WHERE search_date >= DATE_SUB(NOW(), INTERVAL HOUR(NOW()) HOUR + MINUTE(NOW()) MINUTE + SECOND(NOW()) SECOND)${userId ? ' AND user_id = ?' : ''}`,
+          `SELECT COUNT(*) as count FROM autres.search_logs WHERE search_date >= DATE(NOW())${userId ? ' AND user_id = ?' : ''}`,
           userId ? [userId] : []
         ),
         userId


### PR DESCRIPTION
## Summary
- compute the overview search count using DATE(NOW()) to avoid invalid MySQL INTERVAL syntax

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caabc805cc83269e19542add2c9f2a