### PR TITLE
Disable payload encryption when key missing

### DIFF
--- a/src/utils/payloadEncryption.ts
+++ b/src/utils/payloadEncryption.ts
@@ -97,6 +97,14 @@ export const setupEncryptedFetch = () => {
     return;
   }
 
+  const base64Key = import.meta.env.VITE_PAYLOAD_ENCRYPTION_KEY?.trim();
+  if (!base64Key) {
+    console.warn(
+      'VITE_PAYLOAD_ENCRYPTION_KEY est introuvable. Le chiffrement des requêtes JSON est désactivé.'
+    );
+    return;
+  }
+
   const INSTALL_FLAG = '__payload_encryption_fetch_wrapper__';
   if ((window as unknown as Record<string, unknown>)[INSTALL_FLAG]) {
     return;


### PR DESCRIPTION
## Summary
- skip installing the encrypted fetch wrapper when the payload encryption key is absent
- log a warning so developers know why JSON encryption was disabled

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d67cc732a08326b732b05b52145c9b