### PR TITLE
Handle missing users when creating logs

### DIFF
--- a/server/models/UserLog.js
+++ b/server/models/UserLog.js
@@ -1,10 +1,22 @@
 import database from '../config/database.js';
 
+const ensureUserExists = async userId => {
+  if (userId === undefined || userId === null) return null;
+
+  const existing = await database.queryOne(
+    'SELECT id FROM autres.users WHERE id = ? LIMIT 1',
+    [userId]
+  );
+
+  return existing ? userId : null;
+};
+
 class UserLog {
   static async create({ user_id, action, details = null, duration_ms = null }) {
+    const safeUserId = await ensureUserExists(user_id);
     await database.query(
       `INSERT INTO autres.user_logs (user_id, action, details, duration_ms) VALUES (?, ?, ?, ?)`,
-      [user_id, action, details, duration_ms]
+      [safeUserId, action, details, duration_ms]
     );
   }
 


### PR DESCRIPTION
## Summary
- check if the associated user exists before inserting a log entry
- default to a null user id when the referenced user no longer exists to avoid foreign key errors

## Testing
- npm run lint *(fails: missing dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68cf394d0cf08326b724d57d88c4ef51