### PR TITLE
Add global fraud detection feature

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -25,6 +25,7 @@ import blacklistRoutes from './routes/blacklist.js';
 import logsRoutes from './routes/logs.js';
 import divisionsRoutes from './routes/divisions.js';
 import notificationsRoutes from './routes/notifications.js';
+import fraudRoutes from './routes/fraud.js';
 import { authenticate } from './middleware/auth.js';
 
 // Initialisation de la base de données
@@ -102,6 +103,7 @@ app.use('/api/blacklist', blacklistRoutes);
 app.use('/api/logs', logsRoutes);
 app.use('/api/divisions', divisionsRoutes);
 app.use('/api/notifications', notificationsRoutes);
+app.use('/api/fraud-detection', fraudRoutes);
 
 // Route de santé
 app.get('/api/health', (req, res) => {

--- a/server/routes/fraud.js
+++ b/server/routes/fraud.js
@@ -1,0 +1,51 @@
+import express from 'express';
+import { authenticate } from '../middleware/auth.js';
+import FraudDetectionService from '../services/FraudDetectionService.js';
+
+const router = express.Router();
+const fraudService = new FraudDetectionService();
+
+const isValidDate = (value) => {
+  if (!value) return false;
+  const str = String(value);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(str)) {
+    return false;
+  }
+  const date = new Date(str);
+  return !Number.isNaN(date.getTime());
+};
+
+router.get('/', authenticate, async (req, res) => {
+  try {
+    const { identifier = '', start, end } = req.query;
+    const trimmedIdentifier = typeof identifier === 'string' ? identifier.trim() : '';
+
+    if (!trimmedIdentifier) {
+      return res.status(400).json({ error: 'Numéro ou IMEI requis' });
+    }
+
+    if ((start && !isValidDate(start)) || (end && !isValidDate(end))) {
+      return res.status(400).json({ error: 'Format de date invalide (YYYY-MM-DD)' });
+    }
+
+    if (start && end && new Date(start) > new Date(end)) {
+      return res.status(400).json({ error: 'La date de début doit précéder la date de fin' });
+    }
+
+    const result = await fraudService.detectAcrossCases(
+      {
+        startDate: start || null,
+        endDate: end || null,
+        identifier: trimmedIdentifier,
+      },
+      req.user
+    );
+
+    res.json(result);
+  } catch (error) {
+    console.error('Erreur détection fraude globale:', error);
+    res.status(500).json({ error: 'Erreur lors de la détection de fraude' });
+  }
+});
+
+export default router;

--- a/server/services/FraudDetectionService.js
+++ b/server/services/FraudDetectionService.js
@@ -1,0 +1,229 @@
+import CaseService from './CaseService.js';
+import Cdr from '../models/Cdr.js';
+
+const normalizePhoneNumber = (value) => {
+  if (!value) return '';
+  let sanitized = String(value).trim();
+  if (!sanitized) return '';
+  sanitized = sanitized.replace(/\s+/g, '');
+  if (sanitized.startsWith('+')) {
+    sanitized = sanitized.slice(1);
+  }
+  while (sanitized.startsWith('00')) {
+    sanitized = sanitized.slice(2);
+  }
+  sanitized = sanitized.replace(/\D/g, '');
+  if (!sanitized) return '';
+  if (sanitized.startsWith('221')) {
+    return sanitized;
+  }
+  sanitized = sanitized.replace(/^0+/, '');
+  return sanitized ? `221${sanitized}` : '';
+};
+
+const normalizeDateValue = (value) => {
+  if (!value) return null;
+  const str = String(value).trim();
+  if (!str) return null;
+  const parsed = new Date(str);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString().split('T')[0];
+  }
+  const match = str.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (match) {
+    return `${match[3]}-${match[2]}-${match[1]}`;
+  }
+  return str;
+};
+
+const normalizeImei = (value) => {
+  if (!value) return '';
+  const digits = String(value).replace(/\D/g, '').trim();
+  return digits.length >= 5 ? digits : '';
+};
+
+class FraudDetectionService {
+  constructor() {
+    this.caseService = new CaseService();
+  }
+
+  async detectAcrossCases(options = {}, user) {
+    const { startDate = null, endDate = null, identifier = '' } = options;
+
+    const cases = await this.caseService.listCases(user);
+    const caseMetaMap = new Map();
+    const caseNames = [];
+
+    for (const item of cases || []) {
+      const name = item?.name ? String(item.name).trim() : '';
+      if (!name) {
+        continue;
+      }
+
+      if (!caseMetaMap.has(name)) {
+        caseMetaMap.set(name, {
+          id: item.id,
+          name,
+          owner: item.user_login || null,
+          division: item.division_name || null,
+        });
+        caseNames.push(name);
+      }
+    }
+
+    if (caseNames.length === 0) {
+      return { imeis: [], updatedAt: new Date().toISOString() };
+    }
+
+    const trimmedIdentifier = typeof identifier === 'string' ? identifier.trim() : '';
+    const normalizedNumberFilter = trimmedIdentifier ? normalizePhoneNumber(trimmedIdentifier) : '';
+    const normalizedImeiFilter = trimmedIdentifier ? normalizeImei(trimmedIdentifier) : '';
+    const hasFilter = Boolean(trimmedIdentifier);
+
+    const imeiMap = new Map();
+
+    for (const caseName of caseNames) {
+      try {
+        const rows = await Cdr.getImeiNumberPairs(caseName, { startDate, endDate });
+        const caseMeta = caseMetaMap.get(caseName);
+
+        for (const row of rows) {
+          const imei = String(row.imei || '').trim();
+          const normalizedNumber = normalizePhoneNumber(row.numero);
+          if (!imei || !normalizedNumber) {
+            continue;
+          }
+
+          const matchesNumber = normalizedNumberFilter
+            ? normalizedNumber === normalizedNumberFilter
+            : false;
+          const matchesImei = normalizedImeiFilter ? imei === normalizedImeiFilter : false;
+
+          if (hasFilter && !matchesNumber && !matchesImei) {
+            continue;
+          }
+
+          const normalizedDate = normalizeDateValue(row.call_date);
+          const role = String(row.role || '').trim();
+
+          let imeiEntry = imeiMap.get(imei);
+          if (!imeiEntry) {
+            imeiEntry = {
+              imei,
+              numbers: new Map(),
+            };
+            imeiMap.set(imei, imeiEntry);
+          }
+
+          let numberEntry = imeiEntry.numbers.get(normalizedNumber);
+          if (!numberEntry) {
+            numberEntry = {
+              number: normalizedNumber,
+              firstSeen: null,
+              lastSeen: null,
+              occurrences: 0,
+              roles: new Set(),
+              cases: new Map(),
+            };
+            imeiEntry.numbers.set(normalizedNumber, numberEntry);
+          }
+
+          numberEntry.occurrences += 1;
+          if (normalizedDate) {
+            if (!numberEntry.firstSeen || normalizedDate < numberEntry.firstSeen) {
+              numberEntry.firstSeen = normalizedDate;
+            }
+            if (!numberEntry.lastSeen || normalizedDate > numberEntry.lastSeen) {
+              numberEntry.lastSeen = normalizedDate;
+            }
+          }
+
+          if (role) {
+            numberEntry.roles.add(role);
+          }
+
+          if (caseMeta) {
+            numberEntry.cases.set(caseMeta.id, caseMeta);
+          }
+        }
+      } catch (error) {
+        console.error(`Erreur détection fraude globale pour ${caseName}:`, error);
+      }
+    }
+
+    const result = [];
+
+    for (const [imei, entry] of imeiMap.entries()) {
+      const numbers = Array.from(entry.numbers.values()).map((number) => ({
+        number: number.number,
+        firstSeen: number.firstSeen,
+        lastSeen: number.lastSeen,
+        occurrences: number.occurrences,
+        roles: Array.from(number.roles).sort(),
+        cases: Array.from(number.cases.values()),
+      }));
+
+      if (numbers.length < 2) {
+        continue;
+      }
+
+      const callerSet = new Set(
+        numbers
+          .filter((n) => n.roles.includes('caller'))
+          .map((n) => n.number)
+      );
+      const calleeSet = new Set(
+        numbers
+          .filter((n) => n.roles.includes('callee'))
+          .map((n) => n.number)
+      );
+
+      if (callerSet.size < 2 && calleeSet.size < 2) {
+        continue;
+      }
+
+      numbers.sort((a, b) => {
+        if (a.lastSeen && b.lastSeen && a.lastSeen !== b.lastSeen) {
+          return a.lastSeen > b.lastSeen ? -1 : 1;
+        }
+        return b.occurrences - a.occurrences;
+      });
+
+      const caseAccumulator = new Map();
+      for (const num of numbers) {
+        for (const info of num.cases) {
+          caseAccumulator.set(info.id, info);
+        }
+      }
+
+      result.push({
+        imei,
+        numbers,
+        roleSummary: {
+          caller: callerSet.size,
+          callee: calleeSet.size,
+        },
+        cases: Array.from(caseAccumulator.values()),
+      });
+    }
+
+    result.sort((a, b) => {
+      const aSuspicious = Math.max(a.roleSummary.caller, a.roleSummary.callee);
+      const bSuspicious = Math.max(b.roleSummary.caller, b.roleSummary.callee);
+      if (aSuspicious !== bSuspicious) {
+        return bSuspicious - aSuspicious;
+      }
+      if (a.numbers.length !== b.numbers.length) {
+        return b.numbers.length - a.numbers.length;
+      }
+      return a.imei.localeCompare(b.imei);
+    });
+
+    return {
+      imeis: result,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+}
+
+export default FraudDetectionService;


### PR DESCRIPTION
## Summary
- implement a `FraudDetectionService` that aggregates IMEI/numéro associations across all accessible CDR cases to flag shared devices
- expose the detection through a secured `/api/fraud-detection` route and register it in the Express app
- add a new "Détection de Fraude" page and navigation entry with a modern UI to launch the global analysis and display results

## Testing
- `npm run lint` *(fails: requires @eslint/js which is unavailable in the environment)*
- `npm run build` *(fails: vite is unavailable because dependency installation is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd093f5a483268411f417a617f2e1