### PR TITLE
Call logout API when user signs out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1552,6 +1552,18 @@ const App: React.FC = () => {
   };
 
   const handleLogout = useCallback((reason?: 'inactivity') => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      fetch('/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      }).catch((error) => {
+        console.error('Erreur lors de la déconnexion:', error);
+      });
+    }
+
     localStorage.removeItem('token');
     setCurrentUser(null);
     setIsAuthenticated(false);


### PR DESCRIPTION
## Summary
- call the backend logout endpoint from `handleLogout` so user sessions are closed server-side

## Testing
- npm run lint *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_68d6827f933083268aace9fe576202ea