### PR TITLE
Handle Elasticsearch verification rejections

### DIFF
--- a/server/services/ElasticSearchService.js
+++ b/server/services/ElasticSearchService.js
@@ -63,9 +63,19 @@ class ElasticSearchService {
       return;
     }
 
-    this.connectionCheckPromise = this.verifyConnection(context).finally(() => {
-      this.connectionCheckPromise = null;
-    });
+    this.connectionCheckPromise = this.verifyConnection(context)
+      .catch((error) => {
+        if (!this.isConnectionError(error)) {
+          console.error(
+            '❌ Erreur inattendue lors de la vérification Elasticsearch:',
+            error
+          );
+        }
+        throw error;
+      })
+      .finally(() => {
+        this.connectionCheckPromise = null;
+      });
   }
 
   async verifyConnection(context = 'healthcheck') {


### PR DESCRIPTION
## Summary
- add an error handler around scheduled Elasticsearch verification to avoid unhandled promise rejections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38be2e7088326bd42f9e0b076eba4