### PR TITLE
Fix JSX ternary closing parentheses

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4280,7 +4280,8 @@ useEffect(() => {
                                     </div>
                                   </div>
                                 );
-                              })}
+                      })
+                    )}
                           </div>
                         )}
                       </div>
@@ -5653,7 +5654,8 @@ useEffect(() => {
                         </div>
                         </div>
                       );
-                    })}
+                    })
+                  )}
                 </div>
                 {cases.length > 0 && (
                   <div className="border-t border-slate-200/80 pt-4 dark:border-slate-800/60">
@@ -6850,7 +6852,8 @@ useEffect(() => {
                             </div>
                           </li>
                         );
-                      })}
+                      })
+                    )}
                     </ul>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- correct the JSX ternary closing inside the paginated case list so that the map expression is properly wrapped

## Testing
- `npm run build` *(fails: vite not found because dependencies are not installed in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d3ea81c37083269b2d706b97d6770b