### PR TITLE
Increase Elasticsearch healthcheck tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Pour résoudre le problème :
 
 - Vérifiez que l'URL définie par `ELASTICSEARCH_URL` pointe vers une instance Elasticsearch accessible (par défaut `http://localhost:9200`).
 - Assurez-vous que l'instance est démarrée et accepte les connexions (testez avec `curl $ELASTICSEARCH_URL`).
+- Par défaut, les vérifications de santé attendent jusqu'à 5 secondes (`ELASTICSEARCH_HEALTHCHECK_TIMEOUT_MS=5000`).
+  Augmentez cette valeur si votre cluster met plus de temps à répondre pendant son démarrage.
 - Si Elasticsearch est volontairement inactif, laissez `USE_ELASTICSEARCH=false` dans votre configuration pour éviter le message de bascule.
 
 Une fois la connexion rétablie, redémarrez le serveur Node.js pour réactiver automatiquement la recherche Elasticsearch.

--- a/server/services/ElasticSearchService.js
+++ b/server/services/ElasticSearchService.js
@@ -22,7 +22,7 @@ class ElasticSearchService {
     this.catalog = this.loadCatalog();
     this.indexes = this.enabled ? this.resolveIndexesFromCatalog(this.catalog) : [];
     const timeoutEnv = Number(process.env.ELASTICSEARCH_HEALTHCHECK_TIMEOUT_MS);
-    this.connectionTimeout = Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : 1000;
+    this.connectionTimeout = Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : 5000;
     this.connectionChecked = false;
     this.connectionCheckPromise = null;
     const retryEnv = Number(process.env.ELASTICSEARCH_RETRY_DELAY_MS);


### PR DESCRIPTION
## Summary
- increase the default Elasticsearch healthcheck timeout to 5 seconds to avoid premature connection errors
- document the new default and how to adjust it when diagnosing Elasticsearch availability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e392d8d5cc8326909c4c21b8838fda