### PR TITLE
Combine CDR search and number change panels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3759,204 +3759,76 @@ useEffect(() => {
   }
 
   const renderCdrSearchForm = () => {
-    const detectionSection = !showCdrMap && selectedCase && (
-      <section className="relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/95 shadow-2xl shadow-slate-200/70 backdrop-blur-xl dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/50">
-        <div
-          className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-500/15 via-indigo-500/10 to-purple-500/20"
-          aria-hidden="true"
-        />
-        <div className="relative z-[1]">
-          <div className="bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 px-6 py-6 text-white">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-              <div className="space-y-1">
-                <p className="text-xs uppercase tracking-wide text-white/70">Détection de fraude</p>
-                <h3 className="text-2xl font-semibold">Changement de numéro</h3>
-                <p className="text-sm text-white/80">
-                  Analysez les numéros utilisés par les terminaux identifiés dans l'opération en cours.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={fetchFraudDetection}
-                disabled={fraudLoading || !selectedCase || cdrIdentifiers.length === 0}
-                className="inline-flex items-center gap-2 rounded-full bg-white/10 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-black/20 transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {fraudLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Scan className="h-4 w-4" />}
-                <span>Analyser</span>
-              </button>
-            </div>
-            <div className="mt-5 grid gap-3 sm:grid-cols-3">
-              <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
-                <p className="text-white/70">IMEI analysés</p>
-                <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalImeis}</p>
-              </div>
-              <div className="rounded-2xl border border-white/30 bg-white/10 px-4 py-3 text-sm">
-                <p className="text-white/70">Numéros détectés</p>
-                <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalNumbers}</p>
-              </div>
-              <div
-                className={`rounded-2xl px-4 py-3 text-sm ${
-                  fraudStats.newNumbers > 0
-                    ? 'border border-rose-100/60 bg-rose-500/40 text-white'
-                    : 'border border-emerald-100/60 bg-emerald-500/30 text-white'
-                }`}
-              >
-                <p className="text-white/80">Nouveaux numéros</p>
-                <p className="mt-1 text-2xl font-semibold">{fraudStats.newNumbers}</p>
-              </div>
-            </div>
-          </div>
-          <div className="space-y-6 p-6">
-            {fraudError && (
-              <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
-                {fraudError}
-              </div>
-            )}
-            {cdrIdentifiers.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
-                Ajoutez au moins un numéro dans la recherche pour lancer l’analyse de fraude.
-              </div>
-            ) : fraudLoading ? (
-              <div className="flex items-center justify-center py-10">
-                <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-slate-100" />
-              </div>
-            ) : fraudResult ? (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  <span>Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}</span>
-                  {hasFraudSuspiciousNumbers && (
-                    <span className="inline-flex items-center gap-2 rounded-full bg-rose-500/10 px-3 py-1 font-semibold text-rose-500 dark:text-rose-300">
-                      <AlertTriangle className="h-3.5 w-3.5" /> Anomalies détectées
-                    </span>
-                  )}
-                </div>
-                {fraudResult.imeis.length === 0 ? (
-                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-700 shadow-inner dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100">
-                    Aucun changement de numéro détecté pour les identifiants recherchés.
-                  </div>
-                ) : (
-                  fraudResult.imeis.map((imeiEntry) => (
-                    <div
-                      key={imeiEntry.imei}
-                      className="space-y-4 rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm dark:border-white/10 dark:bg-slate-900/60"
-                    >
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <div>
-                          <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">IMEI {imeiEntry.imei}</p>
-                          <p className="text-xs text-slate-500 dark:text-slate-400">
-                            {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''} détecté{imeiEntry.numbers.length > 1 ? 's' : ''}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-3 text-xs">
-                          <span className="inline-flex items-center gap-1 rounded-full bg-slate-100/70 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                            <Activity className="h-3.5 w-3.5" /> {imeiEntry.numbers.reduce((acc, item) => acc + item.occurrences, 0)} occurrences
-                          </span>
-                        </div>
-                      </div>
-                      {imeiEntry.numbers.length === 0 ? (
-                        <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
-                          Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
-                        </div>
-                      ) : (
-                        <div className="space-y-3">
-                          {imeiEntry.numbers.map((numberEntry) => {
-                            const isNew = numberEntry.status === 'nouveau';
-                            return (
-                              <div
-                                key={`${imeiEntry.imei}-${numberEntry.number}`}
-                                className={`rounded-2xl border px-4 py-3 transition shadow-sm ${
-                                  isNew
-                                    ? 'border-rose-200 bg-rose-50 dark:border-rose-500/40 dark:bg-rose-500/10'
-                                    : 'border-slate-200 bg-slate-50/70 dark:border-slate-700/60 dark:bg-slate-900/50'
-                                }`}
-                              >
-                                <div className="flex flex-wrap items-center justify-between gap-3">
-                                  <div>
-                                    <p className="text-base font-semibold text-slate-800 dark:text-slate-100">{numberEntry.number}</p>
-                                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
-                                      <span
-                                        className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-semibold ${
-                                          isNew
-                                            ? 'bg-rose-500/20 text-rose-600 dark:text-rose-200'
-                                            : 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-200'
-                                        }`}
-                                      >
-                                        {isNew ? 'Nouveau numéro détecté' : 'Numéro attendu'}
-                                      </span>
-                                      <span className="inline-flex items-center gap-1 rounded-full bg-slate-200/80 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                                        <Clock className="h-3.5 w-3.5" /> {numberEntry.occurrences} occurrence{numberEntry.occurrences > 1 ? 's' : ''}
-                                      </span>
-                                    </div>
-                                  </div>
-                                  <div className="flex flex-col items-end text-xs text-slate-500 dark:text-slate-300">
-                                    <span>
-                                      Première vue :{' '}
-                                      <span className="font-semibold text-slate-700 dark:text-slate-100">
-                                        {formatFraudDate(numberEntry.firstSeen)}
-                                      </span>
-                                    </span>
-                                    <span>
-                                      Dernière vue :{' '}
-                                      <span className="font-semibold text-slate-700 dark:text-slate-100">
-                                        {formatFraudDate(numberEntry.lastSeen)}
-                                      </span>
-                                    </span>
-                                  </div>
-                                </div>
-                                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
-                                  {numberEntry.roles.length === 0 ? (
-                                    <span className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
-                                      Aucun rôle identifié
-                                    </span>
-                                  ) : (
-                                    numberEntry.roles.map((role) => (
-                                      <span
-                                        key={role}
-                                        className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200"
-                                      >
-                                        {FRAUD_ROLE_LABELS[role] || role}
-                                      </span>
-                                    ))
-                                  )}
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  ))
-                )}
-              </div>
-            ) : (
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
-                Lancez une analyse pour détecter les nouveaux numéros associés aux identifiants recherchés.
-              </div>
-            )}
-          </div>
-        </div>
-      </section>
-    );
+    const showDetectionPanel = !showCdrMap && Boolean(selectedCase);
 
-    const searchSection = (
+    const combinedSection = (
       <section className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white/95 shadow-xl shadow-slate-200/60 backdrop-blur-sm dark:border-slate-700/60 dark:bg-slate-900/70 dark:shadow-black/40">
         <div className="border-b border-slate-200/70 bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 p-6 text-white dark:border-slate-700/60">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div>
               <h3 className="text-lg font-semibold">Recherche CDR</h3>
               <p className="text-sm text-white/80">Affinez votre requête pour visualiser les communications pertinentes.</p>
             </div>
-            <div className="hidden md:flex h-12 w-12 items-center justify-center rounded-2xl bg-white/20">
+            {showDetectionPanel && (
+              <div className="rounded-2xl border border-white/30 bg-white/10 p-4 shadow-lg shadow-black/20">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1 text-white/90">
+                    <p className="text-[11px] uppercase tracking-wide text-white/70">Détection de fraude</p>
+                    <h3 className="text-lg font-semibold text-white">Changement de numéro</h3>
+                    <p className="text-xs text-white/80">
+                      Analysez les numéros utilisés par les terminaux identifiés dans l'opération en cours.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={fetchFraudDetection}
+                    disabled={fraudLoading || !selectedCase || cdrIdentifiers.length === 0}
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-white/15 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-white/25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {fraudLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Scan className="h-3.5 w-3.5" />}
+                    <span>Analyser</span>
+                  </button>
+                </div>
+                <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-2xl border border-white/30 bg-white/15 px-4 py-3 text-xs">
+                    <p className="text-white/70">IMEI analysés</p>
+                    <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalImeis}</p>
+                  </div>
+                  <div className="rounded-2xl border border-white/30 bg-white/15 px-4 py-3 text-xs">
+                    <p className="text-white/70">Numéros détectés</p>
+                    <p className="mt-1 text-2xl font-semibold text-white">{fraudStats.totalNumbers}</p>
+                  </div>
+                  <div
+                    className={`rounded-2xl px-4 py-3 text-xs ${
+                      fraudStats.newNumbers > 0
+                        ? 'border border-rose-100/60 bg-rose-500/40 text-white'
+                        : 'border border-emerald-100/60 bg-emerald-500/30 text-white'
+                    }`}
+                  >
+                    <p className="text-white/80">Nouveaux numéros</p>
+                    <p className="mt-1 text-2xl font-semibold">{fraudStats.newNumbers}</p>
+                  </div>
+                </div>
+              </div>
+            )}
+            <div className="hidden h-12 w-12 items-center justify-center rounded-2xl bg-white/20 md:flex">
               <Search className="h-6 w-6" />
             </div>
           </div>
         </div>
-        <form onSubmit={handleCdrSearch} className="space-y-5 p-6">
-          <div>
-            <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Numéros recherchés</label>
-            <div className="mt-2 flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/80 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700/60 dark:bg-slate-900/50">
-              {cdrIdentifiers.map((id, idx) => (
-                <span
+        <div
+          className={`p-6 ${
+            showDetectionPanel
+              ? 'space-y-6 xl:grid xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] xl:items-start xl:space-y-0 xl:gap-6'
+              : ''
+          }`}
+        >
+          <form onSubmit={handleCdrSearch} className="space-y-5">
+            <div>
+              <label className="text-sm font-semibold text-slate-600 dark:text-slate-300">Numéros recherchés</label>
+              <div className="mt-2 flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/80 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700/60 dark:bg-slate-900/50">
+                {cdrIdentifiers.map((id, idx) => (
+                  <span
                   key={idx}
                   className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 font-medium text-blue-700 dark:bg-blue-500/20 dark:text-blue-200"
                 >
@@ -4107,49 +3979,150 @@ useEffect(() => {
               </button>
             )}
           </div>
-        </form>
+          </form>
+          {showDetectionPanel && (
+            <div className="space-y-6 rounded-3xl border border-slate-200/70 bg-slate-50/80 p-6 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/60">
+              {fraudError && (
+                <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-700 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200">
+                  {fraudError}
+                </div>
+              )}
+              {cdrIdentifiers.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+                  Ajoutez au moins un numéro dans la recherche pour lancer l’analyse de fraude.
+                </div>
+              ) : fraudLoading ? (
+                <div className="flex items-center justify-center py-10">
+                  <Loader2 className="h-6 w-6 animate-spin text-blue-600 dark:text-slate-100" />
+                </div>
+              ) : fraudResult ? (
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    <span>Dernière analyse&nbsp;: {formatFraudDateTime(fraudResult.updatedAt)}</span>
+                    {hasFraudSuspiciousNumbers && (
+                      <span className="inline-flex items-center gap-2 rounded-full bg-rose-500/10 px-3 py-1 font-semibold text-rose-500 dark:text-rose-300">
+                        <AlertTriangle className="h-3.5 w-3.5" /> Anomalies détectées
+                      </span>
+                    )}
+                  </div>
+                  {fraudResult.imeis.length === 0 ? (
+                    <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-700 shadow-inner dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-100">
+                      Aucun changement de numéro détecté pour les identifiants recherchés.
+                    </div>
+                  ) : (
+                    fraudResult.imeis.map((imeiEntry) => (
+                      <div
+                        key={imeiEntry.imei}
+                        className="space-y-4 rounded-2xl border border-slate-200 bg-white/90 p-5 shadow-sm dark:border-white/10 dark:bg-slate-900/60"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">IMEI {imeiEntry.imei}</p>
+                            <p className="text-xs text-slate-500 dark:text-slate-400">
+                              {imeiEntry.numbers.length} numéro{imeiEntry.numbers.length > 1 ? 's' : ''} détecté{imeiEntry.numbers.length > 1 ? 's' : ''}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-3 text-xs">
+                            <span className="inline-flex items-center gap-1 rounded-full bg-slate-100/70 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                              <Activity className="h-3.5 w-3.5" /> {imeiEntry.numbers.reduce((acc, item) => acc + item.occurrences, 0)} occurrences
+                            </span>
+                          </div>
+                        </div>
+                        {imeiEntry.numbers.length === 0 ? (
+                          <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+                            Aucun numéro détecté pour cet IMEI sur la période sélectionnée.
+                          </div>
+                        ) : (
+                          <div className="space-y-3">
+                            {imeiEntry.numbers.map((numberEntry) => {
+                              const isNew = numberEntry.status === 'nouveau';
+                              return (
+                                <div
+                                  key={`${imeiEntry.imei}-${numberEntry.number}`}
+                                  className={`rounded-2xl border px-4 py-3 transition shadow-sm ${
+                                    isNew
+                                      ? 'border-rose-200 bg-rose-50 dark:border-rose-500/40 dark:bg-rose-500/10'
+                                      : 'border-slate-200 bg-slate-50/70 dark:border-slate-700/60 dark:bg-slate-900/50'
+                                  }`}
+                                >
+                                  <div className="flex flex-wrap items-center justify-between gap-3">
+                                    <div>
+                                      <p className="text-base font-semibold text-slate-800 dark:text-slate-100">{numberEntry.number}</p>
+                                      <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                                        <span
+                                          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-semibold ${
+                                            isNew
+                                              ? 'bg-rose-500/20 text-rose-600 dark:text-rose-200'
+                                              : 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-200'
+                                          }`}
+                                        >
+                                          {isNew ? 'Nouveau numéro détecté' : 'Numéro attendu'}
+                                        </span>
+                                        <span className="inline-flex items-center gap-1 rounded-full bg-slate-200/80 px-3 py-1 font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                                          <Clock className="h-3.5 w-3.5" /> {numberEntry.occurrences} occurrence{numberEntry.occurrences > 1 ? 's' : ''}
+                                        </span>
+                                      </div>
+                                    </div>
+                                    <div className="flex flex-col items-end text-xs text-slate-500 dark:text-slate-300">
+                                      <span>
+                                        Première vue :{' '}
+                                        <span className="font-semibold text-slate-700 dark:text-slate-100">
+                                          {formatFraudDate(numberEntry.firstSeen)}
+                                        </span>
+                                      </span>
+                                      <span>
+                                        Dernière vue :{' '}
+                                        <span className="font-semibold text-slate-700 dark:text-slate-100">
+                                          {formatFraudDate(numberEntry.lastSeen)}
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </div>
+                                  <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+                                    {numberEntry.roles.length === 0 ? (
+                                      <span className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200">
+                                        Aucun rôle identifié
+                                      </span>
+                                    ) : (
+                                      numberEntry.roles.map((role) => (
+                                        <span
+                                          key={role}
+                                          className="rounded-full bg-slate-200/80 px-3 py-1 text-slate-600 dark:bg-slate-800/70 dark:text-slate-200"
+                                        >
+                                          {FRAUD_ROLE_LABELS[role] || role}
+                                        </span>
+                                      ))
+                                    )}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    ))
+                  )}
+                </div>
+              ) : (
+                <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-600 shadow-inner dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-300">
+                  Lancez une analyse pour détecter les nouveaux numéros associés aux identifiants recherchés.
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </section>
-    );
-
-    const hasDetectionSection = Boolean(detectionSection);
-    const baseFormLayoutClass = 'flex flex-col gap-8';
-    const responsiveLayoutClass = hasDetectionSection
-      ? `${baseFormLayoutClass} xl:grid xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] xl:items-start`
-      : baseFormLayoutClass;
-
-    const formContent = showCdrMap ? (
-      <div className="space-y-6">
-        {searchSection}
-        {hasDetectionSection && <div className="pt-2">{detectionSection}</div>}
-      </div>
-    ) : (
-      <div className={responsiveLayoutClass}>
-        <div className="space-y-6">{searchSection}</div>
-        {hasDetectionSection && (
-          <div className="relative">
-            <div
-              className="absolute -inset-0.5 -z-10 rounded-3xl bg-gradient-to-br from-blue-500/30 via-indigo-500/20 to-purple-500/30 opacity-60 blur-2xl"
-              aria-hidden="true"
-            />
-            {detectionSection}
-          </div>
-        )}
-      </div>
     );
 
     if (showCdrMap) {
       return (
         <div className="fixed bottom-6 left-6 z-[1000] w-[28rem] max-h-[88vh] overflow-y-auto rounded-3xl border border-white/60 bg-white/90 p-5 shadow-2xl shadow-blue-500/20 backdrop-blur-xl dark:border-slate-700/70 dark:bg-slate-900/85">
-          {formContent}
+          {combinedSection}
         </div>
       );
     }
 
-    return (
-      <div className="rounded-3xl border border-slate-200/80 bg-transparent">
-        {formContent}
-      </div>
-    );
+    return combinedSection;
   };
 
   return (


### PR DESCRIPTION
## Summary
- merge the CDR search and number change detection panels into a single cohesive card
- surface fraud detection stats and actions alongside the search inputs for a unified layout
- keep detailed detection results within the same section while preserving existing messaging and states

## Testing
- npm run lint *(fails: missing dependencies due to restricted npm registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d296c32f5083269827d1f06c1e75da