### PR TITLE
fix: correct ProfileShare insert SQL literal

### DIFF
--- a/server/models/ProfileShare.js
+++ b/server/models/ProfileShare.js
@@ -50,8 +50,7 @@ class ProfileShare {
 
     for (const userId of toAdd) {
       await database.query(
-        `INSERT INTO autres.profile_shares (profile_id, user_id) VALUES (?, ?)
-         ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)`,
+        `INSERT INTO autres.profile_shares (profile_id, user_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)`,
         [profileId, userId]
       );
     }


### PR DESCRIPTION
## Summary
- wrap the replaceShares insert statement in a single template literal so it parses correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d122950f588326bf398fe8445f33c8