### PR TITLE
Fix payload encryption wrapper fetch invocation

### DIFF
--- a/src/utils/payloadEncryption.ts
+++ b/src/utils/payloadEncryption.ts
@@ -220,7 +220,8 @@ export const setupEncryptedFetch = () => {
         method: request.method
       });
 
-      return originalFetch(encryptedRequest);
+      const fetchImplementation = originalFetch ?? nativeFetch;
+      return fetchImplementation(encryptedRequest);
     } catch (error) {
       console.error('Échec du chiffrement du payload JSON :', error);
       throw error;


### PR DESCRIPTION
## Summary
- ensure the encrypted fetch wrapper falls back to the native fetch binding when issuing encrypted requests to avoid nullability errors in strict TypeScript mode

## Testing
- not run (dependencies unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d68077594c8326958b39cf199b0992