### PR TITLE
feat: modernize map popups

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -163,6 +163,22 @@
   color: #111827 !important;
 }
 
+.cdr-popup .leaflet-popup-content-wrapper {
+  border-radius: 1.25rem !important;
+  padding: 0.5rem !important;
+  box-shadow: 0 25px 50px -25px rgba(15, 23, 42, 0.45) !important;
+}
+
+.cdr-popup .leaflet-popup-content {
+  margin: 0 !important;
+  width: auto !important;
+  line-height: 1.5;
+}
+
+.cdr-popup .leaflet-popup-tip {
+  border-radius: 0.5rem;
+}
+
 /* Offset layer control from close button */
 .leaflet-top.leaflet-right {
   margin-top: 0;


### PR DESCRIPTION
## Summary
- refactor Leaflet event popups to use a reusable, card-based layout with contextual metadata
- refresh meeting point, location statistics, and triangulation popups with richer summaries and styling
- add targeted Leaflet popup styling to support the new modern designs

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5339bb1008326a8c2f0cf17a10056