### PR TITLE
Fix dark theme popups and PDF export table layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -160,11 +160,11 @@
 }
 .dark .leaflet-popup-content-wrapper,
 .dark .leaflet-popup-tip {
-  background: rgba(15, 23, 42, 0.95) !important;
-  color: #f8fafc !important;
-  border: 1px solid rgba(148, 163, 184, 0.35) !important;
-  box-shadow: 0 30px 60px -28px rgba(2, 6, 23, 0.65) !important;
-  backdrop-filter: blur(6px);
+  background-color: #fff !important;
+  color: #111827 !important;
+  border: 1px solid rgba(15, 23, 42, 0.12) !important;
+  box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.45) !important;
+  backdrop-filter: none;
 }
 
 .cdr-popup .leaflet-popup-content-wrapper,
@@ -195,12 +195,16 @@
   box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.45) !important;
 }
 .dark .cdr-popup .leaflet-popup-content-wrapper {
-  border: 1px solid rgba(148, 163, 184, 0.25) !important;
+  background: rgba(255, 255, 255, 0.95) !important;
+  border: 1px solid rgba(15, 23, 42, 0.12) !important;
 }
 .dark .cdr-popup .leaflet-popup-tip {
-  background: rgba(15, 23, 42, 0.9) !important;
-  box-shadow: 0 30px 60px -28px rgba(2, 6, 23, 0.65) !important;
-  border: 1px solid rgba(148, 163, 184, 0.2) !important;
+  background: rgba(255, 255, 255, 0.95) !important;
+  box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.45) !important;
+  border: 1px solid rgba(15, 23, 42, 0.12) !important;
+}
+.dark .cdr-popup .leaflet-popup-content {
+  color: #111827 !important;
 }
 
 /* Offset layer control from close button */


### PR DESCRIPTION
## Summary
- align Leaflet popups in dark mode with the light theme styling for clearer popups
- update CDR-specific popups so dark mode keeps a bright background and readable text
- recalculate PDF operation report table row heights to accommodate long filenames without overlap

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6431a867c8326944cadab726e14a0