### PR TITLE
Fix CDR dashboard stats and fraud detection fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1393,18 +1393,6 @@ const App: React.FC = () => {
   const [caseFiles, setCaseFiles] = useState<CaseFile[]>([]);
   const [caseFilesPage, setCaseFilesPage] = useState(1);
   const [caseFilesPerPage, setCaseFilesPerPage] = useState(CASE_FILE_PAGE_SIZE_OPTIONS[0]);
-  const caseReferenceNumbers = useMemo(() => {
-    const rawNumbers = caseFiles
-      .map((file) => {
-        const value = file.cdr_number;
-        if (value === null || value === undefined) {
-          return '';
-        }
-        return String(value);
-      })
-      .filter((value) => value.trim().length > 0);
-    return dedupeCdrIdentifiers(rawNumbers);
-  }, [caseFiles, dedupeCdrIdentifiers]);
   const totalCaseFilesPages = Math.ceil(caseFiles.length / caseFilesPerPage) || 1;
   const paginatedCaseFiles = useMemo(
     () =>
@@ -1539,6 +1527,19 @@ const App: React.FC = () => {
     },
     [normalizeCdrNumber]
   );
+
+  const caseReferenceNumbers = useMemo(() => {
+    const rawNumbers = caseFiles
+      .map((file) => {
+        const value = file.cdr_number;
+        if (value === null || value === undefined) {
+          return '';
+        }
+        return String(value);
+      })
+      .filter((value) => value.trim().length > 0);
+    return dedupeCdrIdentifiers(rawNumbers);
+  }, [caseFiles, dedupeCdrIdentifiers]);
 
   const getEffectiveCdrIdentifiers = useCallback(() => {
     const combined = cdrIdentifierInput


### PR DESCRIPTION
## Summary
- move the case reference numbers memo below the dedupe callback so the hook is initialized safely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16525bec48326815bc5bf2e2bf59d