### PR TITLE
Ensure Elasticsearch service only reported operational after health check

### DIFF
--- a/server/services/ElasticSearchService.js
+++ b/server/services/ElasticSearchService.js
@@ -35,7 +35,7 @@ class ElasticSearchService {
   }
 
   isOperational() {
-    return this.enabled === true;
+    return this.enabled === true && this.connectionChecked === true;
   }
 
   isConnectionError(error) {


### PR DESCRIPTION
## Summary
- require a successful connection verification before reporting the Elasticsearch service as operational

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3905432708326a2a345284ca67354