### PR TITLE
Replace gradients with solid blue styling

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1094,7 +1094,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
       <div
         style={{
           transform: `rotate(${carAngle}deg)`,
-          background: 'linear-gradient(135deg, #312e81, #2563eb, #0ea5e9)',
+          backgroundColor: '#2563eb',
           borderRadius: '14px',
           width: size,
           height: size,

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,16 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  [class*="bg-gradient-to-"],
+  [class*="dark:bg-gradient-to-"],
+  [class*="bg-[radial-gradient"],
+  [class*="dark:bg-[radial-gradient"] {
+    background-image: none !important;
+    background-color: #2563eb !important;
+  }
+}
+
 @layer components {
     .dark .text-gray-600 { @apply text-slate-300; }
     .dark .text-gray-700 { @apply text-slate-300; }


### PR DESCRIPTION
## Summary
- override all gradient utility classes to render as a flat blue background so every component now uses a consistent solid color instead of gradients
- adjust the CDR map vehicle icon styling to use the same blue background color rather than a gradient fill

## Testing
- `npm run build` *(fails: vite not found because dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d1691f4c60832699e9d6f6d63b5bc8