### PR TITLE
Restore profiles catalog entry

### DIFF
--- a/server/utils/catalog-loader.js
+++ b/server/utils/catalog-loader.js
@@ -23,7 +23,6 @@ const SYSTEM_DATABASES = new Set([
 // Tables qui ne doivent jamais être indexées ou accessibles via la recherche
 const EXCLUDED_TABLES = new Set([
   'autres.search_logs',
-  'autres.profiles',
   'autres.profile_attachments',
   'autres.profile_shares',
   'autres.sanctions',


### PR DESCRIPTION
## Summary
- remove autres.profiles from the exclusion list so profiles stay in the search catalog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b2d1837c8326ae1b8e876b3d277a