### PR TITLE
Include linked and theme metadata in ES source fields

### DIFF
--- a/server/services/ElasticSearchService.js
+++ b/server/services/ElasticSearchService.js
@@ -758,6 +758,8 @@ class ElasticSearchService {
           'primary_value',
           'primary_keys',
           'preview',
+          'linked_fields',
+          'theme',
           'search_tokens',
           'full_text',
           'raw_values'


### PR DESCRIPTION
## Summary
- request the linked_fields and theme properties from Elasticsearch so normalized hits include per-document overrides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b65e7a3c832691357b422845d244