### PR TITLE
Fix SQL identifier quoting in search and stats services

### DIFF
--- a/server/services/StatsService.js
+++ b/server/services/StatsService.js
@@ -1,6 +1,7 @@
 import database from '../config/database.js';
 import statsCache from './stats-cache.js';
 import { buildCatalog } from '../utils/catalog-loader.js';
+import { quoteIdentifier } from '../utils/sql.js';
 
 /**
  * Service de génération de statistiques basées sur les journaux de recherche
@@ -212,7 +213,8 @@ class StatsService {
     const results = await Promise.all(
       entries.map(async ([tableName, config]) => {
         try {
-          const result = await database.queryOne(`SELECT COUNT(*) as count FROM ${tableName}`);
+          const escapedTable = quoteIdentifier(tableName);
+          const result = await database.queryOne(`SELECT COUNT(*) as count FROM ${escapedTable}`);
           return [tableName, {
             total_records: result?.count || 0,
             table_name: config.display,

--- a/server/utils/sql.js
+++ b/server/utils/sql.js
@@ -1,0 +1,31 @@
+export function quoteIdentifier(identifier = '') {
+  if (!identifier) {
+    return '';
+  }
+
+  if (Array.isArray(identifier)) {
+    return identifier.map((value) => quoteIdentifier(value)).join(', ');
+  }
+
+  return identifier
+    .toString()
+    .split('.')
+    .map((part) => {
+      const trimmed = part.trim();
+      if (!trimmed) {
+        return '';
+      }
+      const withoutBackticks = trimmed.replace(/^`+|`+$/g, '');
+      const escaped = withoutBackticks.replace(/`/g, '``');
+      return `\`${escaped}\``;
+    })
+    .filter(Boolean)
+    .join('.');
+}
+
+export function quoteIdentifiers(identifiers = []) {
+  return identifiers
+    .map((identifier) => quoteIdentifier(identifier))
+    .filter((part) => part.length > 0)
+    .join(', ');
+}


### PR DESCRIPTION
## Summary
- add a SQL identifier quoting helper to safely address catalog tables and columns
- update stats and search services to use escaped identifiers when building dynamic queries

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68e3acdbdafc8326b07f59c96a80e3c1