### PR TITLE
Limit fraud detection to CDR-linked numbers

### DIFF
--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -120,7 +120,10 @@ class CaseService {
       ])
     );
 
-    const detections = await this.cdrService.detectNumberChanges(existingCase.name, options);
+    const detections = await this.cdrService.detectNumberChanges(existingCase.name, {
+      ...options,
+      referenceNumbers: Array.from(referenceNumbers)
+    });
     const imeis = detections.map((entry) => {
       const numbers = entry.numbers.map((numberEntry) => {
         const { fileIds, ...rest } = numberEntry;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4274,7 +4274,7 @@ useEffect(() => {
                         </p>
                         {fraudResult.imeis.length === 0 ? (
                           <div className="rounded-xl border border-dashed border-slate-200/80 bg-slate-50/70 p-4 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/40 dark:text-slate-300">
-                            Aucune donnée CDR importée ne permet d'établir une correspondance IMEI/numéro.
+                            Aucun changement de numéro détecté à partir des numéros associés aux CDR importés.
                           </div>
                         ) : (
                           <div className="space-y-4">


### PR DESCRIPTION
## Summary
- ensure fraud detection only analyses IMEIs associated with the CDR reference numbers and filters to actual number changes
- pass case reference numbers down to the detection service so results are scoped correctly and update the UI copy for empty outcomes

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf07ac94f48326b7a6695653b31a41