### PR TITLE
Allow renaming CDR operations

### DIFF
--- a/server/models/Case.js
+++ b/server/models/Case.js
@@ -81,6 +81,10 @@ class Case {
     await database.query('DELETE FROM autres.cdr_cases WHERE id = ?', [id]);
   }
 
+  static async updateName(id, name) {
+    await database.query('UPDATE autres.cdr_cases SET name = ? WHERE id = ?', [name, id]);
+  }
+
   static async addFile(caseId, filename, cdrNumber, lineCount = 0) {
     const result = await database.query(
       'INSERT INTO autres.cdr_case_files (case_id, filename, cdr_number, line_count, uploaded_at) VALUES (?, ?, ?, ?, NOW())',

--- a/server/routes/cases.js
+++ b/server/routes/cases.js
@@ -92,6 +92,32 @@ router.post('/', authenticate, async (req, res) => {
   }
 });
 
+router.put('/:id', authenticate, async (req, res) => {
+  try {
+    const caseId = parseInt(req.params.id, 10);
+    if (!Number.isInteger(caseId)) {
+      return res.status(400).json({ error: 'ID de dossier invalide' });
+    }
+
+    const { name } = req.body;
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return res.status(400).json({ error: 'Nom requis' });
+    }
+
+    const updated = await caseService.renameCase(caseId, name.trim(), req.user);
+    res.json({ id: updated.id, name: updated.name });
+  } catch (err) {
+    if (err.message === 'Forbidden') {
+      return res.status(403).json({ error: 'Accès refusé' });
+    }
+    if (err.message === 'Case not found') {
+      return res.status(404).json({ error: 'Opération introuvable' });
+    }
+    console.error('Erreur renommage case:', err);
+    res.status(500).json({ error: "Erreur lors de la mise à jour de l'opération" });
+  }
+});
+
 router.post('/:id/upload', authenticate, upload.single('file'), async (req, res) => {
   try {
     const caseId = parseInt(req.params.id, 10);

--- a/server/services/CaseService.js
+++ b/server/services/CaseService.js
@@ -47,6 +47,23 @@ class CaseService {
     return await Case.create(name, userId);
   }
 
+  async renameCase(caseId, newName, user) {
+    const existingCase = await Case.findById(caseId);
+    if (!existingCase) {
+      throw new Error('Case not found');
+    }
+
+    const isOwner = existingCase.user_id === user.id;
+    const isAdmin = this._isAdmin(user);
+
+    if (!isOwner && !isAdmin) {
+      throw new Error('Forbidden');
+    }
+
+    await Case.updateName(caseId, newName);
+    return { ...existingCase, name: newName };
+  }
+
   async getCaseById(id, user) {
     if (this._isAdmin(user)) {
       return await Case.findById(id);


### PR DESCRIPTION
## Summary
- add API support for renaming CDR operations with proper permission checks
- expose rename controls in the operations list and detail views
- sync client state after renaming to keep the active dossier title up to date

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d4044c8cb08326b5bd844bc5c6cb85