### PR TITLE
Improve CDR search layout and link diagram

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3053,14 +3053,14 @@ useEffect(() => {
 
     if (showCdrMap) {
       return (
-        <div className="fixed bottom-4 left-4 z-[1000] w-80 max-h-[80vh] overflow-y-auto rounded-3xl border border-white/60 bg-white/90 p-4 shadow-2xl shadow-blue-500/20 backdrop-blur-xl dark:border-slate-700/70 dark:bg-slate-900/80">
+        <div className="fixed bottom-6 left-6 z-[1000] w-[28rem] max-h-[88vh] overflow-y-auto rounded-3xl border border-white/60 bg-white/90 p-5 shadow-2xl shadow-blue-500/20 backdrop-blur-xl dark:border-slate-700/70 dark:bg-slate-900/85">
           {formContent}
         </div>
       );
     }
 
     return (
-      <div className="max-h-[60vh] overflow-y-auto rounded-3xl border border-slate-200/80 bg-transparent">
+      <div className="rounded-3xl border border-slate-200/80 bg-transparent">
         {formContent}
       </div>
     );
@@ -3074,14 +3074,12 @@ useEffect(() => {
         <button
           type="button"
           onClick={() => setSidebarOpen(true)}
-          className="group fixed bottom-6 left-4 sm:left-10 md:left-12 z-[1100] flex h-12 w-12 items-center justify-center rounded-2xl border border-white/70 bg-white/90 text-slate-700 shadow-lg shadow-blue-500/20 backdrop-blur transition-all hover:-translate-y-0.5 hover:shadow-xl dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200"
+          className="group fixed top-6 left-6 z-[1100] flex h-12 w-12 items-center justify-center rounded-xl border border-white/70 bg-white/90 text-slate-700 shadow-lg shadow-blue-500/20 backdrop-blur transition-all hover:-translate-y-0.5 hover:shadow-xl dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200"
           title="Déployer le menu"
           aria-label="Déployer le menu"
         >
-          <span className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 opacity-0 transition-opacity group-hover:opacity-100" />
-          <span className="relative">
-            <ChevronRight className="h-5 w-5" />
-          </span>
+          <span className="absolute inset-0 rounded-xl bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 opacity-0 transition-opacity group-hover:opacity-100" />
+          <ChevronRight className="relative h-5 w-5" />
         </button>
       )}
       {/* Sidebar */}

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import ForceGraph2D from 'react-force-graph-2d';
-import { X } from 'lucide-react';
+import { Maximize2, Minimize2, X } from 'lucide-react';
 
 interface GraphNode {
   id: string;
@@ -31,6 +31,7 @@ const typePalette = [
 ];
 
 const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const nodeTypes = useMemo(() => Array.from(new Set(data.nodes.map((n) => n.type))), [data]);
 
   const colorByType = useMemo(() => {
@@ -49,17 +50,42 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
     [data, colorByType]
   );
 
+  const overlayClasses = `fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 ${
+    isFullscreen ? '' : 'p-4'
+  }`;
+  const containerClasses = `bg-white dark:bg-gray-900 ${
+    isFullscreen ? 'rounded-none' : 'rounded-2xl'
+  } shadow-2xl w-[92vw] max-w-6xl ${isFullscreen ? 'h-full w-full max-w-none' : 'h-[82vh]'} relative flex flex-col overflow-hidden`;
+
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-11/12 h-5/6 relative flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between p-4 bg-blue-500 text-white">
-          <h2 className="text-lg font-semibold">Diagramme des liens</h2>
-          <button
-            className="text-black hover:text-gray-800 dark:text-white dark:hover:text-gray-200"
-            onClick={onClose}
-          >
-            <X className="w-6 h-6" />
-          </button>
+    <div className={overlayClasses}>
+      <div className={containerClasses}>
+        <div className="flex items-center justify-between px-6 py-4 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 text-white">
+          <div>
+            <h2 className="text-xl font-semibold">Diagramme des liens</h2>
+            <p className="text-sm text-white/80">Visualisez les interactions entre les correspondants sélectionnés.</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsFullscreen((value) => !value)}
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/50 bg-white/20 text-white transition hover:bg-white/30"
+              aria-label={isFullscreen ? 'Réduire le diagramme' : 'Agrandir le diagramme'}
+            >
+              {isFullscreen ? <Minimize2 className="h-5 w-5" /> : <Maximize2 className="h-5 w-5" />}
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/50 bg-white/20 text-white transition hover:bg-white/30"
+              onClick={() => {
+                setIsFullscreen(false);
+                onClose();
+              }}
+              aria-label="Fermer le diagramme"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
         </div>
         <div className="flex-1 relative">
           <ForceGraph2D
@@ -79,8 +105,8 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
             }}
             nodeCanvasObject={(node: any, ctx, globalScale) => {
               const label = node.id;
-              const fontSize = 12 / globalScale;
-              const radius = 8;
+              const fontSize = Math.max(12 / globalScale, 10);
+              const radius = Math.max(10, 18 / globalScale);
               const isDarkMode = document.documentElement.classList.contains('dark');
               ctx.beginPath();
               ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI);
@@ -112,7 +138,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
                 ? '#93c5fd'
                 : '#2563eb'
             }
-            linkWidth={(link: any) => 1 + Math.log(link.callCount + link.smsCount)}
+            linkWidth={(link: any) => 1.5 + Math.log(link.callCount + link.smsCount)}
             linkDirectionalParticles={2}
             linkDirectionalParticleSpeed={0.005}
             linkDirectionalArrowLength={6}
@@ -124,7 +150,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
               const end = link.target;
               if (typeof start !== 'object' || typeof end !== 'object') return;
               const label = `${link.callCount} appels / ${link.smsCount} SMS`;
-              const fontSize = 10 / globalScale;
+              const fontSize = Math.max(11 / globalScale, 9);
               const textX = (start.x + end.x) / 2;
               const textY = (start.y + end.y) / 2;
               const isDarkMode = document.documentElement.classList.contains('dark');
@@ -135,14 +161,14 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
               ctx.fillText(label, textX, textY);
             }}
           />
-          <div className="absolute top-4 left-4 bg-white/80 dark:bg-gray-800/80 rounded-md shadow p-2 text-xs space-y-1">
+          <div className="absolute top-4 left-4 bg-white/85 dark:bg-gray-800/85 rounded-xl shadow p-3 text-sm space-y-2">
             {nodeTypes.map((type) => (
               <div key={type} className="flex items-center gap-2">
                 <span
-                  className="w-3 h-3 rounded-full"
+                  className="w-3.5 h-3.5 rounded-full"
                   style={{ backgroundColor: colorByType[type] }}
                 ></span>
-                <span className="capitalize text-gray-800 dark:text-gray-200">{type}</span>
+                <span className="capitalize font-medium text-gray-800 dark:text-gray-200">{type}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- élargir le formulaire de recherche CDR lorsqu'il est épinglé sur la carte et supprimer le scroll interne inutile lorsqu'il est affiché sur la page
- ajuster le bouton d'ouverture du menu pour qu'il corresponde aux boutons iconiques du thème
- enrichir le diagramme de liens avec un affichage plus grand, un mode plein écran et des marqueurs plus lisibles

## Testing
- npm run build *(échoue : vite absent car l'installation des dépendances est bloquée par le registre)*

------
https://chatgpt.com/codex/tasks/task_e_68cf15473ce083268b56b02aa9cf41fa