### PR TITLE
Adjust change detection styling and add dual link diagrams

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2741,16 +2741,16 @@ useEffect(() => {
 
   const renderCdrSearchForm = () => {
     const detectionSection = !showCdrMap && selectedCase && (
-      <section className="rounded-3xl border border-slate-200/80 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-slate-100 shadow-xl shadow-slate-900/30 dark:from-slate-900 dark:via-slate-900 dark:to-black">
+      <section className="rounded-3xl border border-slate-200/80 bg-white/95 text-slate-900 shadow-xl shadow-slate-200/60 backdrop-blur-sm dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-100 dark:shadow-black/40">
         <div className="flex flex-col gap-4 p-6">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-500/20 text-blue-200">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-100 text-blue-600 dark:bg-blue-500/20 dark:text-blue-200">
                 <Shield className="h-6 w-6" />
               </div>
               <div>
                 <h3 className="text-lg font-semibold">Détection de changement de numéro</h3>
-                <p className="text-sm text-slate-300">
+                <p className="text-sm text-slate-500 dark:text-slate-300">
                   Identifiez instantanément les nouveaux numéros associés aux identifiants surveillés.
                 </p>
               </div>
@@ -2759,7 +2759,7 @@ useEffect(() => {
               type="button"
               onClick={fetchFraudDetection}
               disabled={fraudLoading || !selectedCase || cdrIdentifiers.length === 0}
-              className="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-2 text-sm font-semibold text-slate-100 transition-all hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition-all hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-white/10 dark:text-slate-100 dark:hover:bg-white/20"
             >
               {fraudLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Scan className="h-4 w-4" />}
               <span>Analyser</span>
@@ -2767,49 +2767,49 @@ useEffect(() => {
           </div>
 
           {fraudError && (
-            <p className="text-sm text-rose-300">{fraudError}</p>
+            <p className="text-sm text-rose-500 dark:text-rose-300">{fraudError}</p>
           )}
 
           {cdrIdentifiers.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-white/20 bg-white/5 px-4 py-3 text-sm text-slate-200">
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-white/20 dark:bg-white/5 dark:text-slate-200">
               Ajoutez au moins un numéro dans la recherche pour lancer l’analyse.
             </div>
           ) : fraudLoading ? (
             <div className="flex items-center justify-center py-6">
-              <Loader2 className="h-6 w-6 animate-spin text-slate-100" />
+              <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-slate-100" />
             </div>
           ) : fraudResult ? (
             <div className="space-y-4">
-              <div className="text-xs uppercase tracking-wide text-slate-400">
+              <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}
               </div>
               {fraudResult.imeis.length === 0 ? (
-                <div className="rounded-2xl border border-emerald-300/20 bg-emerald-400/10 px-4 py-4 text-sm text-emerald-100">
+                <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-700 dark:border-emerald-300/20 dark:bg-emerald-400/10 dark:text-emerald-100">
                   Aucun changement de numéro détecté pour les identifiants recherchés.
                 </div>
               ) : (
                 <div className="space-y-4">
                   {!hasFraudSuspiciousNumbers && (
-                    <div className="rounded-2xl border border-emerald-300/20 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-100">
+                    <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-300/20 dark:bg-emerald-400/10 dark:text-emerald-100">
                       Aucune anomalie détectée : tous les numéros correspondent aux identifiants suivis.
                     </div>
                   )}
                   {fraudResult.imeis.map((imeiEntry) => (
-                    <div key={imeiEntry.imei} className="overflow-hidden rounded-2xl border border-white/10 bg-slate-900/60 backdrop-blur">
-                      <div className="flex items-center justify-between border-b border-white/5 px-4 py-3 text-sm font-semibold">
+                    <div key={imeiEntry.imei} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:backdrop-blur">
+                      <div className="flex items-center justify-between border-b border-slate-200/70 px-4 py-3 text-sm font-semibold text-slate-700 dark:border-white/10 dark:text-slate-100">
                         <span>IMEI {imeiEntry.imei}</span>
-                        <span className="text-xs text-slate-400">
+                        <span className="text-xs text-slate-500 dark:text-slate-400">
                           {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''}
                         </span>
                       </div>
                       {imeiEntry.numbers.length === 0 ? (
-                        <div className="px-4 py-3 text-sm text-slate-300">
+                        <div className="px-4 py-3 text-sm text-slate-600 dark:text-slate-300">
                           Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
                         </div>
                       ) : (
                         <div className="overflow-x-auto">
-                          <table className="min-w-full text-xs text-slate-200">
-                            <thead className="bg-white/5 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                          <table className="min-w-full text-xs text-slate-600 dark:text-slate-200">
+                            <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-white/5 dark:text-slate-400">
                               <tr>
                                 <th className="px-4 py-2 text-left">Numéro</th>
                                 <th className="px-4 py-2 text-left">Statut</th>
@@ -2819,32 +2819,32 @@ useEffect(() => {
                                 <th className="px-4 py-2 text-left">Rôles</th>
                               </tr>
                             </thead>
-                            <tbody className="divide-y divide-white/5">
+                            <tbody className="divide-y divide-slate-100 dark:divide-white/10">
                               {imeiEntry.numbers.map((numberEntry) => (
                                 <tr
                                   key={`${imeiEntry.imei}-${numberEntry.number}`}
                                   className={
                                     numberEntry.status === 'nouveau'
-                                      ? 'bg-rose-500/10'
-                                      : 'odd:bg-white/5 even:bg-white/0'
+                                      ? 'bg-rose-50 dark:bg-rose-500/10'
+                                      : 'odd:bg-white even:bg-slate-50 dark:odd:bg-white/5 dark:even:bg-white/0'
                                   }
                                 >
-                                  <td className="px-4 py-2 font-medium text-slate-100">{numberEntry.number}</td>
+                                  <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-100">{numberEntry.number}</td>
                                   <td className="px-4 py-2">
                                     <span
                                       className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
                                         numberEntry.status === 'nouveau'
-                                          ? 'bg-rose-500/20 text-rose-100'
-                                          : 'bg-emerald-500/20 text-emerald-100'
+                                          ? 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-100'
+                                          : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-100'
                                       }`}
                                     >
                                       {numberEntry.status === 'nouveau' ? 'Nouveau' : 'Attendu'}
                                     </span>
                                   </td>
-                                  <td className="px-4 py-2 text-slate-200">{formatFraudDate(numberEntry.firstSeen)}</td>
-                                  <td className="px-4 py-2 text-slate-200">{formatFraudDate(numberEntry.lastSeen)}</td>
-                                  <td className="px-4 py-2 text-slate-200">{numberEntry.occurrences}</td>
-                                  <td className="px-4 py-2 text-slate-200">
+                                  <td className="px-4 py-2 text-slate-600 dark:text-slate-200">{formatFraudDate(numberEntry.firstSeen)}</td>
+                                  <td className="px-4 py-2 text-slate-600 dark:text-slate-200">{formatFraudDate(numberEntry.lastSeen)}</td>
+                                  <td className="px-4 py-2 text-slate-700 dark:text-slate-100">{numberEntry.occurrences}</td>
+                                  <td className="px-4 py-2 text-slate-600 dark:text-slate-200">
                                     {numberEntry.roles.length === 0
                                       ? '-'
                                       : numberEntry.roles
@@ -2863,7 +2863,7 @@ useEffect(() => {
               )}
             </div>
           ) : (
-            <p className="text-sm text-slate-300">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               Lancez une analyse pour détecter les nouveaux numéros associés aux identifiants recherchés.
             </p>
           )}

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import ForceGraph2D from 'react-force-graph-2d';
-import { Maximize2, Minimize2, X } from 'lucide-react';
+import { GitBranch, Maximize2, Minimize2, Network, X } from 'lucide-react';
 
 interface GraphNode {
   id: string;
@@ -30,8 +30,24 @@ const typePalette = [
   '#14b8a6'
 ];
 
+type ViewMode = 'network' | 'hierarchical';
+
+interface NormalizedNode extends GraphNode {
+  color: string;
+  degree: number;
+  val: number;
+}
+
+interface NormalizedLink extends GraphLink {
+  source: string;
+  target: string;
+  synthetic?: boolean;
+}
+
 const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>('network');
+  const [selectedRoot, setSelectedRoot] = useState<string | null>(null);
   const nodeTypes = useMemo(() => Array.from(new Set(data.nodes.map((n) => n.type))), [data]);
 
   const colorByType = useMemo(() => {
@@ -42,12 +58,142 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
     return map;
   }, [nodeTypes]);
 
+  const degreeByNode = useMemo(() => {
+    const map: Record<string, number> = {};
+    const normalize = (value: string | GraphNode) => (typeof value === 'string' ? value : value.id);
+    data.links.forEach((link) => {
+      const source = normalize(link.source);
+      const target = normalize(link.target);
+      map[source] = (map[source] || 0) + 1;
+      map[target] = (map[target] || 0) + 1;
+    });
+    return map;
+  }, [data.links]);
+
+  const graphNodes: NormalizedNode[] = useMemo(
+    () =>
+      data.nodes.map((node) => ({
+        ...node,
+        color: colorByType[node.type],
+        degree: degreeByNode[node.id] || 0,
+        val: Math.max(1, degreeByNode[node.id] || 1)
+      })),
+    [data.nodes, colorByType, degreeByNode]
+  );
+
+  const graphLinks: NormalizedLink[] = useMemo(() => {
+    const normalize = (value: string | GraphNode) => (typeof value === 'string' ? value : value.id);
+    return data.links.map((link) => ({
+      ...link,
+      source: normalize(link.source),
+      target: normalize(link.target)
+    }));
+  }, [data.links]);
+
+  const defaultRoot = useMemo(() => {
+    if (graphNodes.length === 0) return null;
+    const sorted = [...graphNodes].sort((a, b) => b.degree - a.degree);
+    return sorted[0]?.id ?? null;
+  }, [graphNodes]);
+
+  useEffect(() => {
+    if (!selectedRoot || !graphNodes.some((node) => node.id === selectedRoot)) {
+      setSelectedRoot(defaultRoot);
+    }
+  }, [defaultRoot, graphNodes, selectedRoot]);
+
+  const metricsByPair = useMemo(() => {
+    const map = new Map<string, { callCount: number; smsCount: number }>();
+    const makeKey = (a: string, b: string) =>
+      [a, b].sort((first, second) => (first > second ? 1 : first < second ? -1 : 0)).join('--');
+    graphLinks.forEach((link) => {
+      const key = makeKey(link.source, link.target);
+      const previous = map.get(key) || { callCount: 0, smsCount: 0 };
+      map.set(key, {
+        callCount: previous.callCount + link.callCount,
+        smsCount: previous.smsCount + link.smsCount
+      });
+    });
+    return map;
+  }, [graphLinks]);
+
+  const adjacency = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    graphLinks.forEach((link) => {
+      if (!map.has(link.source)) map.set(link.source, new Set());
+      if (!map.has(link.target)) map.set(link.target, new Set());
+      map.get(link.source)!.add(link.target);
+      map.get(link.target)!.add(link.source);
+    });
+    return map;
+  }, [graphLinks]);
+
+  const { hierarchicalGraph, effectiveRoot } = useMemo(() => {
+    const root = selectedRoot ?? defaultRoot;
+    if (!root) {
+      return { hierarchicalGraph: { nodes: graphNodes, links: graphLinks }, effectiveRoot: null };
+    }
+
+    const visited = new Set<string>();
+    const parent = new Map<string, string | null>();
+    const queue: string[] = [];
+
+    visited.add(root);
+    parent.set(root, null);
+    queue.push(root);
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const neighbors = adjacency.get(current);
+      if (!neighbors) continue;
+      neighbors.forEach((neighbor) => {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          parent.set(neighbor, current);
+          queue.push(neighbor);
+        }
+      });
+    }
+
+    const makeKey = (a: string, b: string) =>
+      [a, b].sort((first, second) => (first > second ? 1 : first < second ? -1 : 0)).join('--');
+
+    const treeLinks: NormalizedLink[] = [];
+
+    graphNodes.forEach((node) => {
+      if (node.id === root) return;
+      if (!visited.has(node.id)) {
+        parent.set(node.id, root);
+      }
+    });
+
+    parent.forEach((parentId, nodeId) => {
+      if (!parentId) return;
+      const metrics = metricsByPair.get(makeKey(parentId, nodeId)) || { callCount: 0, smsCount: 0 };
+      treeLinks.push({
+        source: parentId,
+        target: nodeId,
+        callCount: metrics.callCount,
+        smsCount: metrics.smsCount,
+        synthetic: metrics.callCount === 0 && metrics.smsCount === 0
+      });
+    });
+
+    return {
+      hierarchicalGraph: {
+        nodes: graphNodes,
+        links: treeLinks
+      },
+      effectiveRoot: root
+    };
+  }, [adjacency, defaultRoot, graphLinks, graphNodes, metricsByPair, selectedRoot]);
+
   const graphData = useMemo(
     () => ({
-      nodes: data.nodes.map((n) => ({ ...n, color: colorByType[n.type] })),
-      links: data.links
+      nodes: graphNodes,
+      links: graphLinks
     }),
-    [data, colorByType]
+    [graphLinks, graphNodes]
   );
 
   const overlayClasses = `fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 ${
@@ -60,117 +206,192 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
   return (
     <div className={overlayClasses}>
       <div className={containerClasses}>
-        <div className="flex items-center justify-between px-6 py-4 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 text-white">
-          <div>
-            <h2 className="text-xl font-semibold">Diagramme des liens</h2>
-            <p className="text-sm text-white/80">Visualisez les interactions entre les correspondants sélectionnés.</p>
+        <div className="flex flex-col gap-4 px-6 py-4 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 text-white">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Diagramme des liens</h2>
+              <p className="text-sm text-white/80">Comparez la vue réseau et la vue hiérarchique des entités liées.</p>
+            </div>
+            <div className="flex items-center gap-2 self-end sm:self-auto">
+              <button
+                type="button"
+                onClick={() => setIsFullscreen((value) => !value)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/50 bg-white/20 text-white transition hover:bg-white/30"
+                aria-label={isFullscreen ? 'Réduire le diagramme' : 'Agrandir le diagramme'}
+              >
+                {isFullscreen ? <Minimize2 className="h-5 w-5" /> : <Maximize2 className="h-5 w-5" />}
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/50 bg-white/20 text-white transition hover:bg-white/30"
+                onClick={() => {
+                  setIsFullscreen(false);
+                  onClose();
+                }}
+                aria-label="Fermer le diagramme"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setIsFullscreen((value) => !value)}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/50 bg-white/20 text-white transition hover:bg-white/30"
-              aria-label={isFullscreen ? 'Réduire le diagramme' : 'Agrandir le diagramme'}
-            >
-              {isFullscreen ? <Minimize2 className="h-5 w-5" /> : <Maximize2 className="h-5 w-5" />}
-            </button>
-            <button
-              type="button"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/50 bg-white/20 text-white transition hover:bg-white/30"
-              onClick={() => {
-                setIsFullscreen(false);
-                onClose();
-              }}
-              aria-label="Fermer le diagramme"
-            >
-              <X className="h-5 w-5" />
-            </button>
+          <div className="flex flex-col gap-3 rounded-2xl bg-white/10 p-3 shadow-inner backdrop-blur-sm sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2 rounded-full bg-white/20 p-1 text-sm font-medium">
+              <button
+                type="button"
+                onClick={() => setViewMode('network')}
+                className={`flex items-center gap-2 rounded-full px-4 py-1.5 transition ${
+                  viewMode === 'network' ? 'bg-white text-blue-700' : 'text-white/80 hover:bg-white/10'
+                }`}
+              >
+                <Network className="h-4 w-4" />
+                Vue réseau
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('hierarchical')}
+                className={`flex items-center gap-2 rounded-full px-4 py-1.5 transition ${
+                  viewMode === 'hierarchical' ? 'bg-white text-blue-700' : 'text-white/80 hover:bg-white/10'
+                }`}
+              >
+                <GitBranch className="h-4 w-4" />
+                Vue hiérarchique
+              </button>
+            </div>
+            {viewMode === 'hierarchical' && effectiveRoot && (
+              <div className="flex flex-col gap-1 text-sm text-white sm:flex-row sm:items-center sm:gap-2">
+                <span className="text-white/80">Entité racine :</span>
+                <select
+                  className="rounded-xl border-0 bg-white/90 px-3 py-1.5 text-sm font-medium text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  value={selectedRoot ?? effectiveRoot}
+                  onChange={(event) => setSelectedRoot(event.target.value)}
+                >
+                  {graphNodes.map((node) => (
+                    <option key={node.id} value={node.id}>
+                      {node.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
           </div>
         </div>
-        <div className="flex-1 relative">
+        <div className="relative flex-1">
           <ForceGraph2D
-            graphData={graphData}
-            enableNodeDrag={true}
+            graphData={viewMode === 'network' ? graphData : hierarchicalGraph}
+            enableNodeDrag={viewMode === 'network'}
+            dagMode={viewMode === 'hierarchical' ? 'radialinout' : undefined}
+            dagLevelDistance={viewMode === 'hierarchical' ? 140 : undefined}
             onNodeDragStart={(node: any) => {
+              if (viewMode !== 'network') return;
               node.fx = node.x;
               node.fy = node.y;
             }}
             onNodeDrag={(node: any) => {
+              if (viewMode !== 'network') return;
               node.fx = node.x;
               node.fy = node.y;
             }}
             onNodeDragEnd={(node: any) => {
+              if (viewMode !== 'network') return;
               node.fx = node.x;
               node.fy = node.y;
             }}
             nodeCanvasObject={(node: any, ctx, globalScale) => {
               const label = node.id;
-              const fontSize = Math.max(12 / globalScale, 10);
-              const radius = Math.max(10, 18 / globalScale);
               const isDarkMode = document.documentElement.classList.contains('dark');
+              const baseRadius = 14 + (node.degree || 0) * 2;
+              const radius = Math.max(10, baseRadius / globalScale);
+              const fontSize = Math.max(12 / globalScale, 10);
               ctx.beginPath();
               ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI);
               ctx.fillStyle = node.color;
               ctx.fill();
-              ctx.strokeStyle = isDarkMode ? '#374151' : '#e5e7eb';
-              ctx.lineWidth = 1;
+              ctx.lineWidth = 1.2;
+              ctx.strokeStyle = isDarkMode ? '#1f2937' : '#e5e7eb';
               ctx.stroke();
+              if (viewMode === 'hierarchical' && effectiveRoot && node.id === effectiveRoot) {
+                ctx.beginPath();
+                ctx.arc(node.x, node.y, radius + 4, 0, 2 * Math.PI);
+                ctx.strokeStyle = isDarkMode ? '#facc15' : '#f97316';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+              }
               ctx.font = `${fontSize}px sans-serif`;
               ctx.textAlign = 'center';
               ctx.textBaseline = 'top';
-              ctx.fillStyle = isDarkMode ? '#fff' : '#000';
+              ctx.fillStyle = isDarkMode ? '#f9fafb' : '#111827';
               ctx.fillText(label, node.x, node.y + radius + 4);
             }}
             nodePointerAreaPaint={(node: any, color, ctx) => {
-              const radius = 8;
+              const radius = 12 + (node.degree || 0);
               ctx.beginPath();
               ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
               ctx.fillStyle = color;
               ctx.fill();
             }}
-            linkColor={() =>
-              document.documentElement.classList.contains('dark')
-                ? '#93c5fd'
-                : '#2563eb'
-            }
-            linkDirectionalArrowColor={() =>
-              document.documentElement.classList.contains('dark')
-                ? '#93c5fd'
-                : '#2563eb'
-            }
-            linkWidth={(link: any) => 1.5 + Math.log(link.callCount + link.smsCount)}
-            linkDirectionalParticles={2}
+            linkColor={(link: any) => {
+              if (link.synthetic) {
+                return document.documentElement.classList.contains('dark') ? '#4b5563' : '#d1d5db';
+              }
+              return document.documentElement.classList.contains('dark') ? '#93c5fd' : '#2563eb';
+            }}
+            linkDirectionalArrowColor={(link: any) => {
+              if (link.synthetic) {
+                return document.documentElement.classList.contains('dark') ? '#4b5563' : '#d1d5db';
+              }
+              return document.documentElement.classList.contains('dark') ? '#93c5fd' : '#2563eb';
+            }}
+            linkWidth={(link: any) => 1 + Math.log((link.callCount || 0) + (link.smsCount || 0) + 1)}
+            linkDirectionalParticles={viewMode === 'network' ? 2 : 0}
             linkDirectionalParticleSpeed={0.005}
             linkDirectionalArrowLength={6}
-            // Position arrows near targets so call/SMS labels remain unobstructed
             linkDirectionalArrowRelPos={0.9}
             linkCanvasObjectMode={() => 'after'}
             linkCanvasObject={(link: any, ctx, globalScale) => {
               const start = link.source;
               const end = link.target;
               if (typeof start !== 'object' || typeof end !== 'object') return;
-              const label = `${link.callCount} appels / ${link.smsCount} SMS`;
+              const label =
+                viewMode === 'hierarchical' && link.synthetic
+                  ? 'Lien ajouté (aucune interaction)'
+                  : `${link.callCount} appels / ${link.smsCount} SMS`;
               const fontSize = Math.max(11 / globalScale, 9);
               const textX = (start.x + end.x) / 2;
               const textY = (start.y + end.y) / 2;
               const isDarkMode = document.documentElement.classList.contains('dark');
               ctx.font = `${fontSize}px sans-serif`;
-              ctx.fillStyle = isDarkMode ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.6)';
+              ctx.fillStyle = isDarkMode ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.65)';
               ctx.textAlign = 'center';
               ctx.textBaseline = 'middle';
               ctx.fillText(label, textX, textY);
             }}
           />
-          <div className="absolute top-4 left-4 bg-white/85 dark:bg-gray-800/85 rounded-xl shadow p-3 text-sm space-y-2">
-            {nodeTypes.map((type) => (
-              <div key={type} className="flex items-center gap-2">
-                <span
-                  className="w-3.5 h-3.5 rounded-full"
-                  style={{ backgroundColor: colorByType[type] }}
-                ></span>
-                <span className="capitalize font-medium text-gray-800 dark:text-gray-200">{type}</span>
+          <div className="absolute top-4 left-4 space-y-3">
+            <div className="rounded-xl bg-white/85 p-3 text-sm shadow dark:bg-gray-800/85">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Légende des types
+              </p>
+              <div className="space-y-1.5">
+                {nodeTypes.map((type) => (
+                  <div key={type} className="flex items-center gap-2">
+                    <span
+                      className="h-3.5 w-3.5 rounded-full"
+                      style={{ backgroundColor: colorByType[type] }}
+                    ></span>
+                    <span className="capitalize font-medium text-gray-800 dark:text-gray-200">{type}</span>
+                  </div>
+                ))}
               </div>
-            ))}
+            </div>
+            <div className="rounded-xl bg-white/85 p-3 text-xs shadow text-gray-600 dark:bg-gray-800/85 dark:text-gray-300">
+              <p className="font-semibold text-gray-700 dark:text-gray-200">Interactions</p>
+              <p>Largeur et taille des nœuds proportionnelles au nombre de connexions.</p>
+              {viewMode === 'hierarchical' && effectiveRoot && (
+                <p className="mt-2 font-medium text-blue-600 dark:text-blue-300">
+                  Racine actuelle : {effectiveRoot}
+                </p>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restyle the number change detection table to align with the light design system while keeping dark mode support
- add a toggleable header to the link diagram modal offering both network and hierarchical (radial) views
- introduce root entity selection, dynamic node sizing, and improved legends for clearer comparisons between diagram views

## Testing
- npm run lint *(fails: missing local eslint dependency due to restricted npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cf18ba4ae08326954761864b638d15