### PR TITLE
Remove table name from search results header

### DIFF
--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -34,11 +34,6 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
             <div>
               <h3 className="text-xl font-semibold text-white">Résultat {idx + 1}</h3>
             </div>
-            {(hit.table || hit.database) && (
-              <span className="ml-auto inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white/20 text-white">
-                {hit.table || hit.database}
-              </span>
-            )}
           </div>
           <div className="p-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
             {Object.entries(hit.preview).flatMap(([key, value]) => {


### PR DESCRIPTION
## Summary
- stop rendering the table/database badge in search results so only the result heading remains

## Testing
- ⚠️ `npm run lint` *(fails: eslint plugin dependency missing because npm registry access to @elastic/elasticsearch is forbidden in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a23657cc8326bf133963e7e79e65