### PR TITLE
Fix dashboard top search terms conditional rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1982,6 +1982,7 @@ useEffect(() => {
     }));
   }, [numberFormatter, statsData]);
 
+  const topSearchTerms = useMemo(() => statsData?.top_search_terms ?? [], [statsData]);
 
   const handleCreateUser = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -6710,31 +6711,36 @@ useEffect(() => {
                   </div>
 
                   {/* Termes de recherche populaires */}
-                  <div className="bg-white rounded-2xl shadow-xl p-6 dark:bg-gray-800">
-                    <h3 className="text-xl font-bold text-gray-900 mb-6 flex items-center dark:text-gray-100">
-                      <TrendingUp className="h-6 w-6 mr-2 text-orange-600 dark:text-orange-400" />
-                      Termes de recherche populaires
-                    </h3>
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                      {statsData?.top_search_terms?.slice(0, 9).map((term, index) => (
-                        <div key={index} className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl hover:from-blue-50 hover:to-blue-100 transition-all dark:from-gray-800 dark:to-gray-700 dark:hover:from-blue-900 dark:hover:to-blue-800">
-                          <div className="flex items-center space-x-3">
-                            <div className="flex items-center justify-center w-8 h-8 bg-blue-100 rounded-full text-blue-600 font-bold text-sm dark:bg-blue-900 dark:text-blue-200">
-                              {index + 1}
+                    <div className="bg-white rounded-2xl shadow-xl p-6 dark:bg-gray-800">
+                      <h3 className="text-xl font-bold text-gray-900 mb-6 flex items-center dark:text-gray-100">
+                        <TrendingUp className="h-6 w-6 mr-2 text-orange-600 dark:text-orange-400" />
+                        Termes de recherche populaires
+                      </h3>
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {topSearchTerms.length > 0 ? (
+                          topSearchTerms.slice(0, 9).map((term, index) => (
+                            <div
+                              key={index}
+                              className="flex items-center justify-between p-4 bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl hover:from-blue-50 hover:to-blue-100 transition-all dark:from-gray-800 dark:to-gray-700 dark:hover:from-blue-900 dark:hover:to-blue-800"
+                            >
+                              <div className="flex items-center space-x-3">
+                                <div className="flex items-center justify-center w-8 h-8 bg-blue-100 rounded-full text-blue-600 font-bold text-sm dark:bg-blue-900 dark:text-blue-200">
+                                  {index + 1}
+                                </div>
+                                <span className="font-medium text-gray-900 truncate max-w-xs dark:text-gray-100">"{term.search_term}"</span>
+                              </div>
+                              <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                                {term.search_count} fois
+                              </span>
                             </div>
-                            <span className="font-medium text-gray-900 truncate max-w-xs dark:text-gray-100">"{term.search_term}"</span>
+                          ))
+                        ) : (
+                          <div className="col-span-full text-center py-8">
+                            <Search className="mx-auto h-12 w-12 text-gray-400 mb-4 dark:text-gray-500" />
+                            <p className="text-gray-500 dark:text-gray-400">Aucun terme de recherche populaire</p>
                           </div>
-                          <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                            {term.search_count} fois
-                          </span>
-                        </div>
-                      )) || (
-                        <div className="col-span-full text-center py-8">
-                          <Search className="mx-auto h-12 w-12 text-gray-400 mb-4 dark:text-gray-500" />
-                          <p className="text-gray-500 dark:text-gray-400">Aucun terme de recherche populaire</p>
-                        </div>
-                      )}
-                    </div>
+                        )}
+                      </div>
                   </div>
                 </>
               )}


### PR DESCRIPTION
## Summary
- derive `topSearchTerms` once from the dashboard stats
- render dashboard top-search tiles with an explicit conditional instead of relying on `||`

## Testing
- not run (npm install blocked by registry policy)


------
https://chatgpt.com/codex/tasks/task_e_68d010f828cc8326bdce57112f87f9df