### PR TITLE
Fix chart plugin registration and guard force graph optional API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,8 @@ import {
   LineElement,
   BarElement,
   Tooltip,
-  Legend
+  Legend,
+  Filler
 } from 'chart.js';
 import { format, parseISO, formatDistanceToNow, intervalToDuration, formatDuration } from 'date-fns';
 import { fr } from 'date-fns/locale';
@@ -89,7 +90,7 @@ import CdrMap from './components/CdrMap';
 import LinkDiagram from './components/LinkDiagram';
 import SoraLogo from './components/SoraLogo';
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Tooltip, Legend);
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Tooltip, Legend, Filler);
 
 const LINK_DIAGRAM_PREFIXES = ['22177', '22176', '22178', '22170', '22175', '22133'];
 const PAGE_SIZE_OPTIONS = [10, 25, 50];

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -219,7 +219,9 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
           .strength(0.85)
       );
     }
-    graphRef.current.d3VelocityDecay(0.25);
+    if (typeof graphRef.current.d3VelocityDecay === 'function') {
+      graphRef.current.d3VelocityDecay(0.25);
+    }
   }, [viewMode]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- register the Chart.js Filler plugin so area charts can enable fill without runtime errors
- guard the force graph velocity decay call to avoid invoking an unavailable method

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks package)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cf4fd278832699b5079e95b57a69