### PR TITLE
Fix load callback initialization order

### DIFF
--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -193,25 +193,6 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit, currentUser
     setPage(1);
   }, [view, query]);
 
-  const handleSearch = useCallback(() => {
-    if (page !== 1) {
-      setPage(1);
-    } else {
-      load();
-    }
-  }, [load, page]);
-
-  const buildProtectedUrl = (relativePath?: string | null) => {
-    if (!relativePath) return null;
-    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
-    const normalized = relativePath.startsWith('/') ? relativePath : `/${relativePath}`;
-    if (!token) return normalized;
-    const separator = normalized.includes('?') ? '&' : '?';
-    return `${normalized}${separator}token=${encodeURIComponent(token)}`;
-  };
-
-  const selectedPhotoUrl = selected ? buildProtectedUrl(selected.photo_path) : null;
-
   const load = useCallback(async () => {
     try {
       setLoading(true);
@@ -258,6 +239,25 @@ const ProfileList: React.FC<ProfileListProps> = ({ onCreate, onEdit, currentUser
   useEffect(() => {
     load();
   }, [load]);
+
+  const handleSearch = useCallback(() => {
+    if (page !== 1) {
+      setPage(1);
+    } else {
+      load();
+    }
+  }, [load, page]);
+
+  const buildProtectedUrl = (relativePath?: string | null) => {
+    if (!relativePath) return null;
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    const normalized = relativePath.startsWith('/') ? relativePath : `/${relativePath}`;
+    if (!token) return normalized;
+    const separator = normalized.includes('?') ? '&' : '?';
+    return `${normalized}${separator}token=${encodeURIComponent(token)}`;
+  };
+
+  const selectedPhotoUrl = selected ? buildProtectedUrl(selected.photo_path) : null;
 
   const remove = async (id: number) => {
     if (!window.confirm('Supprimer définitivement ce profil ?')) return;


### PR DESCRIPTION
## Summary
- move the `load` callback definition before its usages in `ProfileList`
- prevent accessing the `load` callback before initialization when triggering searches

## Testing
- `npm run lint` *(fails: missing dev dependency `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68d1154b9ef88326a01ea38a5d21b458