### PR TITLE
Fix fetchSessions block closure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1531,13 +1531,13 @@ const App: React.FC = () => {
         const data = await res.json();
         setSessionLogs(data.sessions || []);
         setSessionTotal(data.total || 0);
-      setSessionPage(page);
+        setSessionPage(page);
+      }
+    } catch (err) {
+      console.error('Erreur chargement sessions:', err);
+    } finally {
+      setSessionLoading(false);
     }
-  } catch (err) {
-    console.error('Erreur chargement sessions:', err);
-  } finally {
-    setSessionLoading(false);
-  }
   }, [logUserFilter]);
 
   const formatSessionDuration = useCallback((durationSeconds?: number | null) => {


### PR DESCRIPTION
## Summary
- close the `if (res.ok)` block inside `fetchSessions` before the catch clause to restore valid syntax
- ensure session fetch state updates run only on successful responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3b9e6b6b4832685a341b38944b9e8