### PR TITLE
feat: enable case renaming and shared profile editing

### DIFF
--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -77,6 +77,14 @@ class Case {
     return rows.map((row) => row.user_id);
   }
 
+  static async updateName(id, name) {
+    await database.query(
+      'UPDATE autres.cdr_cases SET name = ? WHERE id = ?',
+      [name, id]
+    );
+    return { id, name };
+  }
+
   static async delete(id) {
     await database.query('DELETE FROM autres.cdr_cases WHERE id = ?', [id]);
   }

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -92,6 +92,33 @@ router.post('/', authenticate, async (req, res) => {
   }
 });
 
+router.patch('/:id', authenticate, async (req, res) => {
+  try {
+    const caseId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(caseId)) {
+      return res.status(400).json({ error: 'ID de dossier invalide' });
+    }
+    const { name } = req.body || {};
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return res.status(400).json({ error: 'Nom requis' });
+    }
+    const updated = await caseService.renameCase(caseId, name, req.user);
+    res.json({ case: updated });
+  } catch (err) {
+    if (err.message === 'Case not found') {
+      return res.status(404).json({ error: 'Opération introuvable' });
+    }
+    if (err.message === 'Forbidden') {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    if (err.message === 'Invalid name') {
+      return res.status(400).json({ error: 'Nom requis' });
+    }
+    console.error('Erreur renommage case:', err);
+    res.status(500).json({ error: "Erreur lors de la mise à jour de l'opération" });
+  }
+});
+
 router.post('/:id/upload', authenticate, upload.single('file'), async (req, res) => {
   try {
     const caseId = parseInt(req.params.id, 10);

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -47,6 +47,28 @@ class CaseService {
     return await Case.create(name, userId);
   }
 
+  async renameCase(caseId, name, user) {
+    const trimmedName = typeof name === 'string' ? name.trim() : '';
+    if (!trimmedName) {
+      throw new Error('Invalid name');
+    }
+
+    const existingCase = await this.getCaseById(caseId, user);
+    if (!existingCase) {
+      throw new Error('Case not found');
+    }
+
+    const isOwner = existingCase.user_id === user.id || existingCase.is_owner === 1 || existingCase.is_owner === true;
+    const isAdmin = this._isAdmin(user);
+
+    if (!isOwner && !isAdmin) {
+      throw new Error('Forbidden');
+    }
+
+    await Case.updateName(caseId, trimmedName);
+    return { id: existingCase.id, name: trimmedName };
+  }
+
   async getCaseById(id, user) {
     if (this._isAdmin(user)) {
       return await Case.findById(id);

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -106,8 +106,12 @@ class ProfileService {
     const existing = await Profile.findById(id);
     if (!existing) throw new Error('Profil non trouvé');
     const isAdmin = this._isAdmin(user);
-    if (!isAdmin && existing.user_id !== user.id) {
-      throw new Error('Accès refusé');
+    const isOwner = existing.user_id === user.id;
+    if (!isAdmin && !isOwner) {
+      const hasSharedAccess = await ProfileShare.isSharedWithUser(id, user.id);
+      if (!hasSharedAccess) {
+        throw new Error('Accès refusé');
+      }
     }
     const photoFile = Array.isArray(files.photo) ? files.photo[0] : null;
     const attachmentFiles = Array.isArray(files.attachments) ? files.attachments : [];

--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -40,9 +40,12 @@ class StatsService {
    */
   async getOverviewStats(userId = null) {
     const cacheKey = `overview:${userId || 'all'}`;
-    const cached = this.cache.get(cacheKey);
-    if (cached) {
-      return cached;
+    const shouldUseCache = !userId;
+    if (shouldUseCache) {
+      const cached = this.cache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
     }
 
     try {
@@ -158,7 +161,9 @@ class StatsService {
         }
       };
 
-      this.cache.set(cacheKey, stats);
+      if (shouldUseCache) {
+        this.cache.set(cacheKey, stats);
+      }
       return stats;
     } catch (error) {
       console.error('Erreur statistiques overview:', error);
@@ -209,9 +214,12 @@ class StatsService {
    */
   async getTimeSeriesData(days = 30, userId = null) {
     const cacheKey = `timeSeries:${days}:${userId || 'all'}`;
-    const cached = this.cache.get(cacheKey);
-    if (cached) {
-      return cached;
+    const shouldUseCache = !userId;
+    if (shouldUseCache) {
+      const cached = this.cache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
     }
 
     try {
@@ -240,7 +248,9 @@ class StatsService {
         avg_time: Math.round(row.avg_time || 0)
       }));
 
-      this.cache.set(cacheKey, data);
+      if (shouldUseCache) {
+        this.cache.set(cacheKey, data);
+      }
       return data;
     } catch (error) {
       console.error('Erreur données temporelles:', error);
@@ -314,9 +324,12 @@ class StatsService {
    */
   async getSearchLogs(limit = 20, username = '', userId = null) {
     const cacheKey = `searchLogs:${limit}:${username}:${userId || 'all'}`;
-    const cached = this.cache.get(cacheKey);
-    if (cached) {
-      return cached;
+    const shouldUseCache = !userId;
+    if (shouldUseCache) {
+      const cached = this.cache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
     }
 
     try {
@@ -345,7 +358,9 @@ class StatsService {
       params.push(limit);
 
       const logs = await database.query(sql, params);
-      this.cache.set(cacheKey, logs || []);
+      if (shouldUseCache) {
+        this.cache.set(cacheKey, logs || []);
+      }
       return logs || [];
     } catch (error) {
       console.error('Erreur logs de recherche:', error);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1091,6 +1091,10 @@ const App: React.FC = () => {
   const [casePage, setCasePage] = useState(1);
   const [casesPerPage, setCasesPerPage] = useState(CASE_PAGE_SIZE_OPTIONS[0]);
   const totalCasePages = Math.ceil(cases.length / casesPerPage);
+  const [renamingCaseId, setRenamingCaseId] = useState<number | null>(null);
+  const [renamingCaseName, setRenamingCaseName] = useState('');
+  const [renamingCaseError, setRenamingCaseError] = useState('');
+  const [renamingCaseLoading, setRenamingCaseLoading] = useState(false);
   const paginatedCases = useMemo(
     () =>
       cases.slice(
@@ -3083,6 +3087,57 @@ useEffect(() => {
     }
   };
 
+  const startRenamingCase = (cdrCase: CdrCase) => {
+    setRenamingCaseId(cdrCase.id);
+    setRenamingCaseName(cdrCase.name || '');
+    setRenamingCaseError('');
+    setRenamingCaseLoading(false);
+  };
+
+  const cancelRenamingCase = () => {
+    setRenamingCaseId(null);
+    setRenamingCaseName('');
+    setRenamingCaseError('');
+    setRenamingCaseLoading(false);
+  };
+
+  const submitRenameCase = async () => {
+    if (!renamingCaseId) return;
+    const caseId = renamingCaseId;
+    const trimmedName = renamingCaseName.trim();
+    if (!trimmedName) {
+      setRenamingCaseError('Nom requis');
+      return;
+    }
+    setRenamingCaseLoading(true);
+    setRenamingCaseError('');
+    try {
+      const token = localStorage.getItem('token');
+      const res = await fetch(`/api/cases/${caseId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: token ? `Bearer ${token}` : ''
+        },
+        body: JSON.stringify({ name: trimmedName })
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setCases((prev) => prev.map((item) => (item.id === caseId ? { ...item, name: trimmedName } : item)));
+        setSelectedCase((prev) => (prev && prev.id === caseId ? { ...prev, name: trimmedName } : prev));
+        cancelRenamingCase();
+        await fetchCases();
+      } else {
+        setRenamingCaseError(data?.error || "Erreur lors de la mise à jour du nom");
+      }
+    } catch (error) {
+      console.error('Erreur renommage opération:', error);
+      setRenamingCaseError("Erreur lors de la mise à jour du nom");
+    } finally {
+      setRenamingCaseLoading(false);
+    }
+  };
+
   const openShareModalForCase = async (cdrCase: CdrCase) => {
     setShareTargetCase(cdrCase);
     setShareMessage('');
@@ -4228,7 +4283,8 @@ useEffect(() => {
                           </div>
                         )}
                       </div>
-                    ))
+                    );
+                    })
                   )}
                 </div>
               ) : (
@@ -5458,27 +5514,68 @@ useEffect(() => {
                       Aucune opération enregistrée pour le moment.
                     </div>
                   ) : (
-                    paginatedCases.map((c) => (
-                      <div
-                        key={c.id}
-                        className="group relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-xl shadow-slate-200/60 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl dark:border-slate-700/60 dark:bg-slate-900/70"
-                      >
+                    paginatedCases.map((c) => {
+                      const isOwnerCase = Boolean(c.is_owner);
+                      const isSharedWithMe = Boolean(!isOwnerCase && c.shared_with_me);
+                      return (
+                        <div
+                          key={c.id}
+                          className="group relative overflow-hidden rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-xl shadow-slate-200/60 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl dark:border-slate-700/60 dark:bg-slate-900/70"
+                        >
                         <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-blue-500/0 via-indigo-500/10 to-purple-500/20 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
                         <div className="relative flex h-full flex-col gap-5">
                           <div className="flex items-start justify-between gap-4">
-                            <div className="space-y-2">
-                              <h4 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{c.name}</h4>
+                            <div className="space-y-2 flex-1">
+                              {renamingCaseId === c.id ? (
+                                <div className="space-y-3">
+                                  <input
+                                    type="text"
+                                    value={renamingCaseName}
+                                    onChange={(e) => setRenamingCaseName(e.target.value)}
+                                    className="w-full rounded-2xl border border-blue-200/60 bg-white/90 px-3 py-2 text-sm font-medium text-slate-700 shadow-inner focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-500/20 dark:border-slate-700/60 dark:bg-slate-900/50 dark:text-slate-200"
+                                    placeholder="Nom de l'opération"
+                                  />
+                                  {renamingCaseError && (
+                                    <p className="text-xs font-medium text-rose-500 dark:text-rose-300">{renamingCaseError}</p>
+                                  )}
+                                  <div className="flex flex-wrap gap-2">
+                                    <button
+                                      type="button"
+                                      onClick={submitRenameCase}
+                                      disabled={renamingCaseLoading}
+                                      className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-1.5 text-xs font-semibold text-white shadow-sm shadow-blue-400/40 transition hover:-translate-y-0.5 hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                      {renamingCaseLoading ? (
+                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                      ) : (
+                                        <CheckCircle2 className="h-4 w-4" />
+                                      )}
+                                      <span>Enregistrer</span>
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={cancelRenamingCase}
+                                      className="inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/80 px-4 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-800 dark:border-slate-700/60 dark:bg-slate-900/40 dark:text-slate-300 dark:hover:border-slate-500/70 dark:hover:text-slate-100"
+                                    >
+                                      <X className="h-4 w-4" />
+                                      <span>Annuler</span>
+                                    </button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <h4 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{c.name}</h4>
+                              )}
                               {isAdmin && c.user_login && (
                                 <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                                   {c.user_login}
                                 </p>
                               )}
-                              {Boolean(!c.is_owner && c.shared_with_me) ? (
+                              {isSharedWithMe ? (
                                 <span className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200">
                                   <Share2 className="h-3.5 w-3.5" />
                                   Partagée avec vous
                                 </span>
-                              ) : Boolean(c.is_owner) ? (
+                              ) : isOwnerCase ? (
                                 <span className="inline-flex items-center gap-2 rounded-full bg-blue-500/10 px-3 py-1 text-xs font-semibold text-blue-600 dark:bg-blue-500/20 dark:text-blue-200">
                                   <User className="h-3.5 w-3.5" />
                                   Propriétaire
@@ -5513,6 +5610,16 @@ useEffect(() => {
                               <ArrowRight className="h-4 w-4" />
                               <span>Ouvrir</span>
                             </button>
+                            {(isAdmin || isOwnerCase) && renamingCaseId !== c.id && (
+                              <button
+                                type="button"
+                                className="inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-blue-300 hover:text-blue-600 dark:border-slate-600/70 dark:bg-slate-900/40 dark:text-slate-200 dark:hover:border-blue-400 dark:hover:text-blue-200"
+                                onClick={() => startRenamingCase(c)}
+                              >
+                                <Edit className="h-4 w-4" />
+                                <span>Renommer</span>
+                              </button>
+                            )}
                             <button
                               type="button"
                               className="inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-blue-300 hover:text-blue-600 dark:border-slate-600/70 dark:bg-slate-900/40 dark:text-slate-200 dark:hover:border-blue-400 dark:hover:text-blue-200"
@@ -5521,7 +5628,7 @@ useEffect(() => {
                               <Download className="h-4 w-4" />
                               <span>Exporter</span>
                             </button>
-                            {(isAdmin || c.is_owner) && (
+                            {(isAdmin || isOwnerCase) && (
                               <button
                                 type="button"
                                 className="inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-blue-300 hover:text-blue-600 dark:border-slate-600/70 dark:bg-slate-900/40 dark:text-slate-200 dark:hover:border-blue-400 dark:hover:text-blue-200"
@@ -5531,7 +5638,7 @@ useEffect(() => {
                                 <span>Partager</span>
                               </button>
                             )}
-                            {Boolean(c.is_owner) && (
+                            {isOwnerCase && (
                               <button
                                 type="button"
                                 className="inline-flex items-center gap-2 rounded-full border border-rose-300/70 bg-rose-50/80 px-4 py-2 text-sm font-semibold text-rose-600 transition hover:border-rose-400 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200 dark:hover:border-rose-400/60"
@@ -5543,9 +5650,9 @@ useEffect(() => {
                             )}
                           </div>
                         </div>
-                      </div>
-                    ))
-                  )}
+                        </div>
+                      );
+                    })}
                 </div>
                 {cases.length > 0 && (
                   <div className="border-t border-slate-200/80 pt-4 dark:border-slate-800/60">

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -155,7 +155,8 @@ const ProfileList: React.FC<ProfileListProps> = ({
   const isOwner = useCallback((profile: ProfileListItem) => currentUser?.id === profile.user_id, [currentUser]);
 
   const canEditProfile = useCallback(
-    (profile: ProfileListItem) => Boolean(onEdit) && (isAdminUser || isOwner(profile)),
+    (profile: ProfileListItem) =>
+      Boolean(onEdit) && (isAdminUser || isOwner(profile) || Boolean(profile.shared_with_me)),
     [isAdminUser, isOwner, onEdit]
   );
 


### PR DESCRIPTION
## Summary
- allow renaming CDR cases via a new PATCH endpoint and the dashboard case cards
- let users edit shared profiles by updating backend checks and list actions
- bypass stats cache for user-specific requests to keep simple-user dashboards up to date

## Testing
- `npm run build` *(fails: vite binary unavailable in environment)*
- `npm install` *(fails: 403 retrieving @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e37474c08326a7b88844d9c4adf9