### PR TITLE
feat: expand catalog datasets and upload sources

### DIFF
--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -540,6 +540,19 @@ export default {
     theme: 'telecom'
   },
 
+  'autres.sanctions': {
+    display: 'sanctions',
+    database: 'autres',
+    searchable: ['prenom', 'nom', 'cni', 'structure', 'motif', 'decision', 'date_sanction'],
+    preview: ['prenom', 'nom', 'cni', 'structure', 'decision'],
+    filters: {
+      structure: 'string',
+      decision: 'string',
+      date_sanction: 'date'
+    },
+    theme: 'pro'
+  },
+
   'autres.tresor': {
     display: 'tresor',
     database: 'autres',
@@ -606,6 +619,30 @@ export default {
       telephone: 'string'
     },
     theme: 'identite'
+  },
+
+  'autres.agents_penitentiare': {
+    display: 'agents_penitentiare',
+    database: 'autres',
+    searchable: [
+      'prenom',
+      'nom',
+      'cni',
+      'matricule',
+      'grade',
+      'fonction',
+      'corps',
+      'emploi',
+      'telephone'
+    ],
+    preview: ['prenom', 'nom', 'cni', 'grade', 'fonction'],
+    filters: {
+      grade: 'string',
+      fonction: 'string',
+      corps: 'string',
+      emploi: 'string'
+    },
+    theme: 'pro'
   },
 
   'autres.petrosen': {
@@ -700,6 +737,17 @@ export default {
     theme: 'identite'
   },
 
+  'autres.divisions': {
+    display: 'divisions',
+    database: 'autres',
+    searchable: ['name'],
+    preview: ['name', 'created_at'],
+    filters: {
+      created_at: 'date'
+    },
+    theme: 'interne'
+  },
+
   'autres.collections': {
     display: 'collections',
     database: 'autres',
@@ -724,5 +772,38 @@ export default {
     },
     linkedFields: ['phone'],
     theme: 'identite'
+  },
+
+  'autres.identification_requests': {
+    display: 'identification_requests',
+    database: 'autres',
+    searchable: ['phone', 'status', 'created_at', 'user_id'],
+    preview: ['phone', 'status', 'created_at'],
+    filters: {
+      status: 'enum',
+      created_at: 'date'
+    },
+    linkedFields: ['phone'],
+    theme: 'interne'
+  },
+
+  'autres.search_logs': {
+    display: 'search_logs',
+    database: 'autres',
+    searchable: [
+      'username',
+      'search_term',
+      'search_type',
+      'tables_searched',
+      'ip_address',
+      'user_agent'
+    ],
+    preview: ['username', 'search_term', 'search_type', 'results_count'],
+    filters: {
+      search_type: 'string',
+      search_date: 'date',
+      results_count: 'number'
+    },
+    theme: 'interne'
   }
 };

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -145,15 +145,41 @@ router.delete('/history/:id', authenticate, requireAdmin, async (req, res) => {
 // Obtenir la liste des bases disponibles
 router.get('/databases', authenticate, (req, res) => {
   const databases = [
-    { id: 'esolde.mytable', name: 'esolde - mytable', description: 'Données employés esolde' },
-    { id: 'rhpolice.personne_concours', name: 'rhpolice - personne_concours', description: 'Concours police nationale' },
+    { id: 'autres.affaire_etrangere', name: 'autres - affaire_etrangere', description: 'Agents des affaires étrangères' },
+    { id: 'autres.agents_collectes_ansd', name: 'autres - agents_collectes_ansd', description: 'Agents de collecte ANSD' },
+    { id: 'autres.agents_penitentiare', name: 'autres - agents_penitentiare', description: 'Agents de l’administration pénitentiaire' },
+    { id: 'autres.agent_non_fonctionnaire', name: 'autres - agent_non_fonctionnaire', description: 'Agents non fonctionnaires' },
+    { id: 'autres.alignement_janvier2024', name: 'autres - alignement_janvier2024', description: 'Alignement janvier 2024' },
+    { id: 'autres.annuaire_gendarmerie', name: 'autres - annuaire_gendarmerie', description: 'Annuaire des unités de gendarmerie' },
+    { id: 'autres.candidats_ansd', name: 'autres - candidats_ansd', description: 'Candidats ANSD' },
+    { id: 'autres.collectes1', name: 'autres - collectes1', description: 'Données collecte population' },
+    { id: 'autres.collections', name: 'autres - collections', description: 'Collectes diverses' },
+    { id: 'autres.comptable_local', name: 'autres - comptable_local', description: 'Comptables locaux' },
+    { id: 'autres.conseil_constitutionel', name: 'autres - conseil_constitutionel', description: 'Personnel du Conseil constitutionnel' },
+    { id: 'autres.demdikk', name: 'autres - demdikk', description: 'Personnel Dem Dikk' },
+    { id: 'autres.divisions', name: 'autres - divisions', description: 'Divisions administratives internes' },
+    { id: 'autres.education', name: 'autres - education', description: 'Agents du ministère de l’éducation' },
+    { id: 'autres.entreprises', name: 'autres - entreprises', description: 'Registre des entreprises' },
+    { id: 'autres.esolde_new', name: 'autres - esolde_new', description: 'Référentiel esolde (nouvelle version)' },
+    { id: 'autres.fichemilitaire', name: 'autres - fichemilitaire', description: 'Fiches militaires' },
+    { id: 'autres.fpublique', name: 'autres - fpublique', description: 'Fonction publique' },
+    { id: 'autres.identification_requests', name: 'autres - identification_requests', description: 'Demandes d’identification' },
+    { id: 'autres.identified_numbers', name: 'autres - identified_numbers', description: 'Numéros identifiés' },
+    { id: 'autres.ong', name: 'autres - ong', description: 'Organisations non gouvernementales' },
+    { id: 'autres.petrosen', name: 'autres - petrosen', description: 'Contacts Petrosen' },
+    { id: 'autres.sanctions', name: 'autres - sanctions', description: 'Sanctions administratives' },
+    { id: 'autres.sde_clients', name: 'autres - sde_clients', description: 'Clients SDE' },
+    { id: 'autres.search_logs', name: 'autres - search_logs', description: 'Journaux de recherche' },
+    { id: 'autres.tresor', name: 'autres - tresor', description: 'Personnel du Trésor' },
+    { id: 'autres.uvs', name: 'autres - uvs', description: 'Université virtuelle du Sénégal' },
+    { id: 'autres.Vehicules', name: 'autres - vehicules', description: 'Immatriculations véhicules' },
+    { id: 'esolde.mytable', name: 'esolde - mytable', description: 'Référentiel esolde historique' },
+    { id: 'elections.dakar', name: 'elections - dakar', description: 'Électeurs région de Dakar' },
+    { id: 'expresso.expresso', name: 'expresso - expresso', description: 'Données Expresso Money' },
+    { id: 'permis.tables', name: 'permis - tables', description: 'Permis de conduire' },
     { id: 'renseignement.agentfinance', name: 'renseignement - agentfinance', description: 'Agents finances publiques' },
     { id: 'rhgendarmerie.personne', name: 'rhgendarmerie - personne', description: 'Personnel gendarmerie' },
-    { id: 'permis.tables', name: 'permis - tables', description: 'Permis de conduire' },
-    { id: 'expresso.expresso', name: 'expresso - expresso', description: 'Données Expresso Money' },
-    { id: 'elections.dakar', name: 'elections - dakar', description: 'Électeurs région Dakar' },
-    { id: 'autres.Vehicules', name: 'autres - vehicules', description: 'Immatriculations véhicules' },
-    { id: 'autres.entreprises', name: 'autres - entreprises', description: 'Registre des entreprises' }
+    { id: 'rhpolice.personne_concours', name: 'rhpolice - personne_concours', description: 'Concours police nationale' }
   ];
 
   res.json({ databases });

--- a/server/utils/catalog-loader.js
+++ b/server/utils/catalog-loader.js
@@ -22,17 +22,12 @@ const SYSTEM_DATABASES = new Set([
 
 // Tables qui ne doivent jamais être indexées ou accessibles via la recherche
 const EXCLUDED_TABLES = new Set([
-  'autres.search_logs',
   'autres.profile_attachments',
   'autres.profile_shares',
-  'autres.sanctions',
-  'autres.sde_clients',
-  'autres.tresor',
   'autres.upload_history',
   'autres.users',
   'autres.user_logs',
-  'autres.user_sessions',
-  'autres.uvs'
+  'autres.user_sessions'
 ]);
 
 function collectConfiguredDatabases(catalog = {}) {


### PR DESCRIPTION
## Summary
- add catalog entries for additional Autres datasets including sanctions, identification requests, search logs, divisions and penitentiary agents
- allow these datasets to be indexed by updating the catalog exclusion list
- expose the complete list of importable datasets in the upload API

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b8871fb48326b74c6bd58d1a527d