### PR TITLE
Intégrer la détection de changement de numéro dans la recherche CDR

### DIFF
--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -149,6 +149,21 @@ router.get('/:id/fraud-detection', authenticate, async (req, res) => {
     }
 
     const { start, end } = req.query;
+    const numberParams = req.query.numbers;
+    const targetNumbers = [];
+    if (Array.isArray(numberParams)) {
+      for (const value of numberParams) {
+        if (typeof value === 'string' && value.trim()) {
+          targetNumbers.push(value.trim());
+        }
+      }
+    } else if (typeof numberParams === 'string' && numberParams.trim()) {
+      for (const value of numberParams.split(',')) {
+        if (value && value.trim()) {
+          targetNumbers.push(value.trim());
+        }
+      }
+    }
     const isValidDate = (str) => {
       if (!str) return false;
       const regex = /^\d{4}-\d{2}-\d{2}$/;
@@ -168,7 +183,8 @@ router.get('/:id/fraud-detection', authenticate, async (req, res) => {
       caseId,
       {
         startDate: start || null,
-        endDate: end || null
+        endDate: end || null,
+        targetNumbers
       },
       req.user
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -832,6 +832,11 @@ const App: React.FC = () => {
     );
   }, [fraudResult]);
 
+  useEffect(() => {
+    setFraudResult(null);
+    setFraudError('');
+  }, [selectedCase, cdrIdentifiers]);
+
   const normalizeCdrNumber = useCallback((value: string) => {
     let sanitized = value.trim();
     if (!sanitized) return '';
@@ -2142,6 +2147,11 @@ useEffect(() => {
 
   const fetchFraudDetection = async () => {
     if (!selectedCase) return;
+    if (cdrIdentifiers.length === 0) {
+      setFraudResult(null);
+      setFraudError('Ajoutez au moins un numéro pour lancer l’analyse');
+      return;
+    }
 
     setFraudLoading(true);
     setFraudError('');
@@ -2151,6 +2161,9 @@ useEffect(() => {
       const params = new URLSearchParams();
       if (cdrStart) params.append('start', new Date(cdrStart).toISOString().split('T')[0]);
       if (cdrEnd) params.append('end', new Date(cdrEnd).toISOString().split('T')[0]);
+      cdrIdentifiers.forEach((identifier) => {
+        params.append('numbers', identifier);
+      });
       const query = params.toString();
       const res = await fetch(
         `/api/cases/${selectedCase.id}/fraud-detection${query ? `?${query}` : ''}`,
@@ -2867,6 +2880,135 @@ useEffect(() => {
           )}
         </div>
         </form>
+        {selectedCase && (
+          <div className="rounded-2xl border border-slate-200/80 bg-white/95 p-5 shadow-inner dark:bg-slate-900/60 dark:border-slate-700/60 space-y-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300">
+                  <Shield className="h-5 w-5" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-200">Détection de changement de numéro</h3>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    Identifiez les changements de numéro pour les identifiants recherchés.
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={fetchFraudDetection}
+                disabled={fraudLoading || !selectedCase || cdrIdentifiers.length === 0}
+                className="inline-flex items-center justify-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {fraudLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  'Analyser le changement de numéro'
+                )}
+              </button>
+            </div>
+            {fraudError && (
+              <p className="text-sm text-rose-600 dark:text-rose-400">{fraudError}</p>
+            )}
+            {cdrIdentifiers.length === 0 ? (
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Ajoutez au moins un numéro dans la recherche pour lancer l’analyse.
+              </p>
+            ) : fraudLoading ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-blue-400" />
+              </div>
+            ) : fraudResult ? (
+              <div className="space-y-4">
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}
+                </p>
+                {fraudResult.imeis.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-slate-200/80 bg-slate-50/70 p-4 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/40 dark:text-slate-300">
+                    Aucun changement de numéro détecté pour les identifiants recherchés.
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    {!hasFraudSuspiciousNumbers && (
+                      <div className="rounded-xl border border-emerald-200/70 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-900/30 dark:text-emerald-200">
+                        Aucune anomalie détectée : tous les numéros correspondent aux identifiants suivis.
+                      </div>
+                    )}
+                    {fraudResult.imeis.map((imeiEntry) => (
+                      <div key={imeiEntry.imei} className="rounded-xl border border-slate-200/80 bg-white/95 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
+                        <div className="flex items-center justify-between border-b border-slate-200/70 px-4 py-3 dark:border-slate-700/60">
+                          <div className="text-sm font-semibold text-slate-700 dark:text-slate-200">IMEI {imeiEntry.imei}</div>
+                          <div className="text-xs text-slate-500 dark:text-slate-400">
+                            {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''}
+                          </div>
+                        </div>
+                        {imeiEntry.numbers.length === 0 ? (
+                          <div className="px-4 py-3 text-sm text-slate-500 dark:text-slate-300">
+                            Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
+                          </div>
+                        ) : (
+                          <div className="overflow-x-auto">
+                            <table className="min-w-full text-xs text-slate-700 dark:text-slate-200">
+                              <thead className="bg-slate-100/80 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-800/60 dark:text-slate-300">
+                                <tr>
+                                  <th className="px-4 py-2 text-left">Numéro</th>
+                                  <th className="px-4 py-2 text-left">Statut</th>
+                                  <th className="px-4 py-2 text-left">Première vue</th>
+                                  <th className="px-4 py-2 text-left">Dernière vue</th>
+                                  <th className="px-4 py-2 text-left">Occurrences</th>
+                                  <th className="px-4 py-2 text-left">Rôles</th>
+                                </tr>
+                              </thead>
+                              <tbody className="divide-y divide-slate-200/70 dark:divide-slate-700/60">
+                                {imeiEntry.numbers.map((numberEntry) => (
+                                  <tr
+                                    key={`${imeiEntry.imei}-${numberEntry.number}`}
+                                    className={
+                                      numberEntry.status === 'nouveau'
+                                        ? 'bg-rose-50/70 dark:bg-rose-900/20'
+                                        : 'odd:bg-white even:bg-slate-50/70 dark:odd:bg-slate-900/40 dark:even:bg-slate-800/40'
+                                    }
+                                  >
+                                    <td className="px-4 py-2 font-medium">{numberEntry.number}</td>
+                                    <td className="px-4 py-2">
+                                      <span
+                                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                                          numberEntry.status === 'nouveau'
+                                            ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200'
+                                            : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200'
+                                        }`}
+                                      >
+                                        {numberEntry.status === 'nouveau' ? 'Nouveau' : 'Attendu'}
+                                      </span>
+                                    </td>
+                                    <td className="px-4 py-2">{formatFraudDate(numberEntry.firstSeen)}</td>
+                                    <td className="px-4 py-2">{formatFraudDate(numberEntry.lastSeen)}</td>
+                                    <td className="px-4 py-2">{numberEntry.occurrences}</td>
+                                    <td className="px-4 py-2">
+                                      {numberEntry.roles.length === 0
+                                        ? '-'
+                                        : numberEntry.roles
+                                            .map((role) => FRAUD_ROLE_LABELS[role] || role)
+                                            .join(', ')}
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Lancez une analyse pour détecter les nouveaux numéros associés aux identifiants recherchés.
+              </p>
+            )}
+          </div>
+        )}
       </>
     );
     if (showCdrMap) {
@@ -4234,146 +4376,6 @@ useEffect(() => {
                       </div>
                     </div>
                   )}
-                  <div className="rounded-2xl border border-slate-200/80 bg-white/95 p-5 shadow-inner dark:bg-slate-900/60 dark:border-slate-700/60 space-y-4">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <div className="flex items-start gap-3">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300">
-                          <Shield className="h-5 w-5" />
-                        </div>
-                        <div>
-                          <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-200">Détection de fraude</h3>
-                          <p className="text-sm text-slate-500 dark:text-slate-400">
-                            Identifiez les changements de numéro pour chaque IMEI.
-                          </p>
-                        </div>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={fetchFraudDetection}
-                        disabled={fraudLoading || !selectedCase}
-                        className="inline-flex items-center justify-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {fraudLoading ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          'Analyser la détection de fraude'
-                        )}
-                      </button>
-                    </div>
-                    {fraudError && (
-                      <p className="text-sm text-rose-600 dark:text-rose-400">{fraudError}</p>
-                    )}
-                    {fraudLoading ? (
-                      <div className="flex items-center justify-center py-6">
-                        <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-blue-400" />
-                      </div>
-                    ) : fraudResult ? (
-                      <div className="space-y-4">
-                        <p className="text-xs text-slate-500 dark:text-slate-400">
-                          Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}
-                        </p>
-                        {fraudResult.imeis.length === 0 ? (
-                          <div className="rounded-xl border border-dashed border-slate-200/80 bg-slate-50/70 p-4 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/40 dark:text-slate-300">
-                            Aucun changement de numéro détecté à partir des numéros associés aux CDR importés.
-                          </div>
-                        ) : (
-                          <div className="space-y-4">
-                            {!hasFraudSuspiciousNumbers && (
-                              <div className="rounded-xl border border-emerald-200/70 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-900/30 dark:text-emerald-200">
-                                Aucune anomalie détectée : tous les numéros correspondent aux références du dossier.
-                              </div>
-                            )}
-                            {fraudResult.imeis.map((imeiEntry) => (
-                              <div key={imeiEntry.imei} className="rounded-xl border border-slate-200/80 bg-white/95 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
-                                <div className="flex items-center justify-between border-b border-slate-200/70 px-4 py-3 dark:border-slate-700/60">
-                                  <div className="text-sm font-semibold text-slate-700 dark:text-slate-200">IMEI {imeiEntry.imei}</div>
-                                  <div className="text-xs text-slate-500 dark:text-slate-400">
-                                    {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''}
-                                  </div>
-                                </div>
-                                {imeiEntry.numbers.length === 0 ? (
-                                  <div className="px-4 py-3 text-sm text-slate-500 dark:text-slate-300">
-                                    Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
-                                  </div>
-                                ) : (
-                                  <div className="overflow-x-auto">
-                                    <table className="min-w-full text-xs text-slate-700 dark:text-slate-200">
-                                      <thead className="bg-slate-100/80 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-800/60 dark:text-slate-300">
-                                        <tr>
-                                          <th className="px-4 py-2 text-left">Numéro</th>
-                                          <th className="px-4 py-2 text-left">Statut</th>
-                                          <th className="px-4 py-2 text-left">Première vue</th>
-                                          <th className="px-4 py-2 text-left">Dernière vue</th>
-                                          <th className="px-4 py-2 text-left">Occurrences</th>
-                                          <th className="px-4 py-2 text-left">Rôles</th>
-                                          <th className="px-4 py-2 text-left">Fichiers</th>
-                                        </tr>
-                                      </thead>
-                                      <tbody className="divide-y divide-slate-200/70 dark:divide-slate-700/60">
-                                        {imeiEntry.numbers.map((numberEntry) => (
-                                          <tr
-                                            key={`${imeiEntry.imei}-${numberEntry.number}`}
-                                            className={
-                                              numberEntry.status === 'nouveau'
-                                                ? 'bg-rose-50/70 dark:bg-rose-900/20'
-                                                : 'odd:bg-white even:bg-slate-50/70 dark:odd:bg-slate-900/40 dark:even:bg-slate-800/40'
-                                            }
-                                          >
-                                            <td className="px-4 py-2 font-medium">{numberEntry.number}</td>
-                                            <td className="px-4 py-2">
-                                              <span
-                                                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
-                                                  numberEntry.status === 'nouveau'
-                                                    ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200'
-                                                    : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200'
-                                                }`}
-                                              >
-                                                {numberEntry.status === 'nouveau' ? 'Nouveau' : 'Attendu'}
-                                              </span>
-                                            </td>
-                                            <td className="px-4 py-2">{formatFraudDate(numberEntry.firstSeen)}</td>
-                                            <td className="px-4 py-2">{formatFraudDate(numberEntry.lastSeen)}</td>
-                                            <td className="px-4 py-2">{numberEntry.occurrences}</td>
-                                            <td className="px-4 py-2">
-                                              {numberEntry.roles.length === 0
-                                                ? '-'
-                                                : numberEntry.roles
-                                                    .map((role) => FRAUD_ROLE_LABELS[role] || role)
-                                                    .join(', ')}
-                                            </td>
-                                            <td className="px-4 py-2">
-                                              {numberEntry.files.length === 0 ? (
-                                                <span>-</span>
-                                              ) : (
-                                                <div className="flex flex-wrap gap-2">
-                                                  {numberEntry.files.map((file) => (
-                                                    <span
-                                                      key={file.id}
-                                                      className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
-                                                    >
-                                                      {file.filename}
-                                                    </span>
-                                                  ))}
-                                                </div>
-                                              )}
-                                            </td>
-                                          </tr>
-                                        ))}
-                                      </tbody>
-                                    </table>
-                                  </div>
-                                )}
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-slate-500 dark:text-slate-400">
-                        Lancez une analyse pour détecter les nouveaux numéros associés aux IMEI de l'opération.
-                      </p>
-                    )}
-                  </div>
                 </div>
 
                     {renderCdrSearchForm()}


### PR DESCRIPTION
## Summary
- intègre la détection de changement de numéro directement dans le formulaire de recherche CDR et retire la colonne des fichiers du tableau de résultats
- renomme l’interface et les messages pour refléter la recherche de changements de numéro et ne permettre l’analyse que lorsque des identifiants sont saisis
- filtre l’API de détection pour ne retourner que les changements liés aux numéros recherchés tout en conservant le statut des numéros connus du dossier

## Testing
- npm run lint *(échoue : dépendance @eslint/js manquante et installation bloquée par une erreur 403 du registre)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0dfa44d88326be1fb86b92068e6a