### PR TITLE
Ensure dynamic catalog indexing across all data sources

### DIFF
--- a/server/services/SyncService.js
+++ b/server/services/SyncService.js
@@ -1,10 +1,7 @@
 import database from '../config/database.js';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import baseCatalog from '../config/tables-catalog.js';
 import ElasticSearchService from './ElasticSearchService.js';
 import { isElasticsearchEnabled } from '../config/environment.js';
+import { buildCatalog, catalogOverridesPath } from '../utils/catalog-loader.js';
 
 const DEFAULT_BATCH_SIZE = 500;
 
@@ -14,17 +11,50 @@ const DEFAULT_BATCH_SIZE = 500;
  */
 class SyncService {
   constructor() {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = path.dirname(__filename);
-    this.catalogPath = path.join(__dirname, '../config/tables-catalog.json');
+    this.catalogPath = catalogOverridesPath;
     this.elasticService = new ElasticSearchService();
     this.useElastic = isElasticsearchEnabled();
     this.defaultIndex = process.env.ELASTICSEARCH_DEFAULT_INDEX || 'global_search';
     this.resetIndices = new Set();
-    this.catalog = this.loadCatalog();
+    this.catalog = {};
+    this.catalogPromise = null;
     this.primaryKeyCache = new Map();
     this.tableColumnsCache = new Map();
     this.qualifiedTableNameCache = new Map();
+  }
+
+  loadCatalog() {
+    if (this.catalogPromise) {
+      return this.catalogPromise;
+    }
+
+    this.catalogPromise = buildCatalog()
+      .then((catalog) => {
+        this.catalog = catalog || {};
+        return this.catalog;
+      })
+      .catch((error) => {
+        console.error('❌ Erreur chargement du catalogue pour la synchronisation:', error);
+        if (!this.catalog || Object.keys(this.catalog).length === 0) {
+          this.catalog = {};
+        }
+        return this.catalog;
+      })
+      .finally(() => {
+        this.catalogPromise = null;
+      });
+
+    return this.catalogPromise;
+  }
+
+  async getCatalog() {
+    if (!this.catalog || Object.keys(this.catalog).length === 0) {
+      await this.loadCatalog();
+    } else if (this.catalogPromise) {
+      await this.catalogPromise;
+    }
+
+    return this.catalog;
   }
 
   formatTableName(tableName) {
@@ -100,27 +130,9 @@ class SyncService {
     return fallbackColumn;
   }
 
-  loadCatalog() {
-    let catalog = { ...baseCatalog };
-    try {
-      if (fs.existsSync(this.catalogPath)) {
-        const raw = fs.readFileSync(this.catalogPath, 'utf-8');
-        const json = JSON.parse(raw);
-        for (const [key, value] of Object.entries(json)) {
-          const [db, ...tableParts] = key.split('_');
-          const tableName = `${db}.${tableParts.join('_')}`;
-          catalog[tableName] = value;
-        }
-      }
-    } catch (error) {
-      console.error('❌ Erreur chargement catalogue:', error);
-    }
-    return catalog;
-  }
-
-  resolveBatchSize(syncConfig = {}) {
-    const envBatch = Number(process.env.SYNC_BATCH_SIZE);
-    if (Number.isFinite(envBatch) && envBatch > 0) {
+    resolveBatchSize(syncConfig = {}) {
+      const envBatch = Number(process.env.SYNC_BATCH_SIZE);
+      if (Number.isFinite(envBatch) && envBatch > 0) {
       return envBatch;
     }
 
@@ -133,7 +145,7 @@ class SyncService {
   }
 
   async syncTable(tableName, config = null) {
-    const catalog = config ? null : this.catalog || this.loadCatalog();
+    const catalog = config ? null : await this.getCatalog();
     const tableConfig = config || catalog?.[tableName];
     if (!tableConfig) {
       console.warn(`⚠️ Table ${tableName} absente du catalogue, synchronisation ignorée.`);
@@ -247,8 +259,8 @@ class SyncService {
   }
 
   async syncAllTables() {
-    this.catalog = this.loadCatalog();
-    for (const [tableName, config] of Object.entries(this.catalog)) {
+    const catalog = await this.getCatalog();
+    for (const [tableName, config] of Object.entries(catalog)) {
       await this.syncTable(tableName, config);
     }
   }


### PR DESCRIPTION
## Summary
- add a shared catalog loader that introspects MySQL schemas, merges overrides, and provides complete table metadata
- update search, sync, stats, and Elasticsearch services to consume the dynamic catalog with refreshed caching and watchers
- update the search index creation script to rely on the unified catalog so every table gets indexed

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e39997b23c8326830d8ab35823b9ff