### PR TITLE
Fix FK constraint handling, normalize CDR imports, and refresh dashboard stats

### DIFF
--- a/server/models/SearchLog.js
+++ b/server/models/SearchLog.js
@@ -1,0 +1,79 @@
+import database from '../config/database.js';
+import { ensureUserExists, handleMissingUserForeignKey } from '../utils/foreign-key-helpers.js';
+import statsCache from '../services/stats-cache.js';
+
+const serialize = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch (_) {
+    return null;
+  }
+};
+
+class SearchLog {
+  static async create({
+    user_id,
+    username,
+    search_term,
+    search_type = 'global',
+    tables_searched = [],
+    results_count = 0,
+    execution_time_ms = 0,
+    ip_address = null,
+    user_agent = null
+  }) {
+    const safeUserId = await ensureUserExists(user_id);
+    const payload = [
+      safeUserId,
+      username || null,
+      search_term || null,
+      search_type || null,
+      serialize(tables_searched),
+      Number.isFinite(results_count) ? Math.max(0, Number(results_count)) : 0,
+      Number.isFinite(execution_time_ms) ? Math.max(0, Math.round(Number(execution_time_ms))) : 0,
+      ip_address || null,
+      user_agent || null
+    ];
+
+    const insert = async (userIdValue) => {
+      await database.query(
+        `INSERT INTO autres.search_logs (
+          user_id,
+          username,
+          search_term,
+          search_type,
+          tables_searched,
+          results_count,
+          execution_time_ms,
+          ip_address,
+          user_agent
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [userIdValue, ...payload.slice(1)]
+      );
+    };
+
+    try {
+      await insert(safeUserId);
+    } catch (error) {
+      const handled = await handleMissingUserForeignKey(error, async () => {
+        await insert(null);
+      });
+      if (!handled) {
+        throw error;
+      }
+    }
+
+    statsCache.clear('overview:');
+    statsCache.clear('timeSeries:');
+    statsCache.clear('userActivity');
+    statsCache.clear('searchLogs:');
+  }
+}
+
+export default SearchLog;

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -66,6 +66,10 @@ class CdrService {
             if (isNaN(parsed.getTime())) return null;
             return parsed.toISOString().slice(11, 19);
           };
+          const normalizePhone = (value) => {
+            const normalized = normalizePhoneNumber(value);
+            return normalized || null;
+          };
 
           records.push({
             oce: row['OCE'] || null,
@@ -76,9 +80,9 @@ class CdrService {
             date_fin: normalizeDate(row['Date fin']),
             heure_fin: normalizeTime(row['Heure fin']),
             duree: row['Duree'] || null,
-            numero_intl_appelant: row['Numero intl appelant'] || null,
-            numero_intl_appele: row['Numero intl appele'] || null,
-            numero_intl_appele_original: row['Numero intl appele original'] || null,
+            numero_intl_appelant: normalizePhone(row['Numero intl appelant']),
+            numero_intl_appele: normalizePhone(row['Numero intl appele']),
+            numero_intl_appele_original: normalizePhone(row['Numero intl appele original']),
             imei_appelant: row['IMEI appelant'] || null,
             imei_appele: row['IMEI appele'] || null,
             imei_appele_original: row['IMEI appele original'] || null,
@@ -125,6 +129,11 @@ class CdrService {
       return parsed.toISOString().slice(11, 19);
     };
     const cdrNum = cdrNumber.startsWith('221') ? cdrNumber : `221${cdrNumber}`;
+    const normalizePhone = (value) => {
+      const normalized = normalizePhoneNumber(value);
+      return normalized || null;
+    };
+
     const records = rows.map((row) => ({
       oce: row['OCE'] || null,
       type_cdr: row['Type CDR'] || null,
@@ -134,9 +143,9 @@ class CdrService {
       date_fin: normalizeDate(row['Date fin']),
       heure_fin: normalizeTime(row['Heure fin']),
       duree: row['Duree'] || null,
-      numero_intl_appelant: row['Numero intl appelant'] || null,
-      numero_intl_appele: row['Numero intl appele'] || null,
-      numero_intl_appele_original: row['Numero intl appele original'] || null,
+      numero_intl_appelant: normalizePhone(row['Numero intl appelant']),
+      numero_intl_appele: normalizePhone(row['Numero intl appele']),
+      numero_intl_appele_original: normalizePhone(row['Numero intl appele original']),
       imei_appelant: row['IMEI appelant'] || null,
       imei_appele: row['IMEI appele'] || null,
       imei_appele_original: row['IMEI appele original'] || null,

--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import baseCatalog from '../config/tables-catalog.js';
-import InMemoryCache from '../utils/cache.js';
+import statsCache from './stats-cache.js';
 
 /**
  * Service de génération de statistiques basées sur les journaux de recherche
@@ -14,7 +14,7 @@ class StatsService {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     this.catalogPath = path.join(__dirname, '../config/tables-catalog.json');
-    this.cache = new InMemoryCache();
+    this.cache = statsCache;
   }
 
   loadCatalog() {

--- a/server/services/stats-cache.js
+++ b/server/services/stats-cache.js
@@ -1,0 +1,11 @@
+import InMemoryCache from '../utils/cache.js';
+
+const cache = new InMemoryCache();
+
+export const getStatsCache = () => cache;
+
+export default {
+  get: (key) => cache.get(key),
+  set: (key, value) => cache.set(key, value),
+  clear: (prefix) => cache.clear(prefix)
+};

--- a/server/utils/cache.js
+++ b/server/utils/cache.js
@@ -23,4 +23,16 @@ export default class InMemoryCache {
     const expiry = this._now() + this.ttl;
     this.store.set(key, { value, expiry });
   }
+
+  clear(prefix = null) {
+    if (!prefix) {
+      this.store.clear();
+      return;
+    }
+    for (const key of Array.from(this.store.keys())) {
+      if (String(key).startsWith(prefix)) {
+        this.store.delete(key);
+      }
+    }
+  }
 }

--- a/server/utils/foreign-key-helpers.js
+++ b/server/utils/foreign-key-helpers.js
@@ -1,0 +1,22 @@
+import database from '../config/database.js';
+
+export const ensureUserExists = async (userId) => {
+  if (userId === undefined || userId === null) {
+    return null;
+  }
+  const existing = await database.queryOne(
+    'SELECT id FROM autres.users WHERE id = ? LIMIT 1',
+    [userId]
+  );
+  return existing ? existing.id : null;
+};
+
+export const handleMissingUserForeignKey = async (error, fallbackInsert) => {
+  if (error?.code === 'ER_NO_REFERENCED_ROW_2' || error?.code === 'ER_NO_REFERENCED_ROW') {
+    if (typeof fallbackInsert === 'function') {
+      await fallbackInsert();
+    }
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
## Summary
- add reusable helpers to validate user foreign keys and guard notification, session, and request inserts against missing users
- normalize phone numbers during CDR imports so the 221 prefix is added automatically when absent
- record search activity in MySQL and invalidate cached statistics so dashboard metrics update promptly

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks because npm registry is inaccessible in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b3a50d908326b5898120b202fa3e