### PR TITLE
Retirer les sources de données du dashboard admin et isoler les administrateurs des divisions

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -8,9 +8,11 @@ class User {
     const { login, mdp, admin = 0, active = 1, division_id } = userData;
     const hashedPassword = await bcrypt.hash(mdp, 12);
 
+    const normalizedDivisionId = division_id ?? null;
+
     const result = await database.query(
       'INSERT INTO autres.users (login, mdp, admin, active, division_id) VALUES (?, ?, ?, ?, ?)',
-      [login, hashedPassword, admin, active, division_id]
+      [login, hashedPassword, admin, active, normalizedDivisionId]
     );
 
     return {
@@ -19,7 +21,7 @@ class User {
       mdp: hashedPassword,
       admin,
       active,
-      division_id,
+      division_id: normalizedDivisionId,
       otp_enabled: 0
     };
   }

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -421,26 +421,10 @@ class CaseService {
         doc.save();
         doc.roundedRect(signatureX, signatureY, signatureWidth, signatureHeight, 18).fill(colors.signatureBg);
         doc
-          .font('Helvetica')
-          .fontSize(8)
-          .fillColor(colors.signatureText)
-          .text('Signature officielle', signatureX + 20, signatureY + 16, {
-            width: signatureWidth - 40,
-            align: 'right'
-          });
-        doc
           .font('Helvetica-Bold')
-          .fontSize(20)
+          .fontSize(22)
           .fillColor('#FFFFFF')
-          .text('SORA', signatureX + 20, signatureY + 28, {
-            width: signatureWidth - 40,
-            align: 'right'
-          });
-        doc
-          .font('Helvetica')
-          .fontSize(9)
-          .fillColor(colors.accentSecondary)
-          .text('Division Intelligence & Analyse', signatureX + 20, signatureY + 50, {
+          .text('SORA', signatureX + 20, signatureY + 34, {
             width: signatureWidth - 40,
             align: 'right'
           });


### PR DESCRIPTION
## Summary
- remove the data source metrics and listing from the administrator dashboard UI and simplify the associated statistic loading logic
- ensure administrators are not tied to any division on both the frontend forms and backend user management endpoints
- update the operations PDF signature to display only the SORA application name

## Testing
- `npm run lint` *(fails: missing eslint-plugin-react-hooks because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d25a565e748326bcf72be8ca156542