### PR TITLE
Remove profile archiving feature

### DIFF
--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -59,21 +59,9 @@ class Profile {
     return true;
   }
 
-  static buildAccessConditions({
-    userId,
-    divisionId,
-    isAdmin,
-    includeArchived,
-    search
-  }) {
+  static buildAccessConditions({ userId, divisionId, isAdmin, search }) {
     const conditions = [];
     const params = [];
-
-    if (includeArchived) {
-      conditions.push('p.archived_at IS NOT NULL');
-    } else {
-      conditions.push('p.archived_at IS NULL');
-    }
 
     if (!isAdmin) {
       if (userId == null) {
@@ -104,7 +92,6 @@ class Profile {
     userId = null,
     divisionId = null,
     isAdmin = false,
-    includeArchived = false,
     search = '',
     limit = 10,
     offset = 0
@@ -113,14 +100,13 @@ class Profile {
       userId,
       divisionId,
       isAdmin,
-      includeArchived,
       search: search ? String(search) : ''
     });
 
     const rows = await database.query(
       `${PROFILE_BASE_SELECT}
        ${whereClause}
-       ORDER BY p.archived_at IS NULL DESC, p.created_at DESC
+       ORDER BY p.created_at DESC
        LIMIT ? OFFSET ?`,
       [...params, limit, offset]
     );
@@ -137,8 +123,8 @@ class Profile {
   }
 
   static async findAll(userId = null, limit = 10, offset = 0, options = {}) {
-    const { divisionId = null, isAdmin = false, includeArchived = false } = options;
-    return this.findAccessible({ userId, divisionId, isAdmin, includeArchived, limit, offset });
+    const { divisionId = null, isAdmin = false } = options;
+    return this.findAccessible({ userId, divisionId, isAdmin, limit, offset });
   }
 
   static async searchByNameOrPhone(
@@ -147,14 +133,12 @@ class Profile {
     isAdmin,
     limit = 10,
     offset = 0,
-    divisionId = null,
-    includeArchived = false
+    divisionId = null
   ) {
     return this.findAccessible({
       userId,
       divisionId,
       isAdmin,
-      includeArchived,
       search: term,
       limit,
       offset

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -30,19 +30,6 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
-const parseBoolean = value => {
-  if (typeof value === 'boolean') return value;
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-  }
-  if (typeof value === 'number') {
-    return value === 1;
-  }
-  return false;
-};
-
 const parseAttachmentPayload = data => {
   if (data.extra_fields && typeof data.extra_fields === 'string') {
     try {
@@ -96,13 +83,11 @@ router.get('/', async (req, res) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 10;
-    const includeArchived = parseBoolean(req.query?.archived);
     const { rows, total } = await service.list(
       req.user,
       req.query.q,
       page,
-      limit,
-      includeArchived
+      limit
     );
     res.json({ profiles: rows, total });
   } catch (error) {
@@ -136,21 +121,6 @@ router.patch(
     }
   }
 );
-
-router.post('/:id/archive', async (req, res) => {
-  try {
-    const profileId = parseInt(req.params.id, 10);
-    if (Number.isNaN(profileId)) {
-      return res.status(400).json({ error: 'Identifiant invalide' });
-    }
-    const shouldArchive = parseBoolean(req.body?.archived);
-    const profile = await service.setArchiveStatus(profileId, shouldArchive, req.user);
-    res.json({ profile });
-  } catch (error) {
-    const status = error.message === 'Profil non trouvé' ? 404 : error.message === 'Accès refusé' ? 403 : 500;
-    res.status(status).json({ error: error.message });
-  }
-});
 
 router.delete('/:id', async (req, res) => {
   try {

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -144,20 +144,6 @@ class ProfileService {
     return this.withAttachments(await Profile.findById(id));
   }
 
-  async setArchiveStatus(id, archived, user) {
-    const existing = await Profile.findById(id);
-    if (!existing) throw new Error('Profil non trouvé');
-    const isAdmin = user.admin === 1 || user.admin === '1' || user.admin === true;
-    if (!isAdmin && existing.user_id !== user.id) {
-      throw new Error('Accès refusé');
-    }
-    const updateData = {
-      archived_at: archived ? new Date() : null
-    };
-    await Profile.update(id, updateData);
-    return this.withAttachments(await Profile.findById(id));
-  }
-
   async delete(id, user) {
     const existing = await Profile.findById(id);
     if (!existing) throw new Error('Profil non trouvé');
@@ -190,7 +176,7 @@ class ProfileService {
     return this.withAttachments(profile);
   }
 
-  async list(user, search, page = 1, limit = 10, includeArchived = false) {
+  async list(user, search, page = 1, limit = 10) {
     const offset = (page - 1) * limit;
     const isAdmin = user.admin === 1 || user.admin === '1' || user.admin === true;
     const divisionId =
@@ -201,7 +187,6 @@ class ProfileService {
       userId: user.id,
       divisionId,
       isAdmin,
-      includeArchived,
       search,
       limit,
       offset


### PR DESCRIPTION
## Summary
- remove archived profile filters, sorting, and update helpers on the API
- drop the archive toggle endpoint and related service logic
- simplify the profile list UI to no longer expose archive tabs or actions

## Testing
- npm run build *(fails: `vite: not found` because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11a7e92e883268e31fa4d025e52ea