### PR TITLE
Exclude platform tables from search catalog and fix sync primary keys

### DIFF
--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -503,6 +503,7 @@ export default {
   'autres.education': {
     display: 'education',
     database: 'autres',
+    primaryKey: 'cni',
     searchable: ['prenom', 'nom', 'datenaiss', 'lieunaiss', 'cni', 'corps', 'lib_service', 'lib_org_niv1', 'telephone'],
     preview: ['prenom', 'nom', 'cni', 'corps', 'telephone'],
     filters: {
@@ -568,6 +569,7 @@ export default {
   'autres.demdikk': {
     display: 'demdikk',
     database: 'autres',
+    primaryKey: 'Numero',
     searchable: ['Prenom', 'Nom', 'Numero', 'PassePort'],
     preview: ['Prenom', 'Nom', 'Numero', 'PassePort'],
     filters: {
@@ -609,6 +611,7 @@ export default {
   'autres.petrosen': {
     display: 'petrosen',
     database: 'autres',
+    primaryKey: 'telephone',
     searchable: ['nom', 'telephone', 'email', 'departement', 'titre', 'responsable'],
     linkedFields: ['telephone'],
     preview: ['nom', 'telephone', 'email', 'departement', 'titre'],

--- a/server/utils/catalog-loader.js
+++ b/server/utils/catalog-loader.js
@@ -21,7 +21,20 @@ const SYSTEM_DATABASES = new Set([
 ]);
 
 // Tables qui ne doivent jamais être indexées ou accessibles via la recherche
-const EXCLUDED_TABLES = new Set(['autres.search_logs']);
+const EXCLUDED_TABLES = new Set([
+  'autres.search_logs',
+  'autres.profiles',
+  'autres.profile_attachments',
+  'autres.profile_shares',
+  'autres.sanctions',
+  'autres.sde_clients',
+  'autres.tresor',
+  'autres.upload_history',
+  'autres.users',
+  'autres.user_logs',
+  'autres.user_sessions',
+  'autres.uvs'
+]);
 
 function collectConfiguredDatabases(catalog = {}) {
   const databases = new Set();


### PR DESCRIPTION
## Summary
- prevent platform-related tables from being indexed or exposed through search by adding them to the exclusion list
- specify primary keys for the demdikk, education, and petrosen tables so Elasticsearch sync reads every row

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b054a7408326bc8807da640131dd