### PR TITLE
feat: initialiser l’index Elasticsearch des profils

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Les deux commandes peuvent être exécutées en parallèle pendant le développe
 - `node server/scripts/init-database.js` : crée les tables nécessaires si elles n'existent pas.
 - `node server/scripts/sync-all.js` : synchronise les données pour la recherche.
 
+### Indexation initiale Elasticsearch
+
+Après avoir configuré votre cluster et défini les variables d'environnement nécessaires (`ELASTICSEARCH_URL`, `USE_ELASTICSEARCH=true` et éventuellement `SYNC_BATCH_SIZE` pour ajuster la taille des lots), exécutez :
+
+```bash
+node server/scripts/sync-all.js
+```
+
+Le script lit les tables référencées dans `server/config/tables-catalog.js` (dont `autres.profiles`) et alimente l'index `profiles` d'Elasticsearch en purgant l'index si besoin. Assurez-vous que la base MySQL contient les données à indexer avant de lancer cette opération.
+
 ## Tests
 
 Une suite de tests automatisés n'est pas fournie. Utilisez le lint et les tests manuels fonctionnels avant toute mise en production.

--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -1,4 +1,25 @@
 export default {
+  'autres.profiles': {
+    display: 'profiles',
+    database: 'autres',
+    primaryKey: 'id',
+    searchable: ['first_name', 'last_name', 'phone', 'email'],
+    linkedFields: ['phone', 'email'],
+    preview: ['first_name', 'last_name', 'phone', 'email', 'comment'],
+    filters: {
+      division_id: 'number',
+      phone: 'string',
+      email: 'string'
+    },
+    theme: 'interne',
+    sync: {
+      type: 'profile',
+      elasticsearchIndex: 'profiles',
+      purgeBeforeIndex: true,
+      batchSize: 500
+    }
+  },
+
   // Base esolde
   'esolde.mytable': {
     display: 'mytable',

--- a/server/scripts/sync-all.js
+++ b/server/scripts/sync-all.js
@@ -1,12 +1,26 @@
 import SyncService from '../services/SyncService.js';
+import database from '../config/database.js';
 
 async function run() {
   const service = new SyncService();
   await service.syncAllTables();
-  process.exit(0);
 }
 
-run().catch(err => {
-  console.error('Erreur lors de la synchronisation générale:', err);
-  process.exit(1);
-});
+run()
+  .then(async () => {
+    try {
+      await database.close();
+    } catch (error) {
+      if (error) {
+        console.error('⚠️ Erreur lors de la fermeture de la base de données:', error.message);
+      }
+    }
+    process.exit(0);
+  })
+  .catch(async (err) => {
+    console.error('Erreur lors de la synchronisation générale:', err);
+    try {
+      await database.close();
+    } catch (_) {}
+    process.exit(1);
+  });

--- a/server/services/SyncService.js
+++ b/server/services/SyncService.js
@@ -3,6 +3,9 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import baseCatalog from '../config/tables-catalog.js';
+import ElasticSearchService from './ElasticSearchService.js';
+
+const DEFAULT_BATCH_SIZE = 500;
 
 /**
  * Service utilitaire pour synchroniser les tables configurées.
@@ -13,6 +16,10 @@ class SyncService {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     this.catalogPath = path.join(__dirname, '../config/tables-catalog.json');
+    this.elasticService = new ElasticSearchService();
+    this.useElastic = process.env.USE_ELASTICSEARCH === 'true';
+    this.resetIndices = new Set();
+    this.catalog = this.loadCatalog();
   }
 
   loadCatalog() {
@@ -33,20 +40,121 @@ class SyncService {
     return catalog;
   }
 
-  async syncTable(tableName) {
+  resolveBatchSize(syncConfig = {}) {
+    const envBatch = Number(process.env.SYNC_BATCH_SIZE);
+    if (Number.isFinite(envBatch) && envBatch > 0) {
+      return envBatch;
+    }
+
+    const configBatch = Number(syncConfig.batchSize);
+    if (Number.isFinite(configBatch) && configBatch > 0) {
+      return configBatch;
+    }
+
+    return DEFAULT_BATCH_SIZE;
+  }
+
+  async syncTable(tableName, config = null) {
+    const catalog = config ? null : this.catalog || this.loadCatalog();
+    const tableConfig = config || catalog?.[tableName];
+    if (!tableConfig) {
+      console.warn(`⚠️ Table ${tableName} absente du catalogue, synchronisation ignorée.`);
+      return;
+    }
+
+    const primaryKey = tableConfig.primaryKey || 'id';
+    const syncConfig = tableConfig.sync || {};
+    if (!syncConfig.elasticsearchIndex) {
+      console.log(`ℹ️ Table ${tableName} : aucune configuration de synchronisation Elasticsearch, ignorée.`);
+      return;
+    }
+    if (!this.useElastic) {
+      console.warn(
+        `⚠️ Synchronisation Elasticsearch désactivée (USE_ELASTICSEARCH!=true). Table ${tableName} ignorée.`
+      );
+      return;
+    }
+    const batchSize = this.resolveBatchSize(syncConfig);
+
     try {
-      // Vérifie l'accès à la table en effectuant une requête simple.
-      await database.queryOne(`SELECT 1 FROM ${tableName} LIMIT 1`);
-      console.log(`✅ Table ${tableName} synchronisée`);
+      let offset = 0;
+      let totalIndexed = 0;
+      let totalFetched = 0;
+      let hasMore = true;
+
+      const shouldSyncToElastic =
+        this.useElastic && syncConfig.elasticsearchIndex && syncConfig.type === 'profile';
+
+      if (shouldSyncToElastic && !this.resetIndices.has(syncConfig.elasticsearchIndex)) {
+        if (syncConfig.purgeBeforeIndex !== false) {
+          try {
+            await this.elasticService.resetProfilesIndex({
+              recreate: true,
+              index: syncConfig.elasticsearchIndex
+            });
+            console.log(`🧹 Index ${syncConfig.elasticsearchIndex} réinitialisé`);
+          } catch (error) {
+            console.error(
+              `❌ Échec de la réinitialisation de l'index ${syncConfig.elasticsearchIndex}:`,
+              error.message
+            );
+          }
+        }
+        this.resetIndices.add(syncConfig.elasticsearchIndex);
+      }
+
+      while (hasMore) {
+        const rows = await database.query(
+          `SELECT * FROM ${tableName} ORDER BY \`${primaryKey}\` ASC LIMIT ? OFFSET ?`,
+          [batchSize, offset]
+        );
+
+        if (!rows.length) {
+          hasMore = false;
+          break;
+        }
+
+        totalFetched += rows.length;
+
+        if (shouldSyncToElastic) {
+          try {
+            const { indexed, errors } = await this.elasticService.indexProfilesBulk(rows, {
+              refresh: false,
+              index: syncConfig.elasticsearchIndex
+            });
+            totalIndexed += indexed;
+            if (errors.length > 0) {
+              for (const { id, error } of errors) {
+                console.error(
+                  `❌ Erreur indexation profil ${id} dans ${syncConfig.elasticsearchIndex}:`,
+                  error
+                );
+              }
+            }
+          } catch (error) {
+            console.error(`❌ Échec indexation Elasticsearch pour ${tableName}:`, error.message);
+          }
+        }
+
+        offset += rows.length;
+        hasMore = rows.length === batchSize;
+      }
+
+      const syncSummary = [`${totalFetched} lignes lues`];
+      if (shouldSyncToElastic) {
+        syncSummary.push(`${totalIndexed} documents indexés`);
+      }
+
+      console.log(`✅ Table ${tableName} synchronisée (${syncSummary.join(', ')})`);
     } catch (error) {
       console.error(`❌ Synchronisation échouée pour ${tableName}:`, error.message);
     }
   }
 
   async syncAllTables() {
-    const catalog = this.loadCatalog();
-    for (const tableName of Object.keys(catalog)) {
-      await this.syncTable(tableName);
+    this.catalog = this.loadCatalog();
+    for (const [tableName, config] of Object.entries(this.catalog)) {
+      await this.syncTable(tableName, config);
     }
   }
 }


### PR DESCRIPTION
## Summary
- ajouter la configuration de synchronisation des profils internes dans le catalogue des tables
- implémenter une synchronisation paginée qui pousse les profils vers Elasticsearch via un bulk index et purge l’index au besoin
- documenter et mettre à jour le script d’initialisation pour expliquer comment lancer l’indexation

## Testing
- `npm run lint` *(échoue: module eslint-plugin-react-hooks manquant dans l’environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68de5bbe88788326a71072bbb17cb61c