### PR TITLE
Refine PDF exports and surface division data

### DIFF
--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -319,6 +319,13 @@ class ProfileService {
     try {
       const { default: PDFDocument } = await import('pdfkit');
       const doc = new PDFDocument({ margin: 50 });
+      const exportDateLabel = new Intl.DateTimeFormat('fr-FR', {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      }).format(new Date());
       const stream = new PassThrough();
       const chunks = [];
       doc.pipe(stream);
@@ -383,9 +390,9 @@ class ProfileService {
           });
         doc
           .font('Helvetica')
-          .fontSize(12)
+          .fontSize(11)
           .fillColor('#E0ECFF')
-          .text('Profil confidentiel', 0, headerHeight / 2 + 14, {
+          .text(`Exporté le ${exportDateLabel}`, 0, headerHeight / 2 + 10, {
             width: pageWidth,
             align: 'center'
           });


### PR DESCRIPTION
## Summary
- update profile PDF headers to replace the confidential banner with an export timestamp
- redesign operation report PDFs with a modern layout, refreshed metadata cards, and a persistent Sora signature
- surface division assignments in the UI and extend admin dashboard statistics with a detailed data source block

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d252b2e6288326be3f437f8c9a38a8