### PR TITLE
Wrap App return content in fragment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3684,7 +3684,8 @@ useEffect(() => {
   };
 
   return (
-    <div
+    <>
+      <div
       className="min-h-screen flex bg-slate-100 dark:bg-gradient-to-br dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-900 dark:text-slate-100"
     >
       {!sidebarOpen && (
@@ -7160,6 +7161,8 @@ useEffect(() => {
         </div>
       )}
     </div>
+
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- wrap the `App` component's root markup in a React fragment so that the scroll button and modals can coexist with the main layout container without JSX adjacency errors

## Testing
- `npm run build` *(fails: vite not found because dependencies are unavailable in the environment)*
- `npm install` *(fails: registry access for @elastic/elasticsearch is forbidden in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0157d095083268cdbf6187a45a4c1