### PR TITLE
Align dark theme popups with light palette

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -195,13 +195,14 @@
   box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.45) !important;
 }
 .dark .cdr-popup .leaflet-popup-content-wrapper {
-  background: rgba(255, 255, 255, 0.95) !important;
-  border: 1px solid rgba(15, 23, 42, 0.12) !important;
+  background: transparent !important;
+  border: none !important;
 }
 .dark .cdr-popup .leaflet-popup-tip {
-  background: rgba(255, 255, 255, 0.95) !important;
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.85) !important;
   box-shadow: 0 18px 36px -24px rgba(15, 23, 42, 0.45) !important;
-  border: 1px solid rgba(15, 23, 42, 0.12) !important;
+  border: none !important;
 }
 .dark .cdr-popup .leaflet-popup-content {
   color: #111827 !important;


### PR DESCRIPTION
## Summary
- align the dark theme popups with the light theme color palette for consistent styling

## Testing
- not run (dependency installation blocked by registry 403)


------
https://chatgpt.com/codex/tasks/task_e_68d68d4f0a80832690ec0fb9d6ee9a74