### PR TITLE
Simplify operations PDF signature styling

### DIFF
--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -413,8 +413,8 @@ class CaseService {
       const drawSignature = () => {
         const previousX = doc.x;
         const previousY = doc.y;
-        const previousFontSize = doc._fontSize;
-        const previousFillColor = doc._fillColor;
+
+        doc.save();
 
         const signatureWidth = 120;
         const signatureX = doc.page.width - doc.page.margins.right - signatureWidth;
@@ -435,7 +435,7 @@ class CaseService {
             align: 'right'
           });
 
-        doc.fontSize(previousFontSize).fillColor(previousFillColor);
+        doc.restore();
         doc.x = previousX;
         doc.y = previousY;
       };


### PR DESCRIPTION
## Summary
- restore the graphics state when drawing the footer signature so later content keeps its original font

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d26d6666e083268eb521bc1733def2