### PR TITLE
Ensure MySQL search indexes are created only when missing

### DIFF
--- a/server/scripts/create-search-indexes.js
+++ b/server/scripts/create-search-indexes.js
@@ -1,25 +1,61 @@
 import database from '../config/database.js';
 import catalog from '../config/tables-catalog.js';
 
+function sanitizeIdentifier(name) {
+  return name.replace(/[^a-zA-Z0-9_]/g, '_');
+}
+
+async function indexExists(schema, table, indexName) {
+  const existingIndex = await database.queryOne(
+    `
+      SELECT 1
+      FROM information_schema.STATISTICS
+      WHERE TABLE_SCHEMA = ?
+        AND TABLE_NAME = ?
+        AND INDEX_NAME = ?
+      LIMIT 1
+    `,
+    [schema, table, indexName]
+  );
+
+  return Boolean(existingIndex);
+}
+
 async function createIndexes() {
-  for (const [table, config] of Object.entries(catalog)) {
+  for (const [tableKey, config] of Object.entries(catalog)) {
     const fields = config.searchable || [];
+    if (!fields.length) {
+      continue;
+    }
+
+    const [defaultSchema, defaultTable] = tableKey.split('.');
+    const schema = config.database || defaultSchema || 'autres';
+    const table = defaultTable || tableKey;
+
     for (const field of fields) {
-      const indexName = `idx_${table.replace(/\./g, '_')}_${field}`;
+      const indexName = `idx_${sanitizeIdentifier(schema)}_${sanitizeIdentifier(table)}_${sanitizeIdentifier(field)}`.slice(0, 63);
+
       try {
+        const exists = await indexExists(schema, table, indexName);
+        if (exists) {
+          console.log(`ℹ️ Index ${indexName} déjà présent`);
+          continue;
+        }
+
         await database.query(
-          `CREATE INDEX IF NOT EXISTS ${indexName} ON ${table} (${field})`
+          `CREATE INDEX \`${indexName}\` ON \`${schema}\`.\`${table}\` (\`${field}\`)`
         );
         console.log(`✅ Index ${indexName} créé`);
       } catch (err) {
-        console.log(`ℹ️ Index ${indexName} ignoré: ${err.message}`);
+        console.log(`❌ Échec création index ${indexName}: ${err.message}`);
       }
     }
   }
+
   process.exit(0);
 }
 
-createIndexes().catch(err => {
+createIndexes().catch((err) => {
   console.error('❌ Erreur création index:', err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- check existing indexes in information_schema before creating them to avoid syntax errors
- sanitize identifiers and quote schema, table, and field names when generating CREATE INDEX statements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e29e5e4ecc8326a7187762250be4bb