### PR TITLE
Localize pagination labels and remove gradients

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -1094,7 +1094,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
       <div
         style={{
           transform: `rotate(${carAngle}deg)`,
-          background: 'linear-gradient(135deg, #312e81, #2563eb, #0ea5e9)',
+          backgroundColor: '#2563eb',
           borderRadius: '14px',
           width: size,
           height: size,

--- a/src/components/PaginationControls.tsx
+++ b/src/components/PaginationControls.tsx
@@ -65,7 +65,7 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
           className="inline-flex items-center gap-1 rounded-full border border-slate-200/80 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800/60"
         >
           <ChevronLeft className="h-4 w-4" />
-          Back
+          Précédent
         </button>
         {pages.map((page, index) =>
           typeof page === 'number' ? (
@@ -96,7 +96,7 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
           disabled={currentPage >= totalPages}
           className="inline-flex items-center gap-1 rounded-full border border-slate-200/80 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800/60"
         >
-          Forward
+          Suivant
           <ChevronRight className="h-4 w-4" />
         </button>
       </div>
@@ -108,12 +108,12 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
             disabled={!canLoadMore}
             className="inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white px-4 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800/60"
           >
-            Load more
+            Charger plus
           </button>
         )}
         {showPageSize && pageSizeOptions && onPageSizeChange && (
           <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
-            Show
+            Afficher
             <select
               value={pageSize}
               onChange={(event) => onPageSizeChange(Number(event.target.value))}

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,21 @@
   }
 }
 
+[class*="bg-gradient-"] {
+  background-image: none !important;
+  background-color: var(--tw-gradient-from, transparent) !important;
+}
+
+[class*="bg-gradient-"].bg-clip-text,
+[class*="bg-gradient-"].bg-clip-text.text-transparent {
+  color: var(--tw-gradient-from, currentColor) !important;
+  background-color: transparent !important;
+}
+
+[class*="bg-[radial-gradient"] {
+  background-image: none !important;
+}
+
 @tailwind components;
 @tailwind utilities;
 


### PR DESCRIPTION
## Summary
- localize pagination control labels into French
- override gradient utility classes to render as solid fills and neutralize radial gradients
- replace the inline gradient map icon background with a flat color

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks without npm install)*
- npm install *(fails: registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d16fbc67b483269bc953900752789c