### PR TITLE
Adjust dark mode popup styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -151,16 +151,20 @@
   border-radius: 4px;
 }
 
-/* Ensure Leaflet popups remain white even in dark mode */
+/* Harmonise Leaflet popups with the active theme */
 .leaflet-popup-content-wrapper,
 .leaflet-popup-tip {
   background-color: #fff !important;
   color: #111827 !important;
+  box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.45) !important;
 }
 .dark .leaflet-popup-content-wrapper,
 .dark .leaflet-popup-tip {
-  background-color: #fff !important;
-  color: #111827 !important;
+  background: rgba(15, 23, 42, 0.95) !important;
+  color: #f8fafc !important;
+  border: 1px solid rgba(148, 163, 184, 0.35) !important;
+  box-shadow: 0 30px 60px -28px rgba(2, 6, 23, 0.65) !important;
+  backdrop-filter: blur(6px);
 }
 
 .cdr-popup .leaflet-popup-content-wrapper,
@@ -189,6 +193,14 @@
   border-radius: 0.5rem;
   background: rgba(255, 255, 255, 0.85) !important;
   box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.45) !important;
+}
+.dark .cdr-popup .leaflet-popup-content-wrapper {
+  border: 1px solid rgba(148, 163, 184, 0.25) !important;
+}
+.dark .cdr-popup .leaflet-popup-tip {
+  background: rgba(15, 23, 42, 0.9) !important;
+  box-shadow: 0 30px 60px -28px rgba(2, 6, 23, 0.65) !important;
+  border: 1px solid rgba(148, 163, 184, 0.2) !important;
 }
 
 /* Offset layer control from close button */


### PR DESCRIPTION
## Summary
- harmonise Leaflet popup styling with the active theme and enhance dark mode colours
- refine CDR popup borders and pointer styling in dark mode for better contrast

## Testing
- npm run build *(fails: vite not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d63f9ef58c8326a53d0d199269bbaf