### PR TITLE
Normalize identified number data when creating profiles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5125,11 +5125,41 @@ useEffect(() => {
                             className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
                             onClick={() => {
                               const combined: Record<string, any> = {};
+                              const mergeEntry = (target: Record<string, any>, key: string, value: any) => {
+                                if (value === null || value === undefined) {
+                                  return;
+                                }
+                                if (key === 'data') {
+                                  let parsed = value;
+                                  if (typeof parsed === 'string') {
+                                    try {
+                                      parsed = JSON.parse(parsed);
+                                    } catch {
+                                      parsed = value;
+                                    }
+                                  }
+                                  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                                    Object.entries(parsed).forEach(([nestedKey, nestedValue]) => {
+                                      if (nestedValue === null || nestedValue === undefined) {
+                                        return;
+                                      }
+                                      const normalizedKey = typeof nestedKey === 'string' ? nestedKey : String(nestedKey);
+                                      if (target[normalizedKey] === undefined) {
+                                        target[normalizedKey] = nestedValue;
+                                      }
+                                    });
+                                    return;
+                                  }
+                                }
+                                const normalizedKey = typeof key === 'string' ? key : String(key);
+                                if (target[normalizedKey] === undefined) {
+                                  target[normalizedKey] = value;
+                                }
+                              };
+
                               searchResults.hits.forEach(h => {
                                 Object.entries(h.preview || {}).forEach(([k, v]) => {
-                                  if (v != null && combined[k] === undefined) {
-                                    combined[k] = v;
-                                  }
+                                  mergeEntry(combined, k, v);
                                 });
                               });
                               const { email, ...extra } = combined;

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -98,11 +98,41 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
           className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
           onClick={() => {
             const combined: Record<string, any> = {};
+            const mergeEntry = (target: Record<string, any>, key: string, value: any) => {
+              if (value === null || value === undefined) {
+                return;
+              }
+              if (key === 'data') {
+                let parsed = value;
+                if (typeof parsed === 'string') {
+                  try {
+                    parsed = JSON.parse(parsed);
+                  } catch {
+                    parsed = value;
+                  }
+                }
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                  Object.entries(parsed).forEach(([nestedKey, nestedValue]) => {
+                    if (nestedValue === null || nestedValue === undefined) {
+                      return;
+                    }
+                    const normalizedKey = typeof nestedKey === 'string' ? nestedKey : String(nestedKey);
+                    if (target[normalizedKey] === undefined) {
+                      target[normalizedKey] = nestedValue;
+                    }
+                  });
+                  return;
+                }
+              }
+              const normalizedKey = typeof key === 'string' ? key : String(key);
+              if (target[normalizedKey] === undefined) {
+                target[normalizedKey] = value;
+              }
+            };
+
             hits.forEach(h => {
               Object.entries(h.preview || {}).forEach(([k, v]) => {
-                if (v != null && combined[k] === undefined) {
-                  combined[k] = v;
-                }
+                mergeEntry(combined, k, v);
               });
             });
             const { email, ...extra } = combined;


### PR DESCRIPTION
## Summary
- flatten preview payloads so identified number JSON data is merged into logical fields before creating profiles from search results
- apply the same merge logic in the shared search results component so profile defaults no longer include a raw JSON blob

## Testing
- npm run build *(fails: local Vite binary missing because npm install cannot download from registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da46a657d883269d0bb4e8887cb4cb