### PR TITLE
Activer la synchronisation Elasticsearch des profils

### DIFF
--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -98,9 +98,7 @@ router.post('/', authenticate, async (req, res) => {
       );
     }
 
-    if (!useElastic) {
-      searchAccessManager.remember(req.user.id, results.hits || []);
-    }
+    searchAccessManager.remember(req.user.id, results.hits || []);
 
     const searchTypeValue = typeof search_type === 'string' && search_type ? search_type : 'global';
     const userAgent = req.get('user-agent') || null;


### PR DESCRIPTION
## Summary
- enrichir le document Elasticsearch avec les métadonnées de table et permettre la suppression ciblée d’un profil
- indexer automatiquement les profils dans Elasticsearch lors des créations, mises à jour et suppressions quand USE_ELASTICSEARCH=true
- enregistrer systématiquement les résultats d’une recherche pour l’accès aux détails, y compris en mode Elasticsearch

## Testing
- npm run lint *(échoue : module eslint-plugin-react-hooks manquant dans l’environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a8a3ad5c8326a5c2acedea1094a8