### PR TITLE
feat: add profile sharing and refresh fraud detection UI

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -301,6 +301,20 @@ class DatabaseManager {
       `);
 
       await this.query(`
+        CREATE TABLE IF NOT EXISTS autres.profile_shares (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          profile_id INT NOT NULL,
+          user_id INT NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE KEY unique_profile_user (profile_id, user_id),
+          INDEX idx_profile_share_profile (profile_id),
+          INDEX idx_profile_share_user (user_id),
+          FOREIGN KEY (profile_id) REFERENCES autres.profiles(id) ON DELETE CASCADE,
+          FOREIGN KEY (user_id) REFERENCES autres.users(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      `);
+
+      await this.query(`
         CREATE TABLE IF NOT EXISTS autres.identified_numbers (
           id INT AUTO_INCREMENT PRIMARY KEY,
           phone VARCHAR(50) NOT NULL UNIQUE,

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -67,15 +67,10 @@ class Profile {
       if (userId == null) {
         throw new Error('User id requis');
       }
-      const normalizedDivisionId =
-        divisionId !== undefined && divisionId !== null ? Number(divisionId) : null;
-      if (normalizedDivisionId) {
-        conditions.push('(p.user_id = ? OR u.division_id = ?)');
-        params.push(userId, normalizedDivisionId);
-      } else {
-        conditions.push('p.user_id = ?');
-        params.push(userId);
-      }
+      conditions.push(
+        '(p.user_id = ? OR EXISTS (SELECT 1 FROM autres.profile_shares ps WHERE ps.profile_id = p.id AND ps.user_id = ?))'
+      );
+      params.push(userId, userId);
     }
 
     if (search) {

--- a/server/models/ProfileShare.js
+++ b/server/models/ProfileShare.js
@@ -1,0 +1,72 @@
+import database from '../config/database.js';
+
+class ProfileShare {
+  static async getUserIds(profileId) {
+    if (!profileId) return [];
+    const rows = await database.query(
+      `SELECT user_id FROM autres.profile_shares WHERE profile_id = ?`,
+      [profileId]
+    );
+    return rows.map((row) => row.user_id);
+  }
+
+  static async getSharesForProfiles(profileIds = []) {
+    const map = new Map();
+    if (!Array.isArray(profileIds) || profileIds.length === 0) {
+      return map;
+    }
+    const placeholders = profileIds.map(() => '?').join(',');
+    const rows = await database.query(
+      `SELECT profile_id, user_id FROM autres.profile_shares WHERE profile_id IN (${placeholders})`,
+      profileIds
+    );
+    for (const row of rows) {
+      if (!map.has(row.profile_id)) {
+        map.set(row.profile_id, []);
+      }
+      map.get(row.profile_id).push(row.user_id);
+    }
+    return map;
+  }
+
+  static async replaceShares(profileId, userIds) {
+    if (!profileId) {
+      return { added: [], removed: [] };
+    }
+    const normalized = Array.isArray(userIds)
+      ? Array.from(new Set(userIds.map((id) => Number(id)).filter((id) => Number.isInteger(id) && id > 0)))
+      : [];
+    const current = await this.getUserIds(profileId);
+    const toRemove = current.filter((id) => !normalized.includes(id));
+    const toAdd = normalized.filter((id) => !current.includes(id));
+
+    if (toRemove.length > 0) {
+      const placeholders = toRemove.map(() => '?').join(',');
+      await database.query(
+        `DELETE FROM autres.profile_shares WHERE profile_id = ? AND user_id IN (${placeholders})`,
+        [profileId, ...toRemove]
+      );
+    }
+
+    for (const userId of toAdd) {
+      await database.query(
+        `INSERT INTO autres.profile_shares (profile_id, user_id) VALUES (?, ?)
+         ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)`,
+        [profileId, userId]
+      );
+    }
+
+    return { added: toAdd, removed: toRemove };
+  }
+
+  static async isSharedWithUser(profileId, userId) {
+    if (!profileId || !userId) return false;
+    const row = await database.queryOne(
+      `SELECT 1 FROM autres.profile_shares WHERE profile_id = ? AND user_id = ? LIMIT 1`,
+      [profileId, userId]
+    );
+    return Boolean(row);
+  }
+}
+
+export default ProfileShare;

--- a/server/routes/profiles.js
+++ b/server/routes/profiles.js
@@ -95,6 +95,52 @@ router.get('/', async (req, res) => {
   }
 });
 
+router.get('/:id/share', async (req, res) => {
+  try {
+    const profileId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(profileId)) {
+      return res.status(400).json({ error: 'ID de profil invalide' });
+    }
+    const info = await service.getShareInfo(profileId, req.user);
+    res.json(info);
+  } catch (error) {
+    if (error.message === 'Profil non trouvé') {
+      return res.status(404).json({ error: 'Profil introuvable' });
+    }
+    if (error.message === 'Accès refusé') {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.post('/:id/share', async (req, res) => {
+  try {
+    const profileId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(profileId)) {
+      return res.status(400).json({ error: 'ID de profil invalide' });
+    }
+    const shareAll = req.body.shareAll === true || req.body.shareAll === 'true';
+    const userIds = Array.isArray(req.body.userIds) ? req.body.userIds : [];
+    const result = await service.shareProfile(profileId, req.user, {
+      userIds,
+      shareAll
+    });
+    res.json(result);
+  } catch (error) {
+    if (error.message === 'Profil non trouvé') {
+      return res.status(404).json({ error: 'Profil introuvable' });
+    }
+    if (error.message === 'Accès refusé') {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    if (error.message === 'Division introuvable pour le propriétaire') {
+      return res.status(400).json({ error: "Division introuvable pour le propriétaire du profil" });
+    }
+    res.status(500).json({ error: error.message });
+  }
+});
+
 router.get('/:id', async (req, res) => {
   try {
     const profile = await service.get(parseInt(req.params.id), req.user);


### PR DESCRIPTION
## Summary
- add profile sharing persistence with a dedicated table, model helpers and guarded share endpoints
- expose share metadata through the profile service and refresh the profile list UI with share controls and modal
- redesign fraud detection views with statistic highlights and richer card layouts

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11dfba0e48326b925fa726bf312a0