### PR TITLE
Ensure database queries wait for initialization

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -516,7 +516,9 @@ class DatabaseManager {
 
   async query(sql, params = []) {
     try {
-      await this.ensureInitialized();
+      if (!this.pool) {
+        await this.ensureInitialized();
+      }
       const [rows] = await this.pool.execute(sql, params);
       return rows;
     } catch (error) {
@@ -527,7 +529,9 @@ class DatabaseManager {
 
   async queryOne(sql, params = []) {
     try {
-      await this.ensureInitialized();
+      if (!this.pool) {
+        await this.ensureInitialized();
+      }
       const [rows] = await this.pool.execute(sql, params);
       return rows[0] || null;
     } catch (error) {


### PR DESCRIPTION
## Summary
- avoid re-awaiting the initialization promise when the pool has already been created
- let bootstrap queries run immediately once the pool exists while still waiting for late callers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d133e6015c83269cb37d78d61bab9f