### PR TITLE
Hide delete button for shared operations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4689,12 +4689,14 @@ useEffect(() => {
                               Partager
                             </button>
                           )}
-                          <button
-                            className="flex-1 px-3 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
-                            onClick={() => handleDeleteCase(c.id)}
-                          >
-                            Supprimer
-                          </button>
+                          {c.is_owner && (
+                            <button
+                              className="flex-1 px-3 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                              onClick={() => handleDeleteCase(c.id)}
+                            >
+                              Supprimer
+                            </button>
+                          )}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- hide the delete action for shared CDR operations so only the creator can remove them

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4417c27c8326877712386650094e