### PR TITLE
Add division management and secure case sharing

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -23,6 +23,8 @@ import requestsRoutes from './routes/requests.js';
 import identifiedNumbersRoutes from './routes/identified-numbers.js';
 import blacklistRoutes from './routes/blacklist.js';
 import logsRoutes from './routes/logs.js';
+import divisionsRoutes from './routes/divisions.js';
+import notificationsRoutes from './routes/notifications.js';
 import { authenticate } from './middleware/auth.js';
 
 // Initialisation de la base de données
@@ -98,6 +100,8 @@ app.use('/api/requests', requestsRoutes);
 app.use('/api/identified-numbers', identifiedNumbersRoutes);
 app.use('/api/blacklist', blacklistRoutes);
 app.use('/api/logs', logsRoutes);
+app.use('/api/divisions', divisionsRoutes);
+app.use('/api/notifications', notificationsRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/models/CaseShare.js
+++ b/server/models/CaseShare.js
@@ -1,0 +1,72 @@
+import database from '../config/database.js';
+
+class CaseShare {
+  static async getUserIds(caseId) {
+    if (!caseId) return [];
+    const rows = await database.query(
+      `SELECT user_id FROM autres.cdr_case_shares WHERE case_id = ?`,
+      [caseId]
+    );
+    return rows.map((row) => row.user_id);
+  }
+
+  static async getSharesForCases(caseIds = []) {
+    const map = new Map();
+    if (!Array.isArray(caseIds) || caseIds.length === 0) {
+      return map;
+    }
+    const placeholders = caseIds.map(() => '?').join(',');
+    const rows = await database.query(
+      `SELECT case_id, user_id FROM autres.cdr_case_shares WHERE case_id IN (${placeholders})`,
+      caseIds
+    );
+    for (const row of rows) {
+      if (!map.has(row.case_id)) {
+        map.set(row.case_id, []);
+      }
+      map.get(row.case_id).push(row.user_id);
+    }
+    return map;
+  }
+
+  static async replaceShares(caseId, userIds) {
+    if (!caseId) {
+      return { added: [], removed: [] };
+    }
+    const normalized = Array.isArray(userIds)
+      ? Array.from(new Set(userIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0)))
+      : [];
+    const current = await this.getUserIds(caseId);
+    const toRemove = current.filter((id) => !normalized.includes(id));
+    const toAdd = normalized.filter((id) => !current.includes(id));
+
+    if (toRemove.length > 0) {
+      const placeholders = toRemove.map(() => '?').join(',');
+      await database.query(
+        `DELETE FROM autres.cdr_case_shares WHERE case_id = ? AND user_id IN (${placeholders})`,
+        [caseId, ...toRemove]
+      );
+    }
+
+    for (const userId of toAdd) {
+      await database.query(
+        `INSERT INTO autres.cdr_case_shares (case_id, user_id) VALUES (?, ?)
+         ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)`,
+        [caseId, userId]
+      );
+    }
+
+    return { added: toAdd, removed: toRemove };
+  }
+
+  static async isSharedWithUser(caseId, userId) {
+    if (!caseId || !userId) return false;
+    const row = await database.queryOne(
+      `SELECT 1 FROM autres.cdr_case_shares WHERE case_id = ? AND user_id = ? LIMIT 1`,
+      [caseId, userId]
+    );
+    return Boolean(row);
+  }
+}
+
+export default CaseShare;

--- a/server/models/Division.js
+++ b/server/models/Division.js
@@ -1,0 +1,47 @@
+import database from '../config/database.js';
+
+class Division {
+  static async findAll() {
+    return await database.query(
+      `SELECT id, name, created_at FROM autres.divisions ORDER BY name`
+    );
+  }
+
+  static async findById(id) {
+    return await database.queryOne(
+      `SELECT id, name, created_at FROM autres.divisions WHERE id = ?`,
+      [id]
+    );
+  }
+
+  static async create(name) {
+    const trimmed = typeof name === 'string' ? name.trim() : '';
+    if (!trimmed) {
+      throw new Error('Division name is required');
+    }
+    const result = await database.query(
+      `INSERT INTO autres.divisions (name) VALUES (?)`,
+      [trimmed]
+    );
+    return {
+      id: result.insertId,
+      name: trimmed
+    };
+  }
+
+  static async findUsers(divisionId, { includeInactive = false } = {}) {
+    if (!divisionId) {
+      return [];
+    }
+    const condition = includeInactive ? '' : 'AND u.active = 1';
+    return await database.query(
+      `SELECT u.id, u.login, u.admin, u.active, u.created_at
+       FROM autres.users u
+       WHERE u.division_id = ? ${condition}
+       ORDER BY u.login`,
+      [divisionId]
+    );
+  }
+}
+
+export default Division;

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,0 +1,54 @@
+import database from '../config/database.js';
+
+class Notification {
+  static async create({ user_id, type, data = null }) {
+    if (!user_id || !type) {
+      throw new Error('user_id and type are required');
+    }
+    const payload = data ? JSON.stringify(data) : null;
+    const result = await database.query(
+      `INSERT INTO autres.notifications (user_id, type, data) VALUES (?, ?, ?)`,
+      [user_id, type, payload]
+    );
+    return { id: result.insertId, user_id, type, data };
+  }
+
+  static async findRecentByUser(userId, limit = 20) {
+    if (!userId) {
+      return [];
+    }
+    return await database.query(
+      `SELECT id, user_id, type, data, read_at, created_at
+       FROM autres.notifications
+       WHERE user_id = ?
+       ORDER BY created_at DESC
+       LIMIT ?`,
+      [userId, limit]
+    );
+  }
+
+  static async markAsRead(id, userId) {
+    if (!id || !userId) return false;
+    await database.query(
+      `UPDATE autres.notifications SET read_at = NOW() WHERE id = ? AND user_id = ? AND read_at IS NULL`,
+      [id, userId]
+    );
+    return true;
+  }
+
+  static async markManyAsRead(ids = [], userId) {
+    if (!Array.isArray(ids) || ids.length === 0 || !userId) {
+      return false;
+    }
+    const placeholders = ids.map(() => '?').join(',');
+    await database.query(
+      `UPDATE autres.notifications
+         SET read_at = NOW()
+       WHERE user_id = ? AND id IN (${placeholders}) AND read_at IS NULL`,
+      [userId, ...ids]
+    );
+    return true;
+  }
+}
+
+export default Notification;

--- a/server/models/UserSession.js
+++ b/server/models/UserSession.js
@@ -1,0 +1,65 @@
+import database from '../config/database.js';
+
+class UserSession {
+  static async start(userId) {
+    if (!userId) return null;
+    const result = await database.query(
+      `INSERT INTO autres.user_sessions (user_id, login_at) VALUES (?, NOW())`,
+      [userId]
+    );
+    return { id: result.insertId, user_id: userId };
+  }
+
+  static async endLatest(userId) {
+    if (!userId) return false;
+    const latest = await database.queryOne(
+      `SELECT id FROM autres.user_sessions WHERE user_id = ? AND logout_at IS NULL ORDER BY login_at DESC LIMIT 1`,
+      [userId]
+    );
+    if (!latest) {
+      return false;
+    }
+    await database.query(
+      `UPDATE autres.user_sessions SET logout_at = NOW() WHERE id = ?`,
+      [latest.id]
+    );
+    return true;
+  }
+
+  static async getSessions(page = 1, limit = 20, { username = '' } = {}) {
+    const offset = (page - 1) * limit;
+    const params = [];
+    let whereClause = '';
+
+    if (username) {
+      whereClause = 'WHERE u.login LIKE ?';
+      params.push(`%${username}%`);
+    }
+
+    const rows = await database.query(
+      `SELECT s.id, s.user_id, u.login AS username, s.login_at, s.logout_at,
+              TIMESTAMPDIFF(SECOND, s.login_at, COALESCE(s.logout_at, NOW())) AS duration_seconds
+         FROM autres.user_sessions s
+         JOIN autres.users u ON s.user_id = u.id
+         ${whereClause}
+         ORDER BY s.login_at DESC
+         LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
+    );
+
+    const totalRow = await database.queryOne(
+      `SELECT COUNT(*) AS total
+         FROM autres.user_sessions s
+         JOIN autres.users u ON s.user_id = u.id
+         ${whereClause}`,
+      params
+    );
+
+    return {
+      rows,
+      total: totalRow?.total || 0
+    };
+  }
+}
+
+export default UserSession;

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -2,6 +2,7 @@ import express from 'express';
 import User from '../models/User.js';
 import { authenticate } from '../middleware/auth.js';
 import UserLog from '../models/UserLog.js';
+import UserSession from '../models/UserSession.js';
 
 const router = express.Router();
 
@@ -30,42 +31,54 @@ router.post('/login', async (req, res) => {
       return res.status(401).json({ error: 'Identifiants invalides' });
     }
 
-      const token = User.generateToken(user);
-      const { mdp, ...userResponse } = user;
+    const token = User.generateToken(user);
+    const { mdp, ...userResponse } = user;
 
-      res.json({
-        message: 'Connexion réussie',
+    res.json({
+      message: 'Connexion réussie',
       user: {
         ...userResponse,
         role: user.admin === 1 ? 'ADMIN' : 'USER'
-        },
-        token
-      });
+      },
+      token
+    });
 
-      // Journaliser la connexion
-      try {
-        await UserLog.create({ user_id: user.id, action: 'login' });
-      } catch (_) {}
-    } catch (error) {
+    try {
+      await UserLog.create({ user_id: user.id, action: 'login' });
+    } catch (_) {}
+
+    try {
+      await UserSession.start(user.id);
+    } catch (sessionError) {
+      console.error('Erreur création session utilisateur:', sessionError);
+    }
+  } catch (error) {
     console.error('Erreur lors de la connexion:', error);
     res.status(500).json({ error: 'Erreur serveur: ' + error.message });
   }
 });
 
-  // Route de déconnexion
-  router.post('/logout', authenticate, async (req, res) => {
+// Route de déconnexion
+router.post('/logout', authenticate, async (req, res) => {
+  try {
+    let duration = null;
     try {
-      let duration = null;
-      try {
-        const lastLogin = await UserLog.getLastAction(req.user.id, 'login');
-        if (lastLogin) {
-          duration = Date.now() - new Date(lastLogin.created_at).getTime();
-        }
-      } catch (_) {}
-      await UserLog.create({ user_id: req.user.id, action: 'logout', duration_ms: duration });
+      const lastLogin = await UserLog.getLastAction(req.user.id, 'login');
+      if (lastLogin) {
+        duration = Date.now() - new Date(lastLogin.created_at).getTime();
+      }
     } catch (_) {}
-    res.json({ message: 'Déconnexion réussie' });
-  });
+    await UserLog.create({ user_id: req.user.id, action: 'logout', duration_ms: duration });
+  } catch (_) {}
+
+  try {
+    await UserSession.endLatest(req.user.id);
+  } catch (error) {
+    console.error('Erreur clôture session utilisateur:', error);
+  }
+
+  res.json({ message: 'Déconnexion réussie' });
+});
 
 // Vérification du token
 router.get('/verify', async (req, res) => {

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -30,6 +30,51 @@ router.get('/', authenticate, async (req, res) => {
   }
 });
 
+router.get('/:id/share', authenticate, async (req, res) => {
+  try {
+    const caseId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(caseId)) {
+      return res.status(400).json({ error: 'ID de dossier invalide' });
+    }
+    const info = await caseService.getShareInfo(caseId, req.user);
+    res.json(info);
+  } catch (err) {
+    if (err.message === 'Forbidden') {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    if (err.message === 'Case not found') {
+      return res.status(404).json({ error: 'Opération introuvable' });
+    }
+    console.error('Erreur récupération partage:', err);
+    res.status(500).json({ error: 'Erreur lors de la récupération des partages' });
+  }
+});
+
+router.post('/:id/share', authenticate, async (req, res) => {
+  try {
+    const caseId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(caseId)) {
+      return res.status(400).json({ error: 'ID de dossier invalide' });
+    }
+    const shareAll = req.body.shareAll === true || req.body.shareAll === 'true';
+    const userIds = Array.isArray(req.body.userIds) ? req.body.userIds : [];
+    const result = await caseService.shareCase(caseId, req.user, { userIds, shareAll });
+    res.json(result);
+  } catch (err) {
+    if (err.message === 'Forbidden') {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    if (err.message === 'Case not found') {
+      return res.status(404).json({ error: 'Opération introuvable' });
+    }
+    if (err.message === 'Division not found for owner') {
+      return res.status(400).json({ error: 'Division introuvable pour le responsable' });
+    }
+    console.error('Erreur mise à jour partage:', err);
+    res.status(500).json({ error: 'Erreur lors du partage de l\'opération' });
+  }
+});
+
 router.post('/', authenticate, async (req, res) => {
   try {
     const { name } = req.body;

--- a/server/routes/divisions.js
+++ b/server/routes/divisions.js
@@ -1,0 +1,54 @@
+import express from 'express';
+import { authenticate, requireAdmin } from '../middleware/auth.js';
+import Division from '../models/Division.js';
+
+const router = express.Router();
+
+router.get('/', authenticate, async (req, res) => {
+  try {
+    const divisions = await Division.findAll();
+    res.json({ divisions });
+  } catch (error) {
+    console.error('Erreur récupération divisions:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des divisions' });
+  }
+});
+
+router.post('/', authenticate, requireAdmin, async (req, res) => {
+  try {
+    const { name } = req.body;
+    if (typeof name !== 'string' || !name.trim()) {
+      return res.status(400).json({ error: 'Nom de division requis' });
+    }
+    const division = await Division.create(name.trim());
+    res.status(201).json({ division });
+  } catch (error) {
+    console.error('Erreur création division:', error);
+    res.status(500).json({ error: 'Erreur lors de la création de la division' });
+  }
+});
+
+router.get('/:id/users', authenticate, async (req, res) => {
+  try {
+    const divisionId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(divisionId)) {
+      return res.status(400).json({ error: 'ID de division invalide' });
+    }
+    const division = await Division.findById(divisionId);
+    if (!division) {
+      return res.status(404).json({ error: 'Division non trouvée' });
+    }
+    const isAdmin = req.user?.admin === 1 || req.user?.admin === '1' || req.user?.admin === true;
+    if (!isAdmin && req.user?.division_id !== divisionId) {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    const includeInactive = req.query.includeInactive === 'true';
+    const users = await Division.findUsers(divisionId, { includeInactive });
+    res.json({ division, users });
+  } catch (error) {
+    console.error('Erreur récupération utilisateurs division:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des utilisateurs' });
+  }
+});
+
+export default router;

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -1,0 +1,47 @@
+import express from 'express';
+import { authenticate } from '../middleware/auth.js';
+import Notification from '../models/Notification.js';
+
+const router = express.Router();
+
+router.get('/', authenticate, async (req, res) => {
+  try {
+    const limit = req.query.limit ? parseInt(req.query.limit, 10) : 20;
+    const notifications = await Notification.findRecentByUser(req.user.id, isNaN(limit) ? 20 : limit);
+    const formatted = notifications.map((item) => ({
+      ...item,
+      data: item.data ? JSON.parse(item.data) : null
+    }));
+    res.json({ notifications: formatted });
+  } catch (error) {
+    console.error('Erreur récupération notifications:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des notifications' });
+  }
+});
+
+router.post('/:id/read', authenticate, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    if (!Number.isInteger(id)) {
+      return res.status(400).json({ error: 'ID de notification invalide' });
+    }
+    await Notification.markAsRead(id, req.user.id);
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Erreur mise à jour notification:', error);
+    res.status(500).json({ error: 'Erreur lors de la mise à jour de la notification' });
+  }
+});
+
+router.post('/read', authenticate, async (req, res) => {
+  try {
+    const ids = Array.isArray(req.body.ids) ? req.body.ids : [];
+    await Notification.markManyAsRead(ids, req.user.id);
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Erreur lecture notifications:', error);
+    res.status(500).json({ error: 'Erreur lors de la mise à jour des notifications' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- enforce division membership in the database, seed default divisions, and expose division APIs used by user CRUD workflows
- add case sharing restricted to division members, deliver notifications to new recipients, and update the CDR UI to manage recipients
- record login and logout timestamps in user_sessions and surface the history on the admin logs page alongside enhanced notifications

## Testing
- npm run lint *(fails: cannot resolve @eslint/js because npm install for @elastic/elasticsearch is blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2f8b34508326a082c587f0f49344