### PR TITLE
Restrict search catalog to configured tables

### DIFF
--- a/server/utils/catalog-loader.js
+++ b/server/utils/catalog-loader.js
@@ -366,9 +366,20 @@ export async function buildCatalog() {
 
   const finalCatalog = {};
 
+  const baseTableKeys = new Set(
+    Object.keys(baseCatalog || {}).map((key) => normalizeKey(key))
+  );
+  const overrideTableKeys = new Set(
+    Object.keys(overrides || {}).map((key) => normalizeKey(key))
+  );
+  const allowedTableKeys = new Set([...baseTableKeys, ...overrideTableKeys]);
+
   for (const [key, value] of Object.entries(catalogWithOverrides)) {
     const normalizedKey = normalizeKey(key);
     if (EXCLUDED_TABLES.has(normalizedKey)) {
+      continue;
+    }
+    if (allowedTableKeys.size > 0 && !allowedTableKeys.has(normalizedKey)) {
       continue;
     }
     const fallback = dynamicCatalog[normalizedKey] || {};


### PR DESCRIPTION
## Summary
- restrict the dynamically built catalog to tables that exist in the static configuration or overrides so only intended databases are searched

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bd68c3288326a6a422790a450da6