### PR TITLE
fix: filter archive view to archived profiles only

### DIFF
--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -69,7 +69,9 @@ class Profile {
     const conditions = [];
     const params = [];
 
-    if (!includeArchived) {
+    if (includeArchived) {
+      conditions.push('p.archived_at IS NOT NULL');
+    } else {
       conditions.push('p.archived_at IS NULL');
     }
 


### PR DESCRIPTION
## Summary
- require `archived_at` to be set when the archive view is requested so only archived profiles are returned

## Testing
- not run (environment lacks dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68d1159f6ce08326a937c453b53cba68