### PR TITLE
Compacte les popups de la carte

### DIFF
--- a/src/components/CdrMap.tsx
+++ b/src/components/CdrMap.tsx
@@ -499,14 +499,14 @@ const MeetingPointMarker: React.FC<{
       })}
     >
       <Popup className="cdr-popup">
-        <div className="w-[320px] rounded-2xl border border-rose-200 bg-white/95 shadow-xl">
-          <div className="bg-gradient-to-r from-rose-500 via-pink-500 to-orange-500 px-4 py-4 text-white">
-            <p className="text-xs uppercase tracking-wide text-white/80">Point de rencontre</p>
-            <p className="text-lg font-semibold">{mp.nom || 'Point de rencontre'}</p>
-            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-white/80">
+        <div className="w-[260px] rounded-2xl border border-rose-200 bg-white/95 shadow-xl">
+          <div className="bg-gradient-to-r from-rose-500 via-pink-500 to-orange-500 px-3 py-3 text-white">
+            <p className="text-[10px] uppercase tracking-wide text-white/80">Point de rencontre</p>
+            <p className="text-base font-semibold leading-snug">{mp.nom || 'Point de rencontre'}</p>
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[11px] text-white/80">
               {mp.date && <span>{mp.date}</span>}
               {mp.start && mp.end && (
-                <span className="inline-flex items-center gap-1">
+                <span className="inline-flex items-center gap-1 text-[11px]">
                   <Clock className="h-3 w-3" />
                   {mp.start} – {mp.end}
                 </span>
@@ -518,31 +518,31 @@ const MeetingPointMarker: React.FC<{
               )}
             </div>
           </div>
-          <div className="max-h-64 space-y-3 overflow-y-auto px-4 py-4 text-sm text-rose-600">
+          <div className="max-h-60 space-y-2 overflow-y-auto px-3 py-3 text-sm text-rose-600">
             {mp.perNumber.map((d, idx) => (
-              <div key={idx} className="rounded-2xl border border-rose-100 bg-rose-50 px-3 py-3 shadow-sm">
-                <div className="flex items-center justify-between">
+              <div key={idx} className="rounded-2xl border border-rose-100 bg-rose-50 px-3 py-2.5 shadow-sm">
+                <div className="flex items-center justify-between gap-2">
                   <div>
                     <p className="text-[10px] uppercase tracking-wide text-rose-500">Numéro</p>
-                    <p className="text-sm font-semibold text-rose-600">
+                    <p className="text-sm font-semibold leading-snug text-rose-600">
                       {formatPhoneForDisplay(d.number)}
                     </p>
                   </div>
-                  <span className="inline-flex items-center rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-rose-500 shadow-sm">
+                  <span className="inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold text-rose-500 shadow-sm">
                     {d.total}
                   </span>
                 </div>
-                <div className="mt-2 space-y-1.5 text-xs text-rose-600">
+                <div className="mt-2 space-y-1 text-[11px] text-rose-600">
                   {d.events.map((ev, i) => (
                     <div
                       key={i}
-                      className="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-white/80 px-3 py-1.5"
+                      className="flex flex-wrap items-center justify-between gap-1.5 rounded-lg bg-white/80 px-2.5 py-1.5"
                     >
                       <span className="font-semibold text-rose-600">{ev.date}</span>
                       <span className="text-rose-500">
                         {ev.start} – {ev.end}
                       </span>
-                      <span className="text-[11px] font-semibold text-rose-400">{ev.duration}</span>
+                      <span className="text-[10px] font-semibold text-rose-400">{ev.duration}</span>
                     </div>
                   ))}
                 </div>
@@ -815,9 +815,9 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
       }
 
       return (
-        <div className="w-fit max-w-[18rem] rounded-2xl border border-slate-200 bg-white/95 shadow-xl">
+        <div className="w-fit max-w-[16rem] rounded-2xl border border-slate-200 bg-white/95 shadow-xl">
           <div
-            className={`flex items-start gap-3 px-3 py-3 text-white ${visuals.gradient}`}
+            className={`flex items-start gap-2.5 px-3 py-2.5 text-white ${visuals.gradient}`}
           >
             <div
               className={`flex ${compact ? 'h-9 w-9' : 'h-10 w-10'} items-center justify-center rounded-full bg-white/20 backdrop-blur`}
@@ -842,7 +842,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
               </p>
             </div>
           </div>
-          <div className="space-y-2.5 px-3 py-3 text-sm text-slate-600">
+          <div className="space-y-2 px-3 py-2.5 text-sm text-slate-600">
             {participants.length > 0 && <div className="space-y-1.5">{participants}</div>}
             {detailGrid}
           </div>
@@ -1810,20 +1810,20 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
               )}
             >
               <Popup className="cdr-popup">
-                <div className="w-[320px] space-y-3">
-                  <div className="rounded-2xl border border-slate-200 bg-white/95 px-4 py-4 shadow-sm">
-                    <div className="flex items-center gap-3">
-                      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100">
-                        <MapPin className="h-5 w-5 text-slate-500" />
+                <div className="w-[260px] space-y-2.5">
+                  <div className="rounded-2xl border border-slate-200 bg-white/95 px-3 py-3 shadow-sm">
+                    <div className="flex items-center gap-2.5">
+                      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-100">
+                        <MapPin className="h-4 w-4 text-slate-500" />
                       </span>
                       <div className="flex-1">
-                        <p className="text-xs uppercase tracking-wide text-slate-400">Localisation</p>
-                        <p className="text-sm font-semibold text-slate-800">
+                        <p className="text-[11px] uppercase tracking-wide text-slate-400">Localisation</p>
+                        <p className="text-sm font-semibold leading-snug text-slate-800">
                           {first.nom || 'Localisation'}
                         </p>
                       </div>
                     </div>
-                    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                    <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-500">
                       <span className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-600">
                         {group.events.length} évènement{group.events.length > 1 ? 's' : ''}
                       </span>
@@ -1847,7 +1847,7 @@ const CdrMap: React.FC<Props> = ({ points, showRoute, showMeetingPoints, onToggl
                       ))}
                     </div>
                   </div>
-                  <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+                  <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
                     {group.events.map((loc, i) => (
                       <div key={i}>
                         {renderEventPopupContent(loc, { compact: true, showLocation: false })}


### PR DESCRIPTION
## Summary
- réduit la largeur et les espacements des popups des points de rencontre pour un rendu plus compact
- ajuste la carte des regroupements afin de limiter la largeur et les marges des popups d'évènements
- resserre la présentation générique des popups d'évènement pour harmoniser la compacité

## Testing
- npm run lint *(échoue : dépendance eslint-plugin-react-hooks manquante dans l'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68d53b6aadf483268bda273aa81ab652