### PR TITLE
Restore SyncService state after 'Fix unknown column' update

### DIFF
--- a/server/services/SyncService.js
+++ b/server/services/SyncService.js
@@ -155,19 +155,8 @@ class SyncService {
       elasticsearchIndex: baseSyncConfig.elasticsearchIndex || this.defaultIndex
     };
 
-    let primaryKey;
-    let qualifiedTableName;
-
-    try {
-      primaryKey = await this.resolvePrimaryKey(tableName, tableConfig);
-      qualifiedTableName = this.formatTableName(tableName);
-    } catch (error) {
-      console.error(
-        `❌ Échec de la préparation de la synchronisation pour ${tableName}:`,
-        error.message || error
-      );
-      return;
-    }
+    const primaryKey = await this.resolvePrimaryKey(tableName, tableConfig);
+    const qualifiedTableName = this.formatTableName(tableName);
 
     if (!this.useElastic) {
       console.warn(


### PR DESCRIPTION
## Summary
- revert the extra primary key resolution guard so SyncService matches the "Fix unknown column 'id' in order by clause" version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3949301688326ac337b187db9649c