### PR TITLE
Fix chart imports and stabilize force graph configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,8 +50,30 @@ import {
   MapPinOff,
   CheckCircle2
 } from 'lucide-react';
+import { Line, Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Tooltip,
+  Legend,
+  Filler
+} from 'chart.js';
+import { format, parseISO, formatDistanceToNow, intervalToDuration, formatDuration } from 'date-fns';
+import { fr } from 'date-fns/locale';
 import ToggleSwitch from './components/ToggleSwitch';
 import PaginationControls from './components/PaginationControls';
+import PageHeader from './components/PageHeader';
+import SearchResultProfiles from './components/SearchResultProfiles';
+import LoadingSpinner from './components/LoadingSpinner';
+import ProfileList, { ProfileListItem } from './components/ProfileList';
+import ProfileForm from './components/ProfileForm';
+import CdrMap from './components/CdrMap';
+import LinkDiagram from './components/LinkDiagram';
+import SoraLogo from './components/SoraLogo';
 
 const VisibleIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...props}>
@@ -67,28 +89,6 @@ const HiddenIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <line x1="1" y1="1" x2="23" y2="23" />
   </svg>
 );
-import { Line, Bar } from 'react-chartjs-2';
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  BarElement,
-  Tooltip,
-  Legend,
-  Filler
-} from 'chart.js';
-import { format, parseISO, formatDistanceToNow, intervalToDuration, formatDuration } from 'date-fns';
-import { fr } from 'date-fns/locale';
-import PageHeader from './components/PageHeader';
-import SearchResultProfiles from './components/SearchResultProfiles';
-import LoadingSpinner from './components/LoadingSpinner';
-import ProfileList, { ProfileListItem } from './components/ProfileList';
-import ProfileForm from './components/ProfileForm';
-import CdrMap from './components/CdrMap';
-import LinkDiagram from './components/LinkDiagram';
-import SoraLogo from './components/SoraLogo';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Tooltip, Legend, Filler);
 

--- a/src/components/LinkDiagram.tsx
+++ b/src/components/LinkDiagram.tsx
@@ -200,27 +200,24 @@ const LinkDiagram: React.FC<LinkDiagramProps> = ({ data, onClose }) => {
   );
 
   useEffect(() => {
-    if (!graphRef.current) return;
+    const graphInstance = graphRef.current;
+    if (!graphInstance) return;
 
-    const chargeForce = forceManyBody()
-      .strength(viewMode === 'network' ? -260 : -160)
-      .distanceMax(650);
-    graphRef.current.d3Force('charge', chargeForce);
+    const distance = () => (viewMode === 'network' ? 190 : 150);
+    const chargeForce = forceManyBody().strength(viewMode === 'network' ? -260 : -160).distanceMax(650);
+    graphInstance.d3Force('charge', chargeForce);
 
-    const linkForce = graphRef.current.d3Force('link') as ForceLink<NormalizedNode, NormalizedLink> | undefined;
+    const linkForce = graphInstance.d3Force('link') as ForceLink<NormalizedNode, NormalizedLink> | undefined;
 
     if (linkForce) {
-      linkForce.distance(() => (viewMode === 'network' ? 190 : 150)).strength(0.85);
+      linkForce.distance(distance).strength(0.85);
     } else {
-      graphRef.current.d3Force(
-        'link',
-        forceLink<NormalizedNode, NormalizedLink>()
-          .distance(() => (viewMode === 'network' ? 190 : 150))
-          .strength(0.85)
-      );
+      graphInstance.d3Force('link', forceLink<NormalizedNode, NormalizedLink>().distance(distance).strength(0.85));
     }
-    if (typeof graphRef.current.d3VelocityDecay === 'function') {
-      graphRef.current.d3VelocityDecay(0.25);
+
+    const velocityDecay = (graphInstance as ForceGraphMethods & { d3VelocityDecay?: (decay: number) => void }).d3VelocityDecay;
+    if (typeof velocityDecay === 'function') {
+      velocityDecay.call(graphInstance, 0.25);
     }
   }, [viewMode]);
 


### PR DESCRIPTION
## Summary
- move all App module imports to the top of the file and register the Chart.js filler plugin before rendering charts
- adjust the force graph configuration to reuse calculated distances and guard the optional velocity decay method

## Testing
- npm install *(fails: 403 Forbidden fetching @elastic/elasticsearch from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f2c7f82c83269567061c8c092775