### PR TITLE
Handle alternate table names in search and stats

### DIFF
--- a/server/utils/table-names.js
+++ b/server/utils/table-names.js
@@ -1,0 +1,78 @@
+import { quoteIdentifier } from './sql.js';
+
+const sanitizeTableName = (tableName = '') => {
+  if (!tableName) {
+    return '';
+  }
+
+  return tableName
+    .toString()
+    .replace(/`/g, '')
+    .trim();
+};
+
+const addVariant = (set, value) => {
+  if (!value) {
+    return;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  if (!set.has(trimmed)) {
+    set.add(trimmed);
+  }
+};
+
+export const getTableNameCandidates = (tableName = '') => {
+  const sanitized = sanitizeTableName(tableName);
+  if (!sanitized) {
+    return [];
+  }
+
+  const candidates = new Set();
+  addVariant(candidates, sanitized);
+
+  const lowerCased = sanitized.toLowerCase();
+  if (lowerCased !== sanitized) {
+    addVariant(candidates, lowerCased);
+  }
+
+  if (sanitized.includes('.')) {
+    const [schema, ...tableParts] = sanitized.split('.');
+    const table = tableParts.join('.');
+    if (schema && table) {
+      const schemaLower = schema.toLowerCase();
+      const tableLower = table.toLowerCase();
+      addVariant(candidates, `${schema}.${table}`);
+      addVariant(candidates, `${schemaLower}.${tableLower}`);
+      addVariant(candidates, table);
+      addVariant(candidates, tableLower);
+
+      const underscoredTable = table.replace(/\./g, '_');
+      addVariant(candidates, `${schema}_${underscoredTable}`);
+      addVariant(candidates, `${schemaLower}_${underscoredTable.toLowerCase()}`);
+    }
+  } else if (sanitized.includes('_')) {
+    const [schema, ...tableParts] = sanitized.split('_');
+    if (schema && tableParts.length > 0) {
+      const table = tableParts.join('_');
+      const schemaLower = schema.toLowerCase();
+      const tableLower = table.toLowerCase();
+      addVariant(candidates, `${schema}.${table}`);
+      addVariant(candidates, `${schemaLower}.${tableLower}`);
+    }
+  }
+
+  return Array.from(candidates);
+};
+
+export const getEscapedTableNameCandidates = (tableName = '') => {
+  return getTableNameCandidates(tableName).map((name) => ({
+    raw: name,
+    escaped: quoteIdentifier(name)
+  }));
+};
+


### PR DESCRIPTION
## Summary
- add utilities to generate table name variants and quote them safely
- update the search service to resolve table identifiers before querying so records from the autres schema are reachable
- align statistics counting with the new resolver to keep totals in sync with searchable data

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d23047f88326aae91ed27ee8a7d5