### PR TITLE
Align ElasticSearch results with legacy catalog metadata

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -25,7 +25,9 @@ const FALLBACK_EXCLUDED_FIELDS = new Set([
   'database',
   'primary_keys',
   'score',
-  'previewEntries'
+  'previewEntries',
+  'linkedFields',
+  'theme'
 ]);
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {


### PR DESCRIPTION
## Summary
- ensure Elasticsearch documents include linked field metadata when indexed
- normalize Elasticsearch hits with catalog metadata so database/table labels match the legacy search
- hide internal metadata fields such as linked fields and theme from preview fallbacks on the client

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b3922cb88326bd752df8f1e0ff22