### PR TITLE
Fix pending number handling for CDR diagram and fraud searches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3158,6 +3158,12 @@ useEffect(() => {
     );
 
     if (ids.length === 0) {
+      setLinkDiagram(null);
+      setCdrResult(null);
+      setCdrLoading(false);
+      setCdrError('');
+      setCdrInfoMessage('Ajoutez au moins un identifiant valide pour lancer la recherche');
+      setShowCdrMap(false);
       return;
     }
 


### PR DESCRIPTION
## Summary
- ensure CDR, link diagram, and fraud detection requests use a deduplicated list that also includes the current input value
- update UI handlers so fraud detection and link diagram actions commit pending identifiers before triggering the backend
- reset the CDR search state when every identifier is filtered out so stale results are cleared

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e157206a7c8326b4e737c6585cb1cf