### PR TITLE
Fix: make division_id nullable before cleanup

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -291,17 +291,18 @@ class DatabaseManager {
           }
         }
 
+        // Rendre la colonne nullable pour pouvoir nettoyer les lignes orphelines
+        await this.pool.execute(`
+          ALTER TABLE autres.users
+          MODIFY COLUMN division_id INT NULL
+        `);
+
         // Nettoyer les valeurs orphelines avant de recréer la contrainte
         await this.pool.execute(`
           UPDATE autres.users u
           LEFT JOIN autres.divisions d ON d.id = u.division_id
           SET u.division_id = NULL
           WHERE u.division_id IS NOT NULL AND d.id IS NULL
-        `);
-
-        await this.pool.execute(`
-          ALTER TABLE autres.users
-          MODIFY COLUMN division_id INT NULL
         `);
 
         try {


### PR DESCRIPTION
## Summary
- make `users.division_id` nullable before running orphan cleanup to avoid `ER_BAD_NULL_ERROR`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4d38763c83269b96a1c490de2b4d