### PR TITLE
Fix session list closing tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4985,13 +4985,18 @@ useEffect(() => {
                               </td>
                             </tr>
                           ) : (
-                            <tr key={entry.id} className="odd:bg-white even:bg-slate-50/70 dark:odd:bg-slate-900/60 dark:even:bg-slate-800/60">
+                            <tr
+                              key={entry.id}
+                              className="odd:bg-white even:bg-slate-50/70 dark:odd:bg-slate-900/60 dark:even:bg-slate-800/60"
+                            >
                               <td className="px-6 py-4 whitespace-nowrap">{entry.id}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Libelle}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Telephone}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.SousCategorie}</td>
                               <td className="px-6 py-4 whitespace-nowrap">{entry.Secteur}</td>
-                              <td className="px-6 py-4 whitespace-nowrap">{entry.created_at ? new Date(entry.created_at).toLocaleDateString() : ''}</td>
+                              <td className="px-6 py-4 whitespace-nowrap">
+                                {entry.created_at ? new Date(entry.created_at).toLocaleDateString() : ''}
+                              </td>
                             </tr>
                           );
                         })}
@@ -6684,8 +6689,12 @@ useEffect(() => {
                         const logoutDate = session.logout_at ? parseISO(session.logout_at) : null;
                         const loginLabel = loginDate ? format(loginDate, 'Pp', { locale: fr }) : '-';
                         const logoutLabel = logoutDate ? format(logoutDate, 'Pp', { locale: fr }) : 'Session active';
-                        const loginRelative = loginDate ? formatDistanceToNow(loginDate, { addSuffix: true, locale: fr }) : '';
-                        const logoutRelative = logoutDate ? formatDistanceToNow(logoutDate, { addSuffix: true, locale: fr }) : '';
+                        const loginRelative = loginDate
+                          ? formatDistanceToNow(loginDate, { addSuffix: true, locale: fr })
+                          : '';
+                        const logoutRelative = logoutDate
+                          ? formatDistanceToNow(logoutDate, { addSuffix: true, locale: fr })
+                          : '';
                         const durationLabel = formatSessionDuration(session.duration_seconds);
                         const isActive = !session.logout_at;
                         return (
@@ -6750,8 +6759,7 @@ useEffect(() => {
                             </div>
                           </li>
                         );
-                      })
-                    )}
+                      })}
                     </ul>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- fix the session activity list markup by keeping the <ul> inside the conditional so JSX parses correctly
- adjust indentation around the affected maps for readability

## Testing
- npm run build *(fails: vite not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4020c3bec8326ba08b76e99480f3b