### PR TITLE
Improve CDR search actions and notification styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4416,33 +4416,35 @@ useEffect(() => {
             />
           </div>
 
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-col gap-3">
             <button
               type="button"
               onClick={resetCdrSearch}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-6 py-2.5 text-sm font-semibold text-slate-600 shadow-sm transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 dark:border-slate-700/60 dark:bg-slate-900/40 dark:text-slate-200 dark:hover:bg-slate-800/80"
+              className="inline-flex items-center gap-2 self-start rounded-2xl border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 dark:border-slate-700/60 dark:bg-slate-900/40 dark:text-slate-200 dark:hover:bg-slate-800/80"
             >
               <RefreshCw className="h-4 w-4" />
               <span>Réinitialiser</span>
             </button>
-            <button
-              type="submit"
-              disabled={cdrLoading}
-              className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-indigo-500 via-sky-500 to-cyan-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <Search className="h-4 w-4" />
-              <span>Rechercher</span>
-            </button>
-            {cdrIdentifiers.length >= 2 && (
+            <div className="flex flex-wrap items-center gap-3">
               <button
-                type="button"
-                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-fuchsia-500 via-rose-500 to-orange-400 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-rose-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
-                onClick={handleLinkDiagram}
+                type="submit"
+                disabled={cdrLoading}
+                className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-500 via-sky-500 to-cyan-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                <Share2 className="h-4 w-4" />
-                <span>Diagramme des liens</span>
+                <Search className="h-4 w-4" />
+                <span>Rechercher</span>
               </button>
-            )}
+              {cdrIdentifiers.length >= 2 && (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-fuchsia-500 via-rose-500 to-orange-400 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-rose-300/40 transition-all hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
+                  onClick={handleLinkDiagram}
+                >
+                  <Share2 className="h-4 w-4" />
+                  <span>Diagramme des liens</span>
+                </button>
+              )}
+            </div>
           </div>
           </form>
           {showDetectionPanel && (
@@ -4799,7 +4801,7 @@ useEffect(() => {
             {isAdmin && (
               <button
                 onClick={() => setCurrentPage('blacklist')}
-                title="Black List"
+                title="White List"
                 className={`w-full group flex items-center px-4 py-3 text-sm font-medium rounded-xl transition-all ${
                   currentPage === 'blacklist'
                     ? 'bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 text-white shadow-lg shadow-blue-500/30'
@@ -4807,7 +4809,7 @@ useEffect(() => {
                 } ${!sidebarOpen && 'justify-center px-0'}`}
               >
                 <Ban className="h-5 w-5 transition-transform duration-200 group-hover:scale-110" />
-                {sidebarOpen && <span className="ml-3">Black List</span>}
+                {sidebarOpen && <span className="ml-3">White List</span>}
               </button>
             )}
 
@@ -7132,7 +7134,7 @@ useEffect(() => {
 
         {currentPage === 'blacklist' && isAdmin && (
           <div className="space-y-6">
-            <PageHeader icon={<Ban className="h-6 w-6" />} title="Black List" />
+            <PageHeader icon={<Ban className="h-6 w-6" />} title="White List" />
             <section className="relative overflow-hidden rounded-3xl border border-slate-200/80 bg-gradient-to-br from-white via-slate-50/90 to-blue-50/40 p-6 shadow-xl shadow-blue-200/50 backdrop-blur-sm dark:border-slate-700/60 dark:from-slate-900/80 dark:via-slate-900/60 dark:to-slate-900/40 dark:shadow-black/40">
               <div className="absolute -right-32 top-10 h-64 w-64 rounded-full bg-blue-200/40 blur-3xl dark:bg-blue-900/30" />
               <div className="absolute -left-36 bottom-0 h-56 w-56 rounded-full bg-purple-200/40 blur-3xl dark:bg-purple-900/30" />

--- a/src/components/NotificationProvider.tsx
+++ b/src/components/NotificationProvider.tsx
@@ -21,10 +21,14 @@ interface NotificationContextValue {
 const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
 
 const toneStyles: Record<NotificationTone, string> = {
-  success: 'border-emerald-500/50 bg-emerald-500/10 text-emerald-100',
-  error: 'border-red-500/50 bg-red-500/10 text-red-100',
-  info: 'border-sky-500/50 bg-sky-500/10 text-sky-100',
-  warning: 'border-amber-500/50 bg-amber-500/10 text-amber-100'
+  success:
+    'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/60 dark:bg-emerald-500/15 dark:text-emerald-100',
+  error:
+    'border-red-200 bg-red-50 text-red-700 dark:border-red-500/60 dark:bg-red-500/15 dark:text-red-100',
+  info:
+    'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/60 dark:bg-sky-500/15 dark:text-sky-100',
+  warning:
+    'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/60 dark:bg-amber-500/15 dark:text-amber-100'
 };
 
 const toneIcons: Record<NotificationTone, string> = {
@@ -73,23 +77,23 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
       {children}
       {typeof document !== 'undefined' &&
         createPortal(
-          <div className="pointer-events-none fixed inset-x-0 top-4 z-[1000] flex flex-col items-center gap-2 px-4 sm:items-end sm:px-6">
+          <div className="pointer-events-none fixed inset-x-0 top-4 z-[1000] flex flex-col items-center gap-3 px-4 sm:items-end sm:px-6">
             {notifications.map((notification) => (
               <div
                 key={notification.id}
                 role="status"
-                className={`pointer-events-auto flex max-w-sm items-start gap-3 rounded-lg border px-4 py-3 shadow-lg backdrop-blur transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${toneStyles[notification.tone]}`}
+                className={`pointer-events-auto flex max-w-sm items-start gap-3 rounded-2xl border px-5 py-4 shadow-xl backdrop-blur transition focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-slate-600 dark:focus-visible:ring-offset-slate-900 ${toneStyles[notification.tone]}`}
               >
                 <span className="mt-0.5 text-lg font-semibold leading-none">
                   {toneIcons[notification.tone]}
                 </span>
-                <p className="flex-1 text-sm leading-snug text-white">
+                <p className="flex-1 text-sm leading-snug">
                   {notification.message}
                 </p>
                 <button
                   type="button"
                   onClick={() => clearNotification(notification.id)}
-                  className="ml-2 inline-flex text-sm font-semibold text-white/80 transition hover:text-white"
+                  className="ml-2 inline-flex text-sm font-semibold opacity-70 transition hover:opacity-100"
                   aria-label="Fermer la notification"
                 >
                   ×


### PR DESCRIPTION
## Summary
- brighten notification popup styling for the light theme while keeping dark mode support
- reorganize and restyle the CDR search action buttons to highlight reset separately
- rename the administrative Black List section and navigation entry to White List

## Testing
- `npm install` *(fails: 403 Forbidden fetching @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68de70429fcc83269063c4757a1e62e5