### PR TITLE
Fix SQL search LIKE patterns to restore substring matches

### DIFF
--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -365,7 +365,7 @@ class SearchService {
         // Terme obligatoire (doit être présent)
         for (const field of searchableFields) {
           termConditions.push(`${field} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       } else if (term.type === 'field') {
         // Recherche par champ spécifique
@@ -377,17 +377,17 @@ class SearchService {
         if (matchingFields.length > 0) {
           for (const field of matchingFields) {
             termConditions.push(`${field} LIKE ?`);
-            params.push(`${term.value}%`);
+            params.push(`%${term.value}%`);
           }
         } else if (config.searchable.includes(term.field)) {
           termConditions.push(`${term.field} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       } else if (term.type === 'normal') {
         // Recherche normale dans tous les champs
         for (const field of searchableFields) {
           termConditions.push(`${field} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       }
 
@@ -424,7 +424,7 @@ class SearchService {
       const excludeConditions = [];
       for (const field of searchableFields) {
         excludeConditions.push(`${field} NOT LIKE ?`);
-        params.push(`${term.value}%`);
+        params.push(`%${term.value}%`);
       }
       if (excludeConditions.length > 0) {
         sql += ` AND (${excludeConditions.join(' AND ')})`;


### PR DESCRIPTION
## Summary
- allow SQL search clauses to match substrings instead of only prefixes for required, field-specific, normal, and exclusion terms
- ensure exclusion filters also consider matches anywhere in the field value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38627d4d0832681ac5c0533372d45