### PR TITLE
Fix foreign key setup for users division references

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -291,6 +291,14 @@ class DatabaseManager {
           }
         }
 
+        // Nettoyer les valeurs orphelines avant de recréer la contrainte
+        await this.pool.execute(`
+          UPDATE autres.users u
+          LEFT JOIN autres.divisions d ON d.id = u.division_id
+          SET u.division_id = NULL
+          WHERE u.division_id IS NOT NULL AND d.id IS NULL
+        `);
+
         await this.pool.execute(`
           ALTER TABLE autres.users
           MODIFY COLUMN division_id INT NULL


### PR DESCRIPTION
## Summary
- clean up orphaned division references before recreating the users.division_id foreign key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4b2e4d148326b261b390dbf26187