### PR TITLE
Ensure Demdikk and Petrosen fields appear in search results

### DIFF
--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -584,7 +584,7 @@ export default {
     database: 'autres',
     primaryKey: 'Numero',
     searchable: ['Prenom', 'Nom', 'Numero', 'PassePort'],
-    preview: ['Prenom', 'Nom', 'Numero', 'PassePort'],
+    preview: ['ID', 'Prenom', 'Nom', 'Numero', 'PassePort'],
     filters: {
       Numero: 'string',
       PassePort: 'string'
@@ -651,7 +651,7 @@ export default {
     primaryKey: 'telephone',
     searchable: ['nom', 'telephone', 'email', 'departement', 'titre', 'responsable'],
     linkedFields: ['telephone'],
-    preview: ['nom', 'telephone', 'email', 'departement', 'titre'],
+    preview: ['nom', 'telephone', 'email', 'departement', 'titre', 'responsable'],
     filters: {
       departement: 'string',
       titre: 'string',


### PR DESCRIPTION
## Summary
- include the ID column in the Dem Dikk search preview so it shows up in results
- add the Responsable field to the Petrosen search preview to expose all requested data points

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c58cb8b08326a4c3f445d290652d