### PR TITLE
Handle missing JWT secret in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Copiez ensuite vos paramètres sensibles (connexion MySQL, clés JWT, etc.) dans
 
 ### Variables d'environnement de sécurité
 
-- `JWT_SECRET` : clé secrète **obligatoire** pour signer les jetons JWT. Utilisez une valeur aléatoire robuste (32 caractères ou plus).
+- `JWT_SECRET` : clé secrète **obligatoire** pour signer les jetons JWT. Utilisez une valeur aléatoire robuste (32 caractères ou plus). En développement, un secret temporaire est généré automatiquement si la variable est absente, mais ne vous reposez pas dessus pour la production.
 - `CORS_ALLOWED_ORIGINS` : liste séparée par des virgules des URL autorisées à appeler l'API via CORS. Ajoutez ici les domaines de vos front-ends autorisés.
 
 ## Lancement


### PR DESCRIPTION
## Summary
- generate a temporary JWT secret during development when JWT_SECRET is missing
- cache the generated secret and emit a warning to highlight the configuration gap
- document the development fallback in the README so production environments still configure a real secret

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d676c35f7c8326b8516f25c1f78e86