### PR TITLE
Restore legacy design for CDR tables

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,6 @@ import {
   X,
   Scan,
   MapPinOff,
-  Sparkles,
   CheckCircle2
 } from 'lucide-react';
 import ToggleSwitch from './components/ToggleSwitch';
@@ -3761,74 +3760,70 @@ useEffect(() => {
 
   const renderCdrSearchForm = () => {
     const detectionSection = !showCdrMap && selectedCase && (
-      <section className="relative overflow-hidden rounded-4xl border border-slate-200/70 bg-white/95 shadow-2xl shadow-slate-200/70 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/40">
+      <section className="relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/95 shadow-2xl shadow-slate-200/70 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/50">
         <div
-          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-indigo-500/10 via-blue-500/10 to-purple-500/15"
+          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-500/15 via-indigo-500/10 to-purple-500/20"
           aria-hidden="true"
         />
         <div className="relative z-[1]">
-          <div className="border-b border-white/20 bg-gradient-to-br from-indigo-600 via-blue-600 to-sky-500 p-8 text-white">
-            <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-              <div className="space-y-3">
-                <span className="inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.4em] text-white/80">
-                  <Sparkles className="h-4 w-4" />
-                  Détection proactive
-                </span>
-                <h3 className="text-3xl font-semibold leading-tight">Changement de numéro</h3>
-                <p className="text-sm text-white/80 lg:max-w-2xl">
-                  Analysez instantanément les nouveaux numéros utilisés par les terminaux identifiés dans l'opération en cours.
+          <div className="bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 px-6 py-6 text-white">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-1">
+                <p className="text-xs uppercase tracking-wide text-white/70">Détection de fraude</p>
+                <h3 className="text-2xl font-semibold">Changement de numéro</h3>
+                <p className="text-sm text-white/80">
+                  Analysez les numéros utilisés par les terminaux identifiés dans l'opération en cours.
                 </p>
               </div>
               <button
                 type="button"
                 onClick={fetchFraudDetection}
                 disabled={fraudLoading || !selectedCase || cdrIdentifiers.length === 0}
-                className="inline-flex items-center gap-2 rounded-full bg-white/15 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-black/20 transition hover:bg-white/25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
+                className="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-black/20 transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {fraudLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Scan className="h-4 w-4" />}
-                <span>Lancer l'analyse</span>
+                <span>Analyser</span>
               </button>
             </div>
-            <div className="mt-8 grid gap-4 sm:grid-cols-3">
-              <div className="rounded-3xl border border-white/25 bg-white/10 px-5 py-4 shadow-lg shadow-black/10 backdrop-blur">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-white/70">IMEI analysés</p>
-                <p className="mt-2 text-2xl font-semibold text-white">{fraudStats.totalImeis}</p>
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
+                <p className="text-white/70">IMEI analysés</p>
+                <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalImeis}</p>
               </div>
-              <div className="rounded-3xl border border-white/25 bg-white/10 px-5 py-4 shadow-lg shadow-black/10 backdrop-blur">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-white/70">Numéros détectés</p>
-                <p className="mt-2 text-2xl font-semibold text-white">{fraudStats.totalNumbers}</p>
+              <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
+                <p className="text-white/70">Numéros détectés</p>
+                <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalNumbers}</p>
               </div>
               <div
-                className={`rounded-3xl px-5 py-4 shadow-lg shadow-black/10 backdrop-blur ${
+                className={`rounded-2xl px-4 py-3 text-sm ${
                   fraudStats.newNumbers > 0
                     ? 'border border-rose-100/60 bg-rose-500/40 text-white'
-                    : 'border border-emerald-100/60 bg-emerald-500/40 text-white'
+                    : 'border border-emerald-100/60 bg-emerald-500/30 text-white'
                 }`}
               >
-                <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-white/80">Nouveaux numéros</p>
-                <p className="mt-2 text-2xl font-semibold">{fraudStats.newNumbers}</p>
+                <p className="text-white/80">Nouveaux numéros</p>
+                <p className="mt-1 text-2xl font-semibold">{fraudStats.newNumbers}</p>
               </div>
             </div>
           </div>
-          <div className="space-y-6 p-8">
+          <div className="space-y-6 p-6">
             {fraudError && (
-              <div className="flex items-start gap-3 rounded-3xl border border-rose-200 bg-rose-50/90 px-4 py-3 text-sm font-medium text-rose-700 shadow-inner dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
-                <AlertTriangle className="h-4 w-4 flex-shrink-0" />
-                <span>{fraudError}</span>
+              <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+                {fraudError}
               </div>
             )}
             {cdrIdentifiers.length === 0 ? (
-              <div className="rounded-3xl border border-dashed border-slate-300/80 bg-slate-50/80 px-4 py-5 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+              <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
                 Ajoutez au moins un numéro dans la recherche pour lancer l’analyse de fraude.
               </div>
             ) : fraudLoading ? (
-              <div className="flex items-center justify-center py-12">
+              <div className="flex items-center justify-center py-10">
                 <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-slate-100" />
               </div>
             ) : fraudResult ? (
               <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-500 dark:text-slate-400">
-                  <span>Dernière analyse : {formatFraudDateTime(fraudResult.updatedAt)}</span>
+                <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  <span>Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}</span>
                   {hasFraudSuspiciousNumbers && (
                     <span className="inline-flex items-center gap-2 rounded-full bg-rose-500/10 px-3 py-1 font-semibold text-rose-500 dark:text-rose-300">
                       <AlertTriangle className="h-3.5 w-3.5" /> Anomalies détectées
@@ -3836,14 +3831,14 @@ useEffect(() => {
                   )}
                 </div>
                 {fraudResult.imeis.length === 0 ? (
-                  <div className="rounded-3xl border border-emerald-200 bg-emerald-50/90 px-4 py-5 text-sm text-emerald-700 shadow-inner dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100">
+                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-700 shadow-inner dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100">
                     Aucun changement de numéro détecté pour les identifiants recherchés.
                   </div>
                 ) : (
                   fraudResult.imeis.map((imeiEntry) => (
                     <div
                       key={imeiEntry.imei}
-                      className="space-y-4 rounded-3xl border border-slate-200/80 bg-white/95 p-6 shadow-lg shadow-slate-200/40 dark:border-slate-700/60 dark:bg-slate-900/70"
+                      className="space-y-4 rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm dark:border-white/10 dark:bg-slate-900/60"
                     >
                       <div className="flex flex-wrap items-center justify-between gap-3">
                         <div>
@@ -3852,12 +3847,14 @@ useEffect(() => {
                             {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''} détecté{imeiEntry.numbers.length > 1 ? 's' : ''}
                           </p>
                         </div>
-                        <span className="inline-flex items-center gap-2 rounded-full bg-slate-100/80 px-3 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                          <Activity className="h-3.5 w-3.5" /> {imeiEntry.numbers.reduce((acc, item) => acc + item.occurrences, 0)} occurrences
-                        </span>
+                        <div className="flex items-center gap-3 text-xs">
+                          <span className="inline-flex items-center gap-1 rounded-full bg-slate-100/70 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                            <Activity className="h-3.5 w-3.5" /> {imeiEntry.numbers.reduce((acc, item) => acc + item.occurrences, 0)} occurrences
+                          </span>
+                        </div>
                       </div>
                       {imeiEntry.numbers.length === 0 ? (
-                        <div className="rounded-3xl border border-dashed border-slate-200/80 bg-slate-50/70 px-4 py-4 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+                        <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
                           Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
                         </div>
                       ) : (
@@ -3867,63 +3864,55 @@ useEffect(() => {
                             return (
                               <div
                                 key={`${imeiEntry.imei}-${numberEntry.number}`}
-                                className={`rounded-2xl border px-4 py-4 shadow-sm transition-all ${
+                                className={`rounded-2xl border px-4 py-3 transition shadow-sm ${
                                   isNew
-                                    ? 'border-rose-200/70 bg-rose-50/80 dark:border-rose-500/40 dark:bg-rose-500/10'
-                                    : 'border-slate-200/80 bg-slate-50/70 dark:border-slate-700/60 dark:bg-slate-900/50'
+                                    ? 'border-rose-200 bg-rose-50 dark:border-rose-500/40 dark:bg-rose-500/10'
+                                    : 'border-slate-200 bg-slate-50/70 dark:border-slate-700/60 dark:bg-slate-900/50'
                                 }`}
                               >
-                                <div className="flex flex-wrap items-start justify-between gap-4">
-                                  <div className="space-y-2">
-                                    <p
-                                      className={`text-lg font-semibold ${
-                                        isNew ? 'text-rose-600 dark:text-rose-100' : 'text-slate-800 dark:text-slate-100'
-                                      }`}
-                                    >
-                                      {numberEntry.number}
-                                    </p>
-                                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                                <div className="flex flex-wrap items-center justify-between gap-3">
+                                  <div>
+                                    <p className="text-base font-semibold text-slate-800 dark:text-slate-100">{numberEntry.number}</p>
+                                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
                                       <span
                                         className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-semibold ${
                                           isNew
-                                            ? 'bg-rose-500/20 text-rose-700 dark:text-rose-200'
-                                            : 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-200'
+                                            ? 'bg-rose-500/20 text-rose-600 dark:text-rose-200'
+                                            : 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-200'
                                         }`}
                                       >
                                         {isNew ? 'Nouveau numéro détecté' : 'Numéro attendu'}
                                       </span>
                                       <span className="inline-flex items-center gap-1 rounded-full bg-slate-200/80 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                                        <Activity className="h-3.5 w-3.5" /> {numberEntry.occurrences} occurrence{numberEntry.occurrences > 1 ? 's' : ''}
+                                        <Clock className="h-3.5 w-3.5" /> {numberEntry.occurrences} occurrence{numberEntry.occurrences > 1 ? 's' : ''}
                                       </span>
                                     </div>
                                   </div>
-                                  <div className="grid gap-2 text-xs text-slate-500 dark:text-slate-300">
-                                    <div className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 shadow-sm dark:bg-slate-900/50">
-                                      <Clock className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
-                                      <span>
-                                        <span className="font-semibold text-slate-700 dark:text-slate-100">Première vue :</span>{' '}
+                                  <div className="flex flex-col items-end text-xs text-slate-500 dark:text-slate-300">
+                                    <span>
+                                      Première vue :{' '}
+                                      <span className="font-semibold text-slate-700 dark:text-slate-100">
                                         {formatFraudDate(numberEntry.firstSeen)}
                                       </span>
-                                    </div>
-                                    <div className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 shadow-sm dark:bg-slate-900/50">
-                                      <Timer className="h-3.5 w-3.5 text-slate-400 dark:text-slate-500" />
-                                      <span>
-                                        <span className="font-semibold text-slate-700 dark:text-slate-100">Dernière vue :</span>{' '}
+                                    </span>
+                                    <span>
+                                      Dernière vue :{' '}
+                                      <span className="font-semibold text-slate-700 dark:text-slate-100">
                                         {formatFraudDate(numberEntry.lastSeen)}
                                       </span>
-                                    </div>
+                                    </span>
                                   </div>
                                 </div>
                                 <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
                                   {numberEntry.roles.length === 0 ? (
-                                    <span className="inline-flex items-center gap-2 rounded-full bg-slate-200/80 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                                    <span className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
                                       Aucun rôle identifié
                                     </span>
                                   ) : (
                                     numberEntry.roles.map((role) => (
                                       <span
                                         key={role}
-                                        className="inline-flex items-center gap-2 rounded-full bg-slate-200/80 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200"
+                                        className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200"
                                       >
                                         {FRAUD_ROLE_LABELS[role] || role}
                                       </span>
@@ -3940,7 +3929,7 @@ useEffect(() => {
                 )}
               </div>
             ) : (
-              <div className="rounded-3xl border border-slate-200/80 bg-slate-50/80 px-4 py-5 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
                 Lancez une analyse pour détecter les nouveaux numéros associés aux identifiants recherchés.
               </div>
             )}
@@ -3950,198 +3939,175 @@ useEffect(() => {
     );
 
     const searchSection = (
-      <section className="relative overflow-hidden rounded-4xl border border-slate-200/70 bg-white/95 shadow-xl shadow-slate-200/60 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/40">
-        <div
-          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-500/10 via-indigo-500/10 to-purple-500/15"
-          aria-hidden="true"
-        />
-        <div className="relative z-[1]">
-          <div className="border-b border-white/20 bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 p-8 text-white">
-            <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-              <div className="space-y-3">
-                <span className="inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.4em] text-white/80">
-                  <Sparkles className="h-4 w-4" />
-                  Recherche CDR
-                </span>
-                <h3 className="text-3xl font-semibold leading-tight">Explorer les communications</h3>
-                <p className="text-sm text-white/80 lg:max-w-2xl">
-                  Affinez votre requête pour visualiser les interactions clés et les déplacements associés à votre opération.
-                </p>
-              </div>
-              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/15 text-white">
-                <Search className="h-7 w-7" />
-              </div>
+      <section className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white/95 shadow-xl shadow-slate-200/60 backdrop-blur-sm dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/40">
+        <div className="border-b border-slate-200/70 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 p-6 text-white dark:border-slate-700/60">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold">Recherche CDR</h3>
+              <p className="text-sm text-white/80">Affinez votre requête pour visualiser les communications pertinentes.</p>
+            </div>
+            <div className="hidden md:flex h-12 w-12 items-center justify-center rounded-2xl bg-white/20">
+              <Search className="h-6 w-6" />
             </div>
           </div>
-          <form onSubmit={handleCdrSearch} className="space-y-6 p-8">
-            <div className="space-y-3">
-              <label className="text-sm font-semibold text-slate-700 dark:text-slate-200">Numéros recherchés</label>
-              <div className="flex flex-wrap items-center gap-2 rounded-3xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm shadow-inner dark:border-slate-700/60 dark:bg-slate-900/60">
-                {cdrIdentifiers.map((id, idx) => (
-                  <span
-                    key={idx}
-                    className="inline-flex items-center gap-1 rounded-full border border-blue-200/70 bg-blue-50/80 px-3 py-1 font-medium text-blue-700 shadow-sm dark:border-blue-500/30 dark:bg-blue-500/20 dark:text-blue-200"
-                  >
-                    {id}
-                    <button
-                      type="button"
-                      onClick={() => removeCdrIdentifier(idx)}
-                      className="text-blue-500 transition hover:text-blue-700 dark:text-blue-200 dark:hover:text-blue-100"
-                    >
-                      <X size={14} />
-                    </button>
-                  </span>
-                ))}
-                <input
-                  type="text"
-                  value={cdrIdentifierInput}
-                  onChange={(e) => setCdrIdentifierInput(e.target.value)}
-                  onBlur={(e) => setCdrIdentifierInput(normalizeCdrNumber(e.target.value))}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      addCdrIdentifier();
-                    }
-                  }}
-                  placeholder="Ajouter un numéro"
-                  className="flex-1 min-w-[150px] border-none bg-transparent py-1 text-sm placeholder:text-slate-400 focus:outline-none focus:ring-0 dark:placeholder:text-slate-500"
-                />
-              </div>
-              <p className="text-xs text-slate-500 dark:text-slate-400">Appuyez sur Entrée pour ajouter un numéro à la liste.</p>
-            </div>
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <label className="text-sm font-semibold text-slate-700 dark:text-slate-200">Date de début</label>
-                <input
-                  type="date"
-                  value={cdrStart}
-                  onChange={(e) => setCdrStart(e.target.value)}
-                  className="w-full rounded-3xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-100"
-                />
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-semibold text-slate-700 dark:text-slate-200">Date de fin</label>
-                <input
-                  type="date"
-                  value={cdrEnd}
-                  onChange={(e) => setCdrEnd(e.target.value)}
-                  className="w-full rounded-3xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-100"
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <label className="text-sm font-semibold text-slate-700 dark:text-slate-200">Heure de début</label>
-                <input
-                  type="time"
-                  value={cdrStartTime}
-                  onChange={(e) => setCdrStartTime(e.target.value)}
-                  className="w-full rounded-3xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-100"
-                />
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-semibold text-slate-700 dark:text-slate-200">Heure de fin</label>
-                <input
-                  type="time"
-                  value={cdrEndTime}
-                  onChange={(e) => setCdrEndTime(e.target.value)}
-                  className="w-full rounded-3xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-100"
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              <div className="rounded-2xl border border-slate-200/80 bg-white/70 px-4 py-3 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
-                <ToggleSwitch
-                  label={
-                    <div className="flex items-center gap-2">
-                      <PhoneIncoming className="h-4 w-4 text-emerald-500" />
-                      <span>Appels entrants</span>
-                    </div>
-                  }
-                  checked={cdrIncoming}
-                  onChange={setCdrIncoming}
-                  activeColor="peer-checked:bg-emerald-500 dark:peer-checked:bg-emerald-500"
-                />
-              </div>
-              <div className="rounded-2xl border border-slate-200/80 bg-white/70 px-4 py-3 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
-                <ToggleSwitch
-                  label={
-                    <div className="flex items-center gap-2">
-                      <PhoneOutgoing className="h-4 w-4 text-blue-500" />
-                      <span>Appels sortants</span>
-                    </div>
-                  }
-                  checked={cdrOutgoing}
-                  onChange={setCdrOutgoing}
-                  activeColor="peer-checked:bg-blue-500 dark:peer-checked:bg-blue-500"
-                />
-              </div>
-              <div className="rounded-2xl border border-slate-200/80 bg-white/70 px-4 py-3 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
-                <ToggleSwitch
-                  label={
-                    <div className="flex items-center gap-2">
-                      <MessageSquare className="h-4 w-4 text-green-500" />
-                      <span>SMS</span>
-                    </div>
-                  }
-                  checked={cdrSms}
-                  onChange={setCdrSms}
-                  activeColor="peer-checked:bg-green-500 dark:peer-checked:bg-green-500"
-                />
-              </div>
-              <div className="rounded-2xl border border-slate-200/80 bg-white/70 px-4 py-3 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
-                <ToggleSwitch
-                  label={
-                    <div className="flex items-center gap-2">
-                      <MapPin className="h-4 w-4 text-rose-500" />
-                      <span>Position</span>
-                    </div>
-                  }
-                  checked={cdrPosition}
-                  onChange={setCdrPosition}
-                  activeColor="peer-checked:bg-rose-500 dark:peer-checked:bg-rose-500"
-                />
-              </div>
-              <div className="rounded-2xl border border-slate-200/80 bg-white/70 px-4 py-3 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60">
-                <ToggleSwitch
-                  label={
-                    <div className="flex items-center gap-2">
-                      <Car className="h-4 w-4 text-indigo-500" />
-                      <span>Itinéraire</span>
-                    </div>
-                  }
-                  checked={cdrItinerary}
-                  onChange={setCdrItinerary}
-                  activeColor="peer-checked:bg-indigo-500 dark:peer-checked:bg-indigo-500"
-                />
-              </div>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-3">
-              <button
-                type="submit"
-                disabled={cdrLoading}
-                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-sky-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <Search className="h-4 w-4" />
-                <span>Lancer la recherche</span>
-              </button>
-              {caseFiles.filter((f) => f.cdr_number).length >= 2 && (
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-fuchsia-500 via-rose-500 to-orange-400 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-rose-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
-                  onClick={handleLinkDiagram}
-                >
-                  <Share2 className="h-4 w-4" />
-                  <span>Diagramme des liens</span>
-                </button>
-              )}
-            </div>
-          </form>
         </div>
+        <form onSubmit={handleCdrSearch} className="space-y-5 p-6">
+          <div>
+            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Numéros recherchés</label>
+            <div className="mt-2 flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/80 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700/60 dark:bg-slate-900/50">
+              {cdrIdentifiers.map((id, idx) => (
+                <span
+                  key={idx}
+                  className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 font-medium text-blue-700 dark:bg-blue-500/20 dark:text-blue-200"
+                >
+                  {id}
+                  <button
+                    type="button"
+                    onClick={() => removeCdrIdentifier(idx)}
+                    className="text-blue-500 transition hover:text-blue-700 dark:hover:text-blue-100"
+                  >
+                    <X size={14} />
+                  </button>
+                </span>
+              ))}
+              <input
+                type="text"
+                value={cdrIdentifierInput}
+                onChange={(e) => setCdrIdentifierInput(e.target.value)}
+                onBlur={(e) => setCdrIdentifierInput(normalizeCdrNumber(e.target.value))}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addCdrIdentifier();
+                  }
+                }}
+                placeholder="Ajouter un numéro"
+                className="flex-1 min-w-[150px] border-none bg-transparent py-1 text-sm focus:outline-none focus:ring-0"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Date de début</label>
+              <input
+                type="date"
+                value={cdrStart}
+                onChange={(e) => setCdrStart(e.target.value)}
+                className="w-full rounded-2xl border border-slate-200/80 px-4 py-2 text-sm shadow-inner focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:border-slate-700/60 dark:bg-slate-900/60"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Date de fin</label>
+              <input
+                type="date"
+                value={cdrEnd}
+                onChange={(e) => setCdrEnd(e.target.value)}
+                className="w-full rounded-2xl border border-slate-200/80 px-4 py-2 text-sm shadow-inner focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:border-slate-700/60 dark:bg-slate-900/60"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Heure de début</label>
+              <input
+                type="time"
+                value={cdrStartTime}
+                onChange={(e) => setCdrStartTime(e.target.value)}
+                className="w-full rounded-2xl border border-slate-200/80 px-4 py-2 text-sm shadow-inner focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:border-slate-700/60 dark:bg-slate-900/60"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Heure de fin</label>
+              <input
+                type="time"
+                value={cdrEndTime}
+                onChange={(e) => setCdrEndTime(e.target.value)}
+                className="w-full rounded-2xl border border-slate-200/80 px-4 py-2 text-sm shadow-inner focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:border-slate-700/60 dark:bg-slate-900/60"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <ToggleSwitch
+              label={
+                <div className="flex items-center gap-2">
+                  <PhoneIncoming className="h-4 w-4 text-emerald-500" />
+                  <span>Appels entrants</span>
+                </div>
+              }
+              checked={cdrIncoming}
+              onChange={setCdrIncoming}
+              activeColor="peer-checked:bg-emerald-500 dark:peer-checked:bg-emerald-500"
+            />
+            <ToggleSwitch
+              label={
+                <div className="flex items-center gap-2">
+                  <PhoneOutgoing className="h-4 w-4 text-blue-500" />
+                  <span>Appels sortants</span>
+                </div>
+              }
+              checked={cdrOutgoing}
+              onChange={setCdrOutgoing}
+              activeColor="peer-checked:bg-blue-500 dark:peer-checked:bg-blue-500"
+            />
+            <ToggleSwitch
+              label={
+                <div className="flex items-center gap-2">
+                  <MessageSquare className="h-4 w-4 text-green-500" />
+                  <span>SMS</span>
+                </div>
+              }
+              checked={cdrSms}
+              onChange={setCdrSms}
+              activeColor="peer-checked:bg-green-500 dark:peer-checked:bg-green-500"
+            />
+            <ToggleSwitch
+              label={
+                <div className="flex items-center gap-2">
+                  <MapPin className="h-4 w-4 text-rose-500" />
+                  <span>Position</span>
+                </div>
+              }
+              checked={cdrPosition}
+              onChange={setCdrPosition}
+              activeColor="peer-checked:bg-rose-500 dark:peer-checked:bg-rose-500"
+            />
+            <ToggleSwitch
+              label={
+                <div className="flex items-center gap-2">
+                  <Car className="h-4 w-4 text-indigo-500" />
+                  <span>Itinéraire</span>
+                </div>
+              }
+              checked={cdrItinerary}
+              onChange={setCdrItinerary}
+              activeColor="peer-checked:bg-indigo-500 dark:peer-checked:bg-indigo-500"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="submit"
+              disabled={cdrLoading}
+              className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-sky-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Search className="h-4 w-4" />
+              <span>Rechercher</span>
+            </button>
+            {caseFiles.filter((f) => f.cdr_number).length >= 2 && (
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-fuchsia-500 via-rose-500 to-orange-400 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-rose-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
+                onClick={handleLinkDiagram}
+              >
+                <Share2 className="h-4 w-4" />
+                <span>Diagramme des liens</span>
+              </button>
+            )}
+          </div>
+        </form>
       </section>
     );
 


### PR DESCRIPTION
## Summary
- revert the Détection proactive panel to its previous gradient card layout and messaging
- restore the classic Recherche CDR card structure with legacy styling and form controls
- drop the unused Sparkles icon import left over from the redesign

## Testing
- npm run lint *(fails: Cannot find package 'eslint-plugin-react-hooks' in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d292acfb2083269a17dae60e95860d