### PR TITLE
Remove stray marker from TOTP util

### DIFF
--- a/server/utils/totp.js
+++ b/server/utils/totp.js
@@ -118,4 +118,3 @@ export function buildQrCodeUrl(otpauthUrl, size = 200) {
   const encoded = encodeURIComponent(otpauthUrl);
   return `https://chart.googleapis.com/chart?chs=${size}x${size}&chld=M|0&cht=qr&chl=${encoded}`;
 }
-*** End File


### PR DESCRIPTION
## Summary
- remove an accidental "*** End File" marker left in the TOTP utility module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1329886288326b84b2c9a5a6018b3