### PR TITLE
Fix sync primary key detection for tables without id (follow-up)

### DIFF
--- a/server/services/SyncService.js
+++ b/server/services/SyncService.js
@@ -155,8 +155,19 @@ class SyncService {
       elasticsearchIndex: baseSyncConfig.elasticsearchIndex || this.defaultIndex
     };
 
-    const primaryKey = await this.resolvePrimaryKey(tableName, tableConfig);
-    const qualifiedTableName = this.formatTableName(tableName);
+    let primaryKey;
+    let qualifiedTableName;
+
+    try {
+      primaryKey = await this.resolvePrimaryKey(tableName, tableConfig);
+      qualifiedTableName = this.formatTableName(tableName);
+    } catch (error) {
+      console.error(
+        `❌ Échec de la préparation de la synchronisation pour ${tableName}:`,
+        error.message || error
+      );
+      return;
+    }
 
     if (!this.useElastic) {
       console.warn(


### PR DESCRIPTION
## Summary
- add metadata caching helpers to determine the primary key for each table at runtime
- fall back to inspecting primary keys and column order when a table has no `id` column and log informative warnings
- ensure generated SQL statements quote database and table identifiers before executing sync queries
- guard primary-key resolution and table-name formatting inside `syncTable` so metadata errors are logged without aborting the sync run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38312f2fc8326b543fe332fbe3bf8