### PR TITLE
Remove operation renaming and shared profile editing features

### DIFF
--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -77,14 +77,6 @@ class Case {
     return rows.map((row) => row.user_id);
   }
 
-  static async updateName(id, name) {
-    await database.query(
-      'UPDATE autres.cdr_cases SET name = ? WHERE id = ?',
-      [name, id]
-    );
-    return { id, name };
-  }
-
   static async delete(id) {
     await database.query('DELETE FROM autres.cdr_cases WHERE id = ?', [id]);
   }

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -92,33 +92,6 @@ router.post('/', authenticate, async (req, res) => {
   }
 });
 
-router.patch('/:id', authenticate, async (req, res) => {
-  try {
-    const caseId = parseInt(req.params.id, 10);
-    if (!Number.isInteger(caseId)) {
-      return res.status(400).json({ error: 'ID de dossier invalide' });
-    }
-    const { name } = req.body || {};
-    if (!name || typeof name !== 'string' || !name.trim()) {
-      return res.status(400).json({ error: 'Nom requis' });
-    }
-    const updated = await caseService.renameCase(caseId, name, req.user);
-    res.json({ case: updated });
-  } catch (err) {
-    if (err.message === 'Case not found') {
-      return res.status(404).json({ error: 'Opération introuvable' });
-    }
-    if (err.message === 'Forbidden') {
-      return res.status(403).json({ error: 'Accès refusé' });
-    }
-    if (err.message === 'Invalid name') {
-      return res.status(400).json({ error: 'Nom requis' });
-    }
-    console.error('Erreur renommage case:', err);
-    res.status(500).json({ error: "Erreur lors de la mise à jour de l'opération" });
-  }
-});
-
 router.post('/:id/upload', authenticate, upload.single('file'), async (req, res) => {
   try {
     const caseId = parseInt(req.params.id, 10);

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -47,28 +47,6 @@ class CaseService {
     return await Case.create(name, userId);
   }
 
-  async renameCase(caseId, name, user) {
-    const trimmedName = typeof name === 'string' ? name.trim() : '';
-    if (!trimmedName) {
-      throw new Error('Invalid name');
-    }
-
-    const existingCase = await this.getCaseById(caseId, user);
-    if (!existingCase) {
-      throw new Error('Case not found');
-    }
-
-    const isOwner = existingCase.user_id === user.id || existingCase.is_owner === 1 || existingCase.is_owner === true;
-    const isAdmin = this._isAdmin(user);
-
-    if (!isOwner && !isAdmin) {
-      throw new Error('Forbidden');
-    }
-
-    await Case.updateName(caseId, trimmedName);
-    return { id: existingCase.id, name: trimmedName };
-  }
-
   async getCaseById(id, user) {
     if (this._isAdmin(user)) {
       return await Case.findById(id);

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -106,12 +106,8 @@ class ProfileService {
     const existing = await Profile.findById(id);
     if (!existing) throw new Error('Profil non trouvé');
     const isAdmin = this._isAdmin(user);
-    const isOwner = existing.user_id === user.id;
-    if (!isAdmin && !isOwner) {
-      const hasSharedAccess = await ProfileShare.isSharedWithUser(id, user.id);
-      if (!hasSharedAccess) {
-        throw new Error('Accès refusé');
-      }
+    if (!isAdmin && existing.user_id !== user.id) {
+      throw new Error('Accès refusé');
     }
     const photoFile = Array.isArray(files.photo) ? files.photo[0] : null;
     const attachmentFiles = Array.isArray(files.attachments) ? files.attachments : [];

--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -40,12 +40,9 @@ class StatsService {
    */
   async getOverviewStats(userId = null) {
     const cacheKey = `overview:${userId || 'all'}`;
-    const shouldUseCache = !userId;
-    if (shouldUseCache) {
-      const cached = this.cache.get(cacheKey);
-      if (cached) {
-        return cached;
-      }
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
     }
 
     try {
@@ -161,9 +158,7 @@ class StatsService {
         }
       };
 
-      if (shouldUseCache) {
-        this.cache.set(cacheKey, stats);
-      }
+      this.cache.set(cacheKey, stats);
       return stats;
     } catch (error) {
       console.error('Erreur statistiques overview:', error);
@@ -214,12 +209,9 @@ class StatsService {
    */
   async getTimeSeriesData(days = 30, userId = null) {
     const cacheKey = `timeSeries:${days}:${userId || 'all'}`;
-    const shouldUseCache = !userId;
-    if (shouldUseCache) {
-      const cached = this.cache.get(cacheKey);
-      if (cached) {
-        return cached;
-      }
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
     }
 
     try {
@@ -248,9 +240,7 @@ class StatsService {
         avg_time: Math.round(row.avg_time || 0)
       }));
 
-      if (shouldUseCache) {
-        this.cache.set(cacheKey, data);
-      }
+      this.cache.set(cacheKey, data);
       return data;
     } catch (error) {
       console.error('Erreur données temporelles:', error);
@@ -324,12 +314,9 @@ class StatsService {
    */
   async getSearchLogs(limit = 20, username = '', userId = null) {
     const cacheKey = `searchLogs:${limit}:${username}:${userId || 'all'}`;
-    const shouldUseCache = !userId;
-    if (shouldUseCache) {
-      const cached = this.cache.get(cacheKey);
-      if (cached) {
-        return cached;
-      }
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
     }
 
     try {
@@ -358,9 +345,7 @@ class StatsService {
       params.push(limit);
 
       const logs = await database.query(sql, params);
-      if (shouldUseCache) {
-        this.cache.set(cacheKey, logs || []);
-      }
+      this.cache.set(cacheKey, logs || []);
       return logs || [];
     } catch (error) {
       console.error('Erreur logs de recherche:', error);

--- a/src/components/ProfileList.tsx
+++ b/src/components/ProfileList.tsx
@@ -155,8 +155,7 @@ const ProfileList: React.FC<ProfileListProps> = ({
   const isOwner = useCallback((profile: ProfileListItem) => currentUser?.id === profile.user_id, [currentUser]);
 
   const canEditProfile = useCallback(
-    (profile: ProfileListItem) =>
-      Boolean(onEdit) && (isAdminUser || isOwner(profile) || Boolean(profile.shared_with_me)),
+    (profile: ProfileListItem) => Boolean(onEdit) && (isAdminUser || isOwner(profile)),
     [isAdminUser, isOwner, onEdit]
   );
 


### PR DESCRIPTION
## Summary
- remove the backend helpers and routes that allowed renaming operations and sharing edits
- revert stats service tweaks tied to simple user dashboard synchronisation
- simplify the frontend by dropping the rename controls and limiting profile editing to owners or admins

## Testing
- npm run lint *(fails: cannot find eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f07951e083268444183c70974791