### PR TITLE
Reduce map popup size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -167,12 +167,15 @@
   border-radius: 1.25rem !important;
   padding: 0.5rem !important;
   box-shadow: 0 25px 50px -25px rgba(15, 23, 42, 0.45) !important;
+  max-width: min(18rem, 80vw) !important;
 }
 
 .cdr-popup .leaflet-popup-content {
   margin: 0 !important;
   width: auto !important;
+  max-width: min(16rem, 75vw);
   line-height: 1.5;
+  font-size: 0.875rem;
 }
 
 .cdr-popup .leaflet-popup-tip {


### PR DESCRIPTION
## Summary
- constrain Leaflet popup wrappers to a narrower maximum width so point details take up less space
- limit popup content width and reduce font size for a more compact presentation

## Testing
- `npm run build` *(fails: vite not found before dependencies are installed)*
- `npm install` *(fails: 403 Forbidden fetching @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68d5380b38a88326b23bd3d4456f0a1b