### PR TITLE
feat: modernize logs management layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5753,47 +5753,111 @@ useEffect(() => {
         )}
 
         {currentPage === 'logs' && isAdmin && (
-          <div className="space-y-6">
+          <div className="space-y-8">
             <PageHeader icon={<List className="h-6 w-6" />} title="Logs" />
-            <div className="rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-lg shadow-slate-200/60 dark:bg-slate-900/70 dark:border-slate-700/60">
-              <div className="mb-4 flex">
-                <input
-                  type="text"
-                  value={logUserFilter}
-                  onChange={(e) => setLogUserFilter(e.target.value)}
-                  placeholder="Filtrer par utilisateur"
-                  className="flex-1 rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm text-slate-800 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500/70 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-100"
-                />
-                <button
-                  onClick={() => {
-                    fetchLogs(1);
-                    fetchSessions(1);
-                  }}
-                  className="ml-2 rounded-xl bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-indigo-500/40 transition-transform hover:-translate-y-0.5"
-                >
-                  Rechercher
-                </button>
-                <button
-                  onClick={exportLogs}
-                  className="ml-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-emerald-500/30 transition-transform hover:-translate-y-0.5 hover:bg-emerald-600"
-                >
-                  Exporter
-                </button>
+
+            <div className="overflow-hidden rounded-3xl border border-slate-200/80 bg-gradient-to-br from-white via-blue-50/60 to-indigo-50/40 p-8 shadow-xl shadow-blue-200/50 dark:border-slate-700/60 dark:from-slate-900/80 dark:via-slate-900/40 dark:to-blue-950/40">
+              <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+                <div className="max-w-xl">
+                  <p className="text-sm font-medium uppercase tracking-[0.35em] text-blue-600 dark:text-blue-300">Supervision</p>
+                  <h2 className="mt-2 text-3xl font-semibold text-slate-900 dark:text-slate-100">
+                    Surveillez les actions clés de votre plateforme
+                  </h2>
+                  <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                    Analysez les événements sensibles, repérez les alertes et suivez les sessions pour garantir la sécurité de vos opérations.
+                  </p>
+                </div>
+                <div className="grid w-full grid-cols-2 gap-4 sm:w-auto sm:grid-cols-2 md:grid-cols-2">
+                  <div className="rounded-2xl border border-white/80 bg-white/70 p-4 shadow-lg shadow-blue-100/40 backdrop-blur-sm dark:border-slate-700/70 dark:bg-slate-900/60">
+                    <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-300">Logs totaux</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100">{logTotal}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-300">Limité à {LOGS_LIMIT} par page</p>
+                  </div>
+                  <div className="rounded-2xl border border-white/80 bg-white/70 p-4 shadow-lg shadow-blue-100/40 backdrop-blur-sm dark:border-slate-700/70 dark:bg-slate-900/60">
+                    <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-300">Sessions actives</p>
+                    <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100">{sessionLogs.filter((session) => !session.logout_at).length}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-300">{sessionLogs.length} sessions récentes</p>
+                  </div>
+                </div>
               </div>
-              <div className="overflow-x-auto rounded-2xl border border-slate-200/80 bg-white/95 shadow-inner dark:bg-slate-900/60 dark:border-slate-700/60">
-                <table className="min-w-full text-left text-sm text-slate-700 dark:text-slate-200">
-                  <thead className="bg-slate-100/80 dark:bg-slate-800/80">
-                    <tr className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-300">
-                      <th className="px-6 py-3">Utilisateur</th>
-                      <th className="px-6 py-3">Action</th>
-                      <th className="px-6 py-3">Détails</th>
-                      <th className="px-6 py-3">Page</th>
-                      <th className="px-6 py-3">Profil</th>
-                      <th className="px-6 py-3">Durée (min)</th>
-                      <th className="px-6 py-3">Date</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-slate-200/70 dark:divide-slate-700/60">
+            </div>
+
+            <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+              <div className="xl:col-span-2">
+                <div className="rounded-3xl border border-slate-200/80 bg-white/95 p-6 shadow-xl shadow-slate-200/70 dark:bg-slate-900/70 dark:border-slate-700/60">
+                  <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Historique des actions</h3>
+                      <p className="text-sm text-slate-500 dark:text-slate-300">
+                        Filtrez par utilisateur pour isoler les événements critiques et exportez le journal complet.
+                      </p>
+                    </div>
+                    <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center md:w-auto">
+                      <form
+                        onSubmit={(e) => {
+                          e.preventDefault();
+                          fetchLogs(1);
+                          fetchSessions(1);
+                        }}
+                        className="flex w-full gap-2"
+                      >
+                        <div className="flex-1">
+                          <label htmlFor="logsUserFilter" className="sr-only">
+                            Filtrer par utilisateur
+                          </label>
+                          <input
+                            id="logsUserFilter"
+                            type="text"
+                            value={logUserFilter}
+                            onChange={(e) => setLogUserFilter(e.target.value)}
+                            placeholder="Filtrer par utilisateur"
+                            className="w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm text-slate-800 shadow-inner focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500/70 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-100"
+                          />
+                        </div>
+                        <button
+                          type="submit"
+                          className="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-indigo-500/40 transition-transform hover:-translate-y-0.5"
+                        >
+                          Rechercher
+                        </button>
+                      </form>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setLogUserFilter('');
+                            fetchLogs(1);
+                            fetchSessions(1);
+                          }}
+                          className="inline-flex items-center justify-center rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 transition hover:-translate-y-0.5 hover:bg-slate-100 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800/80"
+                        >
+                          Réinitialiser
+                        </button>
+                        <button
+                          type="button"
+                          onClick={exportLogs}
+                          className="inline-flex items-center justify-center rounded-2xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-emerald-500/30 transition-transform hover:-translate-y-0.5 hover:bg-emerald-600"
+                        >
+                          Exporter
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+
+                <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 shadow-inner dark:bg-slate-900/60 dark:border-slate-700/60">
+                  <table className="min-w-full text-left text-sm text-slate-700 dark:text-slate-200">
+                      <thead className="bg-gradient-to-r from-slate-100/90 via-slate-50/90 to-slate-100/90 text-slate-500 dark:from-slate-800/80 dark:via-slate-800/60 dark:to-slate-800/80 dark:text-slate-300">
+                        <tr className="text-xs font-semibold uppercase tracking-wider">
+                          <th className="px-6 py-3">Utilisateur</th>
+                          <th className="px-6 py-3">Action</th>
+                          <th className="px-6 py-3">Détails</th>
+                          <th className="px-6 py-3">Page</th>
+                          <th className="px-6 py-3">Profil</th>
+                          <th className="px-6 py-3">Durée (min)</th>
+                          <th className="px-6 py-3">Date</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-slate-200/70 dark:divide-slate-700/60">
                     {logsData.map((log: any) => {
                       let details: any = {};
                       try {
@@ -5929,19 +5993,23 @@ useEffect(() => {
                   </button>
                 </div>
               </div>
-              <div className="mt-8 rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-lg shadow-slate-200/60 dark:bg-slate-900/70 dark:border-slate-700/60">
-                <h4 className="text-lg font-semibold text-slate-800 dark:text-slate-100 mb-3 flex items-center gap-2">
-                  <Clock className="h-5 w-5 text-emerald-500" />
-                  Sessions utilisateur
-                </h4>
-                <div className="overflow-x-auto rounded-2xl border border-slate-200/80 bg-white/95 shadow-inner dark:bg-slate-900/60 dark:border-slate-700/60">
+              </div>
+              <div className="rounded-3xl border border-slate-200/80 bg-white/95 p-6 shadow-xl shadow-slate-200/70 dark:bg-slate-900/70 dark:border-slate-700/60">
+                <div className="flex flex-col gap-2 pb-4">
+                  <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.25em] text-emerald-500">
+                    <Clock className="h-4 w-4" /> Sessions
+                  </span>
+                  <h4 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Suivi des connexions</h4>
+                  <p className="text-sm text-slate-500 dark:text-slate-300">Comprenez l'activité des utilisateurs et repérez les sessions encore ouvertes.</p>
+                </div>
+                <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 shadow-inner dark:bg-slate-900/60 dark:border-slate-700/60">
                   <table className="min-w-full text-left text-sm text-slate-700 dark:text-slate-200">
-                    <thead className="bg-slate-100/80 dark:bg-slate-800/80">
-                      <tr className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-300">
-                        <th className="px-6 py-3">Utilisateur</th>
-                        <th className="px-6 py-3">Connexion</th>
-                        <th className="px-6 py-3">Déconnexion</th>
-                        <th className="px-6 py-3">Durée</th>
+                    <thead className="bg-gradient-to-r from-slate-100/90 via-slate-50/90 to-slate-100/90 text-slate-500 dark:from-slate-800/80 dark:via-slate-800/60 dark:to-slate-800/80 dark:text-slate-300">
+                      <tr className="text-xs font-semibold uppercase tracking-wider">
+                        <th className="px-5 py-3">Utilisateur</th>
+                        <th className="px-5 py-3">Connexion</th>
+                        <th className="px-5 py-3">Déconnexion</th>
+                        <th className="px-5 py-3">Durée</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-200/70 dark:divide-slate-700/60">
@@ -5958,10 +6026,10 @@ useEffect(() => {
                           const durationMinutes = Math.max(0, Math.round((session.duration_seconds ?? 0) / 60));
                           return (
                             <tr key={session.id} className="odd:bg-white even:bg-slate-50/70 dark:odd:bg-slate-900/40 dark:even:bg-slate-800/40">
-                              <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-slate-900 dark:text-slate-100">{session.username}</td>
-                              <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-500 dark:text-slate-300">{loginAt}</td>
-                              <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-500 dark:text-slate-300">{logoutAt}</td>
-                              <td className="px-6 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{durationMinutes} min</td>
+                              <td className="px-5 py-4 whitespace-nowrap text-sm font-medium text-slate-900 dark:text-slate-100">{session.username}</td>
+                              <td className="px-5 py-4 whitespace-nowrap text-sm text-slate-500 dark:text-slate-300">{loginAt}</td>
+                              <td className="px-5 py-4 whitespace-nowrap text-sm text-slate-500 dark:text-slate-300">{logoutAt}</td>
+                              <td className="px-5 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{durationMinutes} min</td>
                             </tr>
                           );
                         })


### PR DESCRIPTION
## Summary
- redesign the logs administration view with a hero banner, filter form, and refreshed table styling
- add quick stats for total logs and active sessions to surface key monitoring indicators
- introduce a dedicated sessions card aligned with the new layout and descriptive copy

## Testing
- `npm run lint` *(fails: requires @eslint/js package which cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d00cb8c8308326b8a97a845aacf97d