### PR TITLE
Clean up profile shares before deleting profiles

### DIFF
--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -102,6 +102,8 @@ class Profile {
   }
 
   static async delete(id) {
+    // Ensure related shares are removed first to avoid FK constraint issues
+    await database.query('DELETE FROM autres.profile_shares WHERE profile_id = ?', [id]);
     await database.query('DELETE FROM autres.profiles WHERE id = ?', [id]);
     return true;
   }


### PR DESCRIPTION
## Summary
- delete profile share rows before removing a profile so deletions no longer hit foreign key constraints

## Testing
- npm run lint *(fails: missing `eslint-plugin-react-hooks` dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dce1fd1e408326b9890e33cb77855b