### PR TITLE
feat: encrypt JSON payloads end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,7 @@ ELASTICSEARCH_URL=http://localhost:9200
 APP_DATA_KEY=0000000000000000000000000000000000000000000000000000000000000000
 # Clés précédentes optionnelles séparées par des virgules, utilisées pour les rotations.
 APP_PREVIOUS_DATA_KEY=
+
+# Chiffrement applicatif des payloads JSON (clé AES-256 encodée en base64 partagée front/back)
+PAYLOAD_ENCRYPTION_KEY=
+VITE_PAYLOAD_ENCRYPTION_KEY=

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Copiez ensuite vos paramètres sensibles (connexion MySQL, clés JWT, etc.) dans
 
 - `JWT_SECRET` : clé secrète **obligatoire** pour signer les jetons JWT. Utilisez une valeur aléatoire robuste (32 caractères ou plus). En développement, un secret temporaire est généré automatiquement si la variable est absente, mais ne vous reposez pas dessus pour la production.
 - `CORS_ALLOWED_ORIGINS` : liste séparée par des virgules des URL autorisées à appeler l'API via CORS. Ajoutez ici les domaines de vos front-ends autorisés.
+- `PAYLOAD_ENCRYPTION_KEY` : clé AES-256 encodée en base64 utilisée par l'API pour déchiffrer les requêtes JSON chiffrées par le front.
+- `VITE_PAYLOAD_ENCRYPTION_KEY` : copie côté client (toujours préfixée `VITE_`) de la même clé AES-256 encodée en base64 ; elle est injectée par Vite lors du build pour chiffrer les payloads sortants.
+
+### Rotation de la clé de chiffrement des payloads
+
+1. Générer une nouvelle clé aléatoire de 32 octets et l'encoder en base64 :
+
+   ```bash
+   openssl rand -base64 32
+   ```
+
+2. Mettre à jour simultanément `PAYLOAD_ENCRYPTION_KEY` et `VITE_PAYLOAD_ENCRYPTION_KEY` avec la valeur générée.
+3. Redémarrer le serveur et relancer le build du front (`npm run build` ou `npm run dev`) pour prendre en compte la nouvelle clé.
+4. Vérifier manuellement une requête critique (ex. `/api/auth/login`) en observant le header `X-Encrypted: aes-gcm` côté client et la bonne réception côté API.
 
 ## Lancement
 

--- a/server/app.js
+++ b/server/app.js
@@ -28,6 +28,7 @@ import divisionsRoutes from './routes/divisions.js';
 import notificationsRoutes from './routes/notifications.js';
 import fraudRoutes from './routes/fraud.js';
 import { authenticate } from './middleware/auth.js';
+import { payloadEncryptionMiddleware } from './middleware/payloadEncryption.js';
 import { ensureEnvironment, resolveAllowedOrigins } from './config/environment.js';
 
 // Initialisation de la base de données
@@ -104,7 +105,7 @@ app.use(
 );
 app.use(enforceCors);
 
-app.use(express.json({ limit: '50mb' }));
+app.use(payloadEncryptionMiddleware);
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
 const uploadsPath = path.join(__dirname, '../uploads');

--- a/server/middleware/payloadEncryption.js
+++ b/server/middleware/payloadEncryption.js
@@ -1,0 +1,113 @@
+import express from 'express';
+import crypto from 'crypto';
+import { getPayloadEncryptionKey } from '../config/environment.js';
+
+const jsonParser = express.json({ limit: '50mb' });
+const MAX_ENCRYPTED_PAYLOAD_SIZE = 50 * 1024 * 1024; // 50 MB
+
+const base64ToBuffer = (value) => {
+  try {
+    return Buffer.from(value, 'base64');
+  } catch (error) {
+    throw new Error('Invalid base64 value in encrypted payload envelope.');
+  }
+};
+
+const readRawBody = (req) =>
+  new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+
+    req.on('data', (chunk) => {
+      total += chunk.length;
+      if (total > MAX_ENCRYPTED_PAYLOAD_SIZE) {
+        req.destroy();
+        const error = new Error('Encrypted payload exceeds maximum allowed size (50 MB).');
+        error.code = 'PAYLOAD_TOO_LARGE';
+        reject(error);
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks));
+    });
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+  });
+
+const decryptPayload = ({ iv, data }) => {
+  if (typeof iv !== 'string' || typeof data !== 'string') {
+    throw new Error('Encrypted payload must include base64 encoded iv and data strings.');
+  }
+
+  const ivBuffer = base64ToBuffer(iv);
+  const ciphertextWithTag = base64ToBuffer(data);
+
+  if (ivBuffer.length !== 12) {
+    throw new Error('Invalid IV length: AES-GCM requires a 12-byte IV.');
+  }
+
+  if (ciphertextWithTag.length <= 16) {
+    throw new Error('Encrypted payload is too short to contain authentication tag.');
+  }
+
+  const tag = ciphertextWithTag.slice(ciphertextWithTag.length - 16);
+  const ciphertext = ciphertextWithTag.slice(0, ciphertextWithTag.length - 16);
+
+  const key = getPayloadEncryptionKey();
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, ivBuffer);
+  decipher.setAuthTag(tag);
+
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return decrypted.toString('utf-8');
+};
+
+export const payloadEncryptionMiddleware = async (req, res, next) => {
+  const encryptionHeader = req.headers['x-encrypted'];
+  if (!encryptionHeader) {
+    return jsonParser(req, res, next);
+  }
+
+  if (typeof encryptionHeader === 'string' && encryptionHeader.toLowerCase() !== 'aes-gcm') {
+    return res.status(400).json({ error: 'Unsupported encrypted payload format.' });
+  }
+
+  try {
+    const rawBody = await readRawBody(req);
+    if (!rawBody || rawBody.length === 0) {
+      throw new Error('Encrypted payload body is empty.');
+    }
+
+    let envelope;
+    try {
+      envelope = JSON.parse(rawBody.toString('utf-8'));
+    } catch (error) {
+      throw new Error('Encrypted payload envelope must be valid JSON.');
+    }
+
+    const decryptedJson = decryptPayload(envelope);
+
+    try {
+      req.body = JSON.parse(decryptedJson);
+    } catch (error) {
+      throw new Error('Decrypted payload is not valid JSON.');
+    }
+
+    req.headers['content-type'] = 'application/json';
+    req._body = true;
+    req.rawBody = rawBody;
+    return next();
+  } catch (error) {
+    if (error?.code === 'PAYLOAD_TOO_LARGE') {
+      console.warn('Encrypted payload rejected: payload too large.');
+      return res.status(413).json({ error: 'Encrypted payload too large.' });
+    }
+
+    console.error('Failed to decrypt encrypted payload:', error);
+    return res.status(400).json({ error: 'Invalid encrypted payload.' });
+  }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,5 +2,8 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import 'leaflet/dist/leaflet.css';
+import { setupEncryptedFetch } from './utils/payloadEncryption.ts';
+
+setupEncryptedFetch();
 
 createRoot(document.getElementById('root')!).render(<App />);

--- a/src/utils/payloadEncryption.ts
+++ b/src/utils/payloadEncryption.ts
@@ -1,0 +1,153 @@
+const AES_GCM_IV_LENGTH = 12; // 96 bits
+
+let cachedKeyPromise: Promise<CryptoKey> | null = null;
+
+const textEncoder = new TextEncoder();
+
+const getAtob = () => {
+  if (typeof globalThis.atob === 'function') {
+    return globalThis.atob;
+  }
+  throw new Error('atob is not available in the current environment.');
+};
+
+const getBtoa = () => {
+  if (typeof globalThis.btoa === 'function') {
+    return globalThis.btoa;
+  }
+  throw new Error('btoa is not available in the current environment.');
+};
+
+const base64ToUint8Array = (base64: string): Uint8Array => {
+  const normalized = base64.replace(/\s+/g, '');
+  const binaryString = getAtob()(normalized);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let index = 0; index < binaryString.length; index += 1) {
+    bytes[index] = binaryString.charCodeAt(index);
+  }
+  return bytes;
+};
+
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return getBtoa()(binary);
+};
+
+const importEncryptionKey = async (): Promise<CryptoKey> => {
+  if (cachedKeyPromise) {
+    return cachedKeyPromise;
+  }
+
+  const importPromise = (async () => {
+    const cryptoApi = globalThis.crypto;
+    if (!cryptoApi?.subtle) {
+      throw new Error('Web Crypto API is not available in this environment.');
+    }
+
+    const base64Key = import.meta.env.VITE_PAYLOAD_ENCRYPTION_KEY?.trim();
+    if (!base64Key) {
+      throw new Error('VITE_PAYLOAD_ENCRYPTION_KEY est requis pour chiffrer les payloads JSON.');
+    }
+
+    const rawKey = base64ToUint8Array(base64Key);
+    if (rawKey.byteLength !== 32) {
+      throw new Error('La clé de chiffrement doit contenir 32 octets (clé AES-256) après décodage base64.');
+    }
+
+    return cryptoApi.subtle.importKey('raw', rawKey, { name: 'AES-GCM' }, false, ['encrypt']);
+  })();
+
+  cachedKeyPromise = importPromise.catch((error) => {
+    cachedKeyPromise = null;
+    throw error;
+  });
+
+  return cachedKeyPromise;
+};
+
+export interface EncryptedJsonPayload {
+  iv: string;
+  data: string;
+}
+
+export const encryptJsonPayload = async (body: string): Promise<EncryptedJsonPayload> => {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi?.subtle) {
+    throw new Error('Web Crypto API is not available in this environment.');
+  }
+
+  const key = await importEncryptionKey();
+  const encodedBody = textEncoder.encode(body);
+  const iv = cryptoApi.getRandomValues(new Uint8Array(AES_GCM_IV_LENGTH));
+
+  const encryptedBuffer = await cryptoApi.subtle.encrypt({ name: 'AES-GCM', iv }, key, encodedBody);
+
+  return {
+    iv: arrayBufferToBase64(iv.buffer),
+    data: arrayBufferToBase64(encryptedBuffer)
+  };
+};
+
+export const setupEncryptedFetch = () => {
+  if (typeof window === 'undefined' || typeof window.fetch !== 'function') {
+    return;
+  }
+
+  const INSTALL_FLAG = '__payload_encryption_fetch_wrapper__';
+  if ((window as unknown as Record<string, unknown>)[INSTALL_FLAG]) {
+    return;
+  }
+
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const method = request.method?.toUpperCase();
+    const headers = new Headers(request.headers);
+    const contentType = headers.get('content-type')?.toLowerCase() ?? '';
+
+    const callOriginalFetch = () =>
+      init === undefined ? originalFetch(input) : originalFetch(input, init);
+
+    if (
+      !method ||
+      method === 'GET' ||
+      method === 'HEAD' ||
+      method === 'OPTIONS' ||
+      headers.has('X-Encrypted') ||
+      !contentType.startsWith('application/json')
+    ) {
+      return callOriginalFetch();
+    }
+
+    try {
+      const bodyText = await request.clone().text();
+      if (!bodyText) {
+        return callOriginalFetch();
+      }
+
+      const encryptedPayload = await encryptJsonPayload(bodyText);
+      const encryptedBody = JSON.stringify(encryptedPayload);
+
+      headers.set('Content-Type', 'application/json');
+      headers.set('X-Encrypted', 'aes-gcm');
+
+      const encryptedRequest = new Request(request, {
+        body: encryptedBody,
+        headers,
+        method: request.method
+      });
+
+      return originalFetch(encryptedRequest);
+    } catch (error) {
+      console.error('Échec du chiffrement du payload JSON :', error);
+      throw error;
+    }
+  };
+
+  (window as unknown as Record<string, unknown>)[INSTALL_FLAG] = true;
+};


### PR DESCRIPTION
## Summary
- add a browser payload encryption helper and install a global fetch wrapper to AES-GCM encrypt JSON requests
- require a shared base64 AES key on the server and decrypt encrypted payloads via a new middleware
- document the new environment variables and rotation process for the payload encryption key

## Testing
- npm run lint *(fails: dependencies unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6761229588326b4e57747eb9b64f5