### PR TITLE
Initialize graph ref with null

### DIFF
--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -50,7 +50,7 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>('network');
   const [selectedRoot, setSelectedRoot] = useState<string | null>(null);
-  const graphRef = useRef<ForceGraphMethods>();
+  const graphRef = useRef<ForceGraphMethods | null>(null);
   const nodeTypes = useMemo(() => Array.from(new Set(data.nodes.map((n) => n.type))), [data]);
 
   const colorByType = useMemo(() => {


### PR DESCRIPTION
## Summary
- initialize the force graph ref with a null default to satisfy the useRef signature

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cde81a9483269327660c18911a31