### PR TITLE
Fix closing tags in login view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3374,6 +3374,7 @@ useEffect(() => {
                   )}
                 </button>
               </form>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add the missing closing div in the login page wrapper so the JSX parses correctly

## Testing
- npm install *(fails: 403 Forbidden fetching @elastic/elasticsearch)*
- npm run build *(fails: vite not found because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d02f449bcc8326a40bd25fdbc79180