### PR TITLE
Remove fuzzy search on numeric primary values

### DIFF
--- a/server/services/ElasticSearchService.js
+++ b/server/services/ElasticSearchService.js
@@ -484,8 +484,7 @@ class ElasticSearchService {
                   'email',
                   'search_tokens',
                   'full_text',
-                  'raw_values',
-                  'primary_value'
+                  'raw_values'
                 ],
                 fuzziness: 'AUTO'
               }


### PR DESCRIPTION
## Summary
- remove primary_value from the fuzzy multi_match query so numeric indices do not raise errors during unified search

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2afd3de20832686d30d64378e88af