### PR TITLE
Ensure division FK recreation fails when constraint cannot be created

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -138,7 +138,7 @@ class DatabaseManager {
               REFERENCES autres.divisions(id) ON DELETE SET NULL
           `);
         } catch (error) {
-          if (error.code !== 'ER_DUP_KEYNAME' && error.code !== 'ER_CANT_CREATE_TABLE') {
+          if (error.code !== 'ER_DUP_KEYNAME') {
             throw error;
           }
         }


### PR DESCRIPTION
## Summary
- stop swallowing `ER_CANT_CREATE_TABLE` when re-adding the `users.division_id` foreign key
- keep ignoring `ER_DUP_KEYNAME` when the constraint already exists

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de4046aa548326aad6169f6fc8f5cf