### PR TITLE
Restore gradient visual style

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1094,7 +1094,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
       <div
         style={{
           transform: `rotate(${carAngle}deg)`,
-          backgroundColor: '#2563eb',
+          background: 'linear-gradient(135deg, #312e81, #2563eb, #0ea5e9)',
           borderRadius: '14px',
           width: size,
           height: size,

--- a/src/index.css
+++ b/src/index.css
@@ -37,16 +37,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer utilities {
-  [class*="bg-gradient-to-"],
-  [class*="dark:bg-gradient-to-"],
-  [class*="bg-[radial-gradient"],
-  [class*="dark:bg-[radial-gradient"] {
-    background-image: none !important;
-    background-color: #2563eb !important;
-  }
-}
-
 @layer components {
     .dark .text-gray-600 { @apply text-slate-300; }
     .dark .text-gray-700 { @apply text-slate-300; }


### PR DESCRIPTION
## Summary
- restore the gradient fill for the vehicle icon on the CDR map
- remove the forced solid blue override so existing gradient backgrounds appear again

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d16dbed3188326a7509b9cea671fa3