### PR TITLE
Adjust Leaflet popup sizing

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -815,9 +815,9 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
       }
 
       return (
-        <div className="w-[280px] rounded-2xl border border-slate-200 bg-white/95 shadow-xl">
+        <div className="w-fit max-w-[18rem] rounded-2xl border border-slate-200 bg-white/95 shadow-xl">
           <div
-            className={`flex items-start gap-3 px-4 py-4 text-white ${visuals.gradient}`}
+            className={`flex items-start gap-3 px-3 py-3 text-white ${visuals.gradient}`}
           >
             <div
               className={`flex ${compact ? 'h-9 w-9' : 'h-10 w-10'} items-center justify-center rounded-full bg-white/20 backdrop-blur`}
@@ -842,8 +842,8 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
               </p>
             </div>
           </div>
-          <div className="space-y-3 px-4 py-4 text-sm text-slate-600">
-            {participants.length > 0 && <div className="space-y-2">{participants}</div>}
+          <div className="space-y-2.5 px-3 py-3 text-sm text-slate-600">
+            {participants.length > 0 && <div className="space-y-1.5">{participants}</div>}
             {detailGrid}
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -165,7 +165,7 @@
 
 .cdr-popup .leaflet-popup-content-wrapper {
   border-radius: 1.25rem !important;
-  padding: 0.5rem !important;
+  padding: 0.25rem !important;
   box-shadow: 0 25px 50px -25px rgba(15, 23, 42, 0.45) !important;
   max-width: min(18rem, 80vw) !important;
 }
@@ -174,6 +174,7 @@
   margin: 0 !important;
   width: auto !important;
   max-width: min(16rem, 75vw);
+  padding: 0 !important;
   line-height: 1.5;
   font-size: 0.875rem;
 }


### PR DESCRIPTION
## Summary
- reduce Leaflet popup padding so the rendered card fits its content more tightly
- update the event popup card to rely on fit-content width and smaller internal padding to avoid extra empty space

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency; npm install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d539e106c483269fdbca6b598cd659