### PR TITLE
Prevent shared operation deletion by non-owners

### DIFF
--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -334,6 +334,12 @@ router.delete('/:id', authenticate, async (req, res) => {
     res.json({ message: 'Case supprimé' });
   } catch (err) {
     console.error('Erreur suppression case:', err);
+    if (err.message === 'Case not found') {
+      return res.status(404).json({ error: 'Opération introuvable' });
+    }
+    if (err.message === 'Forbidden') {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
     res.status(500).json({ error: 'Erreur suppression case' });
   }
 });

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -282,6 +282,12 @@ class CaseService {
     if (!existingCase) {
       throw new Error('Case not found');
     }
+    const isOwner = existingCase.user_id === user.id || existingCase.is_owner === 1 || existingCase.is_owner === true;
+    const isAdmin = this._isAdmin(user);
+
+    if (!isOwner && !isAdmin) {
+      throw new Error('Forbidden');
+    }
     // Delete the case first to avoid dropping the CDR table if the delete fails
     await Case.delete(id);
     // Remove any CDR table associated with this case, but don't fail the whole


### PR DESCRIPTION
## Summary
- ensure the case deletion flow checks that the requesting user owns the operation (or is an administrator)
- return 403/404 responses when deletion is forbidden or the operation is missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68cf41d160ec83269b193e37e53e2d79