### PR TITLE
Refine CDR layout for fraud detection panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3759,174 +3759,180 @@ useEffect(() => {
 
   const renderCdrSearchForm = () => {
     const detectionSection = !showCdrMap && selectedCase && (
-      <section className="mt-8 overflow-hidden rounded-3xl border border-slate-200/70 bg-white shadow-xl shadow-slate-200/60 dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/40">
-        <div className="bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 px-6 py-6 text-white">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="space-y-1">
-              <p className="text-xs uppercase tracking-wide text-white/70">Détection de fraude</p>
-              <h3 className="text-2xl font-semibold">Changement de numéro</h3>
-              <p className="text-sm text-white/80">
-                Analysez les numéros utilisés par les terminaux identifiés dans l'opération en cours.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={fetchFraudDetection}
-              disabled={fraudLoading || !selectedCase || cdrIdentifiers.length === 0}
-              className="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-black/20 transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {fraudLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Scan className="h-4 w-4" />}
-              <span>Analyser</span>
-            </button>
-          </div>
-          <div className="mt-5 grid gap-3 sm:grid-cols-3">
-            <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
-              <p className="text-white/70">IMEI analysés</p>
-              <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalImeis}</p>
-            </div>
-            <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
-              <p className="text-white/70">Numéros détectés</p>
-              <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalNumbers}</p>
-            </div>
-            <div
-              className={`rounded-2xl px-4 py-3 text-sm ${
-                fraudStats.newNumbers > 0
-                  ? 'border border-rose-100/60 bg-rose-500/40 text-white'
-                  : 'border border-emerald-100/60 bg-emerald-500/30 text-white'
-              }`}
-            >
-              <p className="text-white/80">Nouveaux numéros</p>
-              <p className="mt-1 text-2xl font-semibold">{fraudStats.newNumbers}</p>
-            </div>
-          </div>
-        </div>
-        <div className="space-y-6 p-6">
-          {fraudError && (
-            <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
-              {fraudError}
-            </div>
-          )}
-          {cdrIdentifiers.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
-              Ajoutez au moins un numéro dans la recherche pour lancer l’analyse de fraude.
-            </div>
-          ) : fraudLoading ? (
-            <div className="flex items-center justify-center py-10">
-              <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-slate-100" />
-            </div>
-          ) : fraudResult ? (
-            <div className="space-y-6">
-              <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                <span>Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}</span>
-                {hasFraudSuspiciousNumbers && (
-                  <span className="inline-flex items-center gap-2 rounded-full bg-rose-500/10 px-3 py-1 font-semibold text-rose-500 dark:text-rose-300">
-                    <AlertTriangle className="h-3.5 w-3.5" /> Anomalies détectées
-                  </span>
-                )}
+      <section className="relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/95 shadow-2xl shadow-slate-200/70 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/50">
+        <div
+          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-500/15 via-indigo-500/10 to-purple-500/20"
+          aria-hidden="true"
+        />
+        <div className="relative z-[1]">
+          <div className="bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 px-6 py-6 text-white">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-wide text-white/70">Détection de fraude</p>
+                <h3 className="text-2xl font-semibold">Changement de numéro</h3>
+                <p className="text-sm text-white/80">
+                  Analysez les numéros utilisés par les terminaux identifiés dans l'opération en cours.
+                </p>
               </div>
-              {fraudResult.imeis.length === 0 ? (
-                <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-700 shadow-inner dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100">
-                  Aucun changement de numéro détecté pour les identifiants recherchés.
+              <button
+                type="button"
+                onClick={fetchFraudDetection}
+                disabled={fraudLoading || !selectedCase || cdrIdentifiers.length === 0}
+                className="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-black/20 transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {fraudLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Scan className="h-4 w-4" />}
+                <span>Analyser</span>
+              </button>
+            </div>
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
+                <p className="text-white/70">IMEI analysés</p>
+                <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalImeis}</p>
+              </div>
+              <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
+                <p className="text-white/70">Numéros détectés</p>
+                <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalNumbers}</p>
+              </div>
+              <div
+                className={`rounded-2xl px-4 py-3 text-sm ${
+                  fraudStats.newNumbers > 0
+                    ? 'border border-rose-100/60 bg-rose-500/40 text-white'
+                    : 'border border-emerald-100/60 bg-emerald-500/30 text-white'
+                }`}
+              >
+                <p className="text-white/80">Nouveaux numéros</p>
+                <p className="mt-1 text-2xl font-semibold">{fraudStats.newNumbers}</p>
+              </div>
+            </div>
+          </div>
+          <div className="space-y-6 p-6">
+            {fraudError && (
+              <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+                {fraudError}
+              </div>
+            )}
+            {cdrIdentifiers.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+                Ajoutez au moins un numéro dans la recherche pour lancer l’analyse de fraude.
+              </div>
+            ) : fraudLoading ? (
+              <div className="flex items-center justify-center py-10">
+                <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-slate-100" />
+              </div>
+            ) : fraudResult ? (
+              <div className="space-y-6">
+                <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  <span>Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}</span>
+                  {hasFraudSuspiciousNumbers && (
+                    <span className="inline-flex items-center gap-2 rounded-full bg-rose-500/10 px-3 py-1 font-semibold text-rose-500 dark:text-rose-300">
+                      <AlertTriangle className="h-3.5 w-3.5" /> Anomalies détectées
+                    </span>
+                  )}
                 </div>
-              ) : (
-                fraudResult.imeis.map((imeiEntry) => (
-                  <div
-                    key={imeiEntry.imei}
-                    className="space-y-4 rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm dark:border-white/10 dark:bg-slate-900/60"
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div>
-                        <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">IMEI {imeiEntry.imei}</p>
-                        <p className="text-xs text-slate-500 dark:text-slate-400">
-                          {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''} détecté{imeiEntry.numbers.length > 1 ? 's' : ''}
-                        </p>
+                {fraudResult.imeis.length === 0 ? (
+                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-700 shadow-inner dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100">
+                    Aucun changement de numéro détecté pour les identifiants recherchés.
+                  </div>
+                ) : (
+                  fraudResult.imeis.map((imeiEntry) => (
+                    <div
+                      key={imeiEntry.imei}
+                      className="space-y-4 rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm dark:border-white/10 dark:bg-slate-900/60"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">IMEI {imeiEntry.imei}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
+                            {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''} détecté{imeiEntry.numbers.length > 1 ? 's' : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-3 text-xs">
+                          <span className="inline-flex items-center gap-1 rounded-full bg-slate-100/70 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                            <Activity className="h-3.5 w-3.5" /> {imeiEntry.numbers.reduce((acc, item) => acc + item.occurrences, 0)} occurrences
+                          </span>
+                        </div>
                       </div>
-                      <div className="flex items-center gap-3 text-xs">
-                        <span className="inline-flex items-center gap-1 rounded-full bg-slate-100/70 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                          <Activity className="h-3.5 w-3.5" /> {imeiEntry.numbers.reduce((acc, item) => acc + item.occurrences, 0)} occurrences
-                        </span>
-                      </div>
-                    </div>
-                    {imeiEntry.numbers.length === 0 ? (
-                      <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
-                        Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
-                      </div>
-                    ) : (
-                      <div className="space-y-3">
-                        {imeiEntry.numbers.map((numberEntry) => {
-                          const isNew = numberEntry.status === 'nouveau';
-                          return (
-                            <div
-                              key={`${imeiEntry.imei}-${numberEntry.number}`}
-                              className={`rounded-2xl border px-4 py-3 transition shadow-sm ${
-                                isNew
-                                  ? 'border-rose-200 bg-rose-50 dark:border-rose-500/40 dark:bg-rose-500/10'
-                                  : 'border-slate-200 bg-slate-50/70 dark:border-slate-700/60 dark:bg-slate-900/50'
-                              }`}
-                            >
-                              <div className="flex flex-wrap items-center justify-between gap-3">
-                                <div>
-                                  <p className="text-base font-semibold text-slate-800 dark:text-slate-100">{numberEntry.number}</p>
-                                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
-                                    <span
-                                      className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-semibold ${
-                                        isNew
-                                          ? 'bg-rose-500/20 text-rose-600 dark:text-rose-200'
-                                          : 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-200'
-                                      }`}
-                                    >
-                                      {isNew ? 'Nouveau numéro détecté' : 'Numéro attendu'}
+                      {imeiEntry.numbers.length === 0 ? (
+                        <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+                          Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
+                        </div>
+                      ) : (
+                        <div className="space-y-3">
+                          {imeiEntry.numbers.map((numberEntry) => {
+                            const isNew = numberEntry.status === 'nouveau';
+                            return (
+                              <div
+                                key={`${imeiEntry.imei}-${numberEntry.number}`}
+                                className={`rounded-2xl border px-4 py-3 transition shadow-sm ${
+                                  isNew
+                                    ? 'border-rose-200 bg-rose-50 dark:border-rose-500/40 dark:bg-rose-500/10'
+                                    : 'border-slate-200 bg-slate-50/70 dark:border-slate-700/60 dark:bg-slate-900/50'
+                                }`}
+                              >
+                                <div className="flex flex-wrap items-center justify-between gap-3">
+                                  <div>
+                                    <p className="text-base font-semibold text-slate-800 dark:text-slate-100">{numberEntry.number}</p>
+                                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                                      <span
+                                        className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-semibold ${
+                                          isNew
+                                            ? 'bg-rose-500/20 text-rose-600 dark:text-rose-200'
+                                            : 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-200'
+                                        }`}
+                                      >
+                                        {isNew ? 'Nouveau numéro détecté' : 'Numéro attendu'}
+                                      </span>
+                                      <span className="inline-flex items-center gap-1 rounded-full bg-slate-200/80 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                                        <Clock className="h-3.5 w-3.5" /> {numberEntry.occurrences} occurrence{numberEntry.occurrences > 1 ? 's' : ''}
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div className="flex flex-col items-end text-xs text-slate-500 dark:text-slate-300">
+                                    <span>
+                                      Première vue :{' '}
+                                      <span className="font-semibold text-slate-700 dark:text-slate-100">
+                                        {formatFraudDate(numberEntry.firstSeen)}
+                                      </span>
                                     </span>
-                                    <span className="inline-flex items-center gap-1 rounded-full bg-slate-200/80 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                                      <Clock className="h-3.5 w-3.5" /> {numberEntry.occurrences} occurrence{numberEntry.occurrences > 1 ? 's' : ''}
+                                    <span>
+                                      Dernière vue :{' '}
+                                      <span className="font-semibold text-slate-700 dark:text-slate-100">
+                                        {formatFraudDate(numberEntry.lastSeen)}
+                                      </span>
                                     </span>
                                   </div>
                                 </div>
-                                <div className="flex flex-col items-end text-xs text-slate-500 dark:text-slate-300">
-                                  <span>
-                                    Première vue :{' '}
-                                    <span className="font-semibold text-slate-700 dark:text-slate-100">
-                                      {formatFraudDate(numberEntry.firstSeen)}
+                                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                                  {numberEntry.roles.length === 0 ? (
+                                    <span className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                                      Aucun rôle identifié
                                     </span>
-                                  </span>
-                                  <span>
-                                    Dernière vue :{' '}
-                                    <span className="font-semibold text-slate-700 dark:text-slate-100">
-                                      {formatFraudDate(numberEntry.lastSeen)}
-                                    </span>
-                                  </span>
+                                  ) : (
+                                    numberEntry.roles.map((role) => (
+                                      <span
+                                        key={role}
+                                        className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200"
+                                      >
+                                        {FRAUD_ROLE_LABELS[role] || role}
+                                      </span>
+                                    ))
+                                  )}
                                 </div>
                               </div>
-                              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
-                                {numberEntry.roles.length === 0 ? (
-                                  <span className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                                    Aucun rôle identifié
-                                  </span>
-                                ) : (
-                                  numberEntry.roles.map((role) => (
-                                    <span
-                                      key={role}
-                                      className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200"
-                                    >
-                                      {FRAUD_ROLE_LABELS[role] || role}
-                                    </span>
-                                  ))
-                                )}
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-                ))
-              )}
-            </div>
-          ) : (
-            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
-              Lancez une analyse pour détecter les nouveaux numéros associés aux identifiants recherchés.
-            </div>
-          )}
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  ))
+                )}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+                Lancez une analyse pour détecter les nouveaux numéros associés aux identifiants recherchés.
+              </div>
+            )}
+          </div>
         </div>
       </section>
     );
@@ -4104,10 +4110,29 @@ useEffect(() => {
       </section>
     );
 
-    const formContent = (
+    const hasDetectionSection = Boolean(detectionSection);
+    const baseFormLayoutClass = 'flex flex-col gap-8';
+    const responsiveLayoutClass = hasDetectionSection
+      ? `${baseFormLayoutClass} xl:grid xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] xl:items-start`
+      : baseFormLayoutClass;
+
+    const formContent = showCdrMap ? (
       <div className="space-y-6">
         {searchSection}
-        {detectionSection}
+        {hasDetectionSection && <div className="pt-2">{detectionSection}</div>}
+      </div>
+    ) : (
+      <div className={responsiveLayoutClass}>
+        <div className="space-y-6">{searchSection}</div>
+        {hasDetectionSection && (
+          <div className="relative">
+            <div
+              className="absolute -inset-0.5 -z-10 rounded-3xl bg-gradient-to-br from-blue-500/30 via-indigo-500/20 to-purple-500/30 opacity-60 blur-2xl"
+              aria-hidden="true"
+            />
+            {detectionSection}
+          </div>
+        )}
       </div>
     );
 


### PR DESCRIPTION
## Summary
- refresh the fraud detection panel with a modern translucent card treatment and ambient gradient glow
- lay out the CDR search form and fraud detection card side by side on wide screens to visually detach them while keeping generous spacing on smaller viewports

## Testing
- `npm run lint` *(fails: Missing eslint-plugin-react-hooks dependency; npm install blocked by registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d28a17e5848326a8181257821734f7