### PR TITLE
Ensure Elasticsearch defaults are applied before services

### DIFF
--- a/server/config/environment.js
+++ b/server/config/environment.js
@@ -27,6 +27,11 @@ const ensureSearchConfiguration = () => {
   }
 };
 
+export const isElasticsearchEnabled = () => {
+  ensureSearchConfiguration();
+  return process.env.USE_ELASTICSEARCH === 'true';
+};
+
 export const getJwtSecret = () => {
   if (cachedSecret) {
     return cachedSecret;

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import SearchService from '../services/SearchService.js';
 import ElasticSearchService from '../services/ElasticSearchService.js';
+import { isElasticsearchEnabled } from '../config/environment.js';
 import { authenticate } from '../middleware/auth.js';
 import Blacklist from '../models/Blacklist.js';
 import UserLog from '../models/UserLog.js';
@@ -11,10 +12,8 @@ const router = express.Router();
 const searchService = new SearchService();
 let elasticService = null;
 
-const isElasticEnabled = () => process.env.USE_ELASTICSEARCH === 'true';
-
 const getElasticService = () => {
-  if (!isElasticEnabled()) {
+  if (!isElasticsearchEnabled()) {
     elasticService = null;
     return null;
   }

--- a/server/services/CdrService.js
+++ b/server/services/CdrService.js
@@ -7,8 +7,7 @@ import { parse as parseDate, format as formatDate } from 'date-fns';
 import chokidar from 'chokidar';
 import client from '../config/elasticsearch.js';
 import Case from '../models/Case.js';
-
-const ELASTICSEARCH_ENABLED = process.env.USE_ELASTICSEARCH === 'true';
+import { isElasticsearchEnabled } from '../config/environment.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -78,7 +77,7 @@ class CdrService {
     }
 
     this.indexName = CDR_INDEX;
-    this.elasticEnabled = ELASTICSEARCH_ENABLED;
+    this.elasticEnabled = isElasticsearchEnabled();
     this.baseDir = path.join(__dirname, '../../uploads/cdr');
     this.manualProcessing = new Set();
 

--- a/server/services/ProfileService.js
+++ b/server/services/ProfileService.js
@@ -9,6 +9,7 @@ import Division from '../models/Division.js';
 import User from '../models/User.js';
 import Notification from '../models/Notification.js';
 import ElasticSearchService from './ElasticSearchService.js';
+import { isElasticsearchEnabled } from '../config/environment.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,7 +23,7 @@ class ProfileService {
         fs.mkdirSync(dir, { recursive: true });
       }
     });
-    this.useElastic = process.env.USE_ELASTICSEARCH === 'true';
+    this.useElastic = isElasticsearchEnabled();
     this.elasticService = this.useElastic ? new ElasticSearchService() : null;
   }
 

--- a/server/services/SyncService.js
+++ b/server/services/SyncService.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import baseCatalog from '../config/tables-catalog.js';
 import ElasticSearchService from './ElasticSearchService.js';
+import { isElasticsearchEnabled } from '../config/environment.js';
 
 const DEFAULT_BATCH_SIZE = 500;
 
@@ -17,7 +18,7 @@ class SyncService {
     const __dirname = path.dirname(__filename);
     this.catalogPath = path.join(__dirname, '../config/tables-catalog.json');
     this.elasticService = new ElasticSearchService();
-    this.useElastic = process.env.USE_ELASTICSEARCH === 'true';
+    this.useElastic = isElasticsearchEnabled();
     this.defaultIndex = process.env.ELASTICSEARCH_DEFAULT_INDEX || 'global_search';
     this.resetIndices = new Set();
     this.catalog = this.loadCatalog();


### PR DESCRIPTION
## Summary
- expose a helper to initialize USE_ELASTICSEARCH defaults when consulted
- update search-related services and routes to rely on the helper instead of caching the environment at import time

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b410674883269ee76b0017174fb8