### PR TITLE
Fix profile share foreign key violation

### DIFF
--- a/server/models/ProfileShare.js
+++ b/server/models/ProfileShare.js
@@ -38,7 +38,17 @@ class ProfileShare {
       : [];
     const current = await this.getUserIds(profileId);
     const toRemove = current.filter((id) => !normalized.includes(id));
-    const toAdd = normalized.filter((id) => !current.includes(id));
+    let toAdd = normalized.filter((id) => !current.includes(id));
+
+    if (toAdd.length > 0) {
+      const placeholders = toAdd.map(() => '?').join(',');
+      const validRows = await database.query(
+        `SELECT id FROM autres.users WHERE id IN (${placeholders})`,
+        toAdd
+      );
+      const validIds = new Set(validRows.map((row) => row.id));
+      toAdd = toAdd.filter((id) => validIds.has(id));
+    }
 
     if (toRemove.length > 0) {
       const placeholders = toRemove.map(() => '?').join(',');


### PR DESCRIPTION
## Summary
- ensure profile sharing only attempts to insert recipients that still exist in the users table to avoid foreign key errors

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d14e5dc9708326a2fc7a1aa78f4f9b