### PR TITLE
Fix dark mode cancel button style for password modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9019,7 +9019,7 @@ useEffect(() => {
                     setPasswordFormData({ currentPassword: '', newPassword: '', confirmPassword: '' });
                     setShowPasswords({ current: false, new: false, confirm: false });
                   }}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
                 >
                   Annuler
                 </button>


### PR DESCRIPTION
## Summary
- adjust the password modal cancel button to include dark theme background and text colors for better contrast

## Testing
- npm run build *(fails: vite command not available in container)*
- npm install *(fails: npm registry request for @elastic/elasticsearch is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5163001b0832688f7e974975b57ba