### PR TITLE
Adjust cancel button styling in dark mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8067,7 +8067,7 @@ useEffect(() => {
                       divisionId: divisions[0]?.id || 0
                     });
                   }}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 dark:text-slate-200 dark:bg-slate-700/70 dark:hover:bg-slate-600/70 rounded-lg transition-colors"
                 >
                   Annuler
                 </button>


### PR DESCRIPTION
## Summary
- update the cancel button in the user management modal to use appropriate colors in dark mode

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ca06f8e48326856ff9b29e244c5f