### PR TITLE
Ensure users table has timestamps

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -117,6 +117,42 @@ class DatabaseManager {
         }
       }
 
+      const hasCreatedAt = await this.queryOne(`
+        SELECT 1 FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = 'autres' AND TABLE_NAME = 'users' AND COLUMN_NAME = 'created_at'
+      `);
+
+      if (!hasCreatedAt) {
+        try {
+          await this.pool.execute(`
+            ALTER TABLE autres.users
+            ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP AFTER division_id
+          `);
+        } catch (error) {
+          if (error.code !== 'ER_DUP_FIELDNAME') {
+            throw error;
+          }
+        }
+      }
+
+      const hasUpdatedAt = await this.queryOne(`
+        SELECT 1 FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = 'autres' AND TABLE_NAME = 'users' AND COLUMN_NAME = 'updated_at'
+      `);
+
+      if (!hasUpdatedAt) {
+        try {
+          await this.pool.execute(`
+            ALTER TABLE autres.users
+            ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER created_at
+          `);
+        } catch (error) {
+          if (error.code !== 'ER_DUP_FIELDNAME') {
+            throw error;
+          }
+        }
+      }
+
       const defaultDivisions = [
         'Division Cybersecurité',
         'Division Analyse',


### PR DESCRIPTION
## Summary
- ensure the users table gains created_at and updated_at columns if they are missing when initializing the database
- add migration logic so legacy databases receive the timestamp fields required by queries

## Testing
- npm run lint *(fails: missing dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3e856db88326892636e4054c52b2