### PR TITLE
Handle dotted override keys when merging search catalog overrides

### DIFF
--- a/server/scripts/create-search-indexes.js
+++ b/server/scripts/create-search-indexes.js
@@ -18,14 +18,30 @@ function loadCatalog() {
       const json = JSON.parse(raw);
 
       for (const [key, value] of Object.entries(json)) {
-        const [db, ...tableParts] = key.split('_');
+        let db;
+        let tableKey;
 
-        if (!db || tableParts.length === 0) {
-          console.warn(`⚠️ Entrée de catalogue invalide ignorée: ${key}`);
-          continue;
+        if (key.includes('.')) {
+          const [schema, ...tableParts] = key.split('.');
+          if (!schema || tableParts.length === 0) {
+            console.warn(`⚠️ Entrée de catalogue invalide ignorée: ${key}`);
+            continue;
+          }
+
+          db = schema;
+          tableKey = tableParts.join('.');
+        } else {
+          const [schema, ...tableParts] = key.split('_');
+          if (!schema || tableParts.length === 0) {
+            console.warn(`⚠️ Entrée de catalogue invalide ignorée: ${key}`);
+            continue;
+          }
+
+          db = schema;
+          tableKey = tableParts.join('_');
         }
 
-        const tableName = `${db}.${tableParts.join('_')}`;
+        const tableName = `${db}.${tableKey}`;
         const existing = catalog[tableName] || {};
         const merged = { ...existing, ...value };
 


### PR DESCRIPTION
## Summary
- allow catalog override entries that use dot-delimited table names
- normalize both dot and underscore formats before merging overrides

## Testing
- not run (script updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e2a49fc84c8326a8c33c3df0f57b8f