### PR TITLE
Align agents_penitentiare metadata with available columns

### DIFF
--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -627,20 +627,11 @@ export default {
     searchable: [
       'prenom',
       'nom',
-      'cni',
-      'matricule',
-      'grade',
-      'fonction',
-      'corps',
-      'emploi',
-      'telephone'
+      'corps'
     ],
-    preview: ['prenom', 'nom', 'cni', 'grade', 'fonction'],
+    preview: ['prenom', 'nom', 'corps'],
     filters: {
-      grade: 'string',
-      fonction: 'string',
-      corps: 'string',
-      emploi: 'string'
+      corps: 'string'
     },
     theme: 'pro'
   },


### PR DESCRIPTION
## Summary
- update the agents_penitentiare catalog entry to match the actual prenom, nom, corps columns
- restrict the available filters to the existing corps column

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3cfdfae348326b5aa6a77cad821a7