### PR TITLE
fix: monitor dashboard scrolling for inactivity timer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1231,14 +1231,32 @@ const App: React.FC = () => {
       'keydown',
       'touchstart',
       'scroll',
-      'focus'
+      'focus',
+      'wheel'
     ];
 
+    const scrollableElement = mainContentRef.current;
+    const elementActivityEvents: (keyof HTMLElementEventMap)[] = ['scroll', 'wheel'];
+    const handleElementActivity: EventListener = () => {
+      resetTimer();
+    };
+
     activityEvents.forEach((event) => window.addEventListener(event, resetTimer));
+    if (scrollableElement) {
+      elementActivityEvents.forEach((event) =>
+        scrollableElement.addEventListener(event, handleElementActivity)
+      );
+    }
+
     resetTimer();
 
     return () => {
       activityEvents.forEach((event) => window.removeEventListener(event, resetTimer));
+      if (scrollableElement) {
+        elementActivityEvents.forEach((event) =>
+          scrollableElement.removeEventListener(event, handleElementActivity)
+        );
+      }
       if (inactivityTimerRef.current !== null) {
         window.clearTimeout(inactivityTimerRef.current);
         inactivityTimerRef.current = null;


### PR DESCRIPTION
## Summary
- listen for wheel and scroll events on the dashboard's scrollable container so user scrolling resets the inactivity timer

## Testing
- npm install *(fails: 403 Forbidden when downloading @elastic/elasticsearch from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d10cf2b6408326bab6436a2070f300