### PR TITLE
feat: enhance dashboard alerts and profile pagination

### DIFF
--- a/src/components/PaginationControls.tsx
+++ b/src/components/PaginationControls.tsx
@@ -108,7 +108,7 @@ const PaginationControls: React.FC<PaginationControlsProps> = ({
             disabled={!canLoadMore}
             className="inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-white px-4 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800/60"
           >
-            Charger plus
+            Afficher plus
           </button>
         )}
         {showPageSize && pageSizeOptions && onPageSizeChange && (

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { X, Paperclip, Download, Search, Users, Eye, PencilLine, Trash2, Share2 } from 'lucide-react';
 import LoadingSpinner from './LoadingSpinner';
+import PaginationControls from './PaginationControls';
 
 interface ProfileAttachment {
   id: number;
@@ -509,26 +510,19 @@ const ProfileList: React.FC<ProfileListProps> = ({
               );
             })}
           </div>
-          <div className="flex items-center justify-center gap-4 pt-4">
-            <button
-              type="button"
-              onClick={() => setPage(prev => Math.max(1, prev - 1))}
-              disabled={page === 1}
-              className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-4 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-            >
-              Précédent
-            </button>
-            <span className="text-sm font-medium text-slate-500 dark:text-slate-400">
-              Page {page} / {totalPages}
-            </span>
-            <button
-              type="button"
-              onClick={() => setPage(prev => Math.min(totalPages, prev + 1))}
-              disabled={page >= totalPages}
-              className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-4 py-1.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-            >
-              Suivant
-            </button>
+          <div className="border-t border-slate-200/70 pt-4 dark:border-slate-700/60">
+            <div className="flex flex-col gap-3">
+              <span className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                Page {page} / {totalPages}
+              </span>
+              <PaginationControls
+                currentPage={page}
+                totalPages={totalPages}
+                onPageChange={setPage}
+                onLoadMore={() => setPage(prev => Math.min(prev + 1, totalPages))}
+                canLoadMore={page < totalPages}
+              />
+            </div>
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary
- surface blacklist alert entries beneath the admin dashboard search logs by fetching filtered user logs
- simplify the unified search toolbar by removing the CSV export button and refining the profile view toggle hover state
- align profile pagination with shared controls and rename the load-more action to "Afficher plus"

## Testing
- `npm run lint` *(fails: missing eslint-plugin-react-hooks in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b9a7cd78832691d18a55d5f22cc9