### PR TITLE
Fix unified search coverage and add edu_sn dataset

### DIFF
--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -518,6 +518,65 @@ export default {
     theme: 'pro'
   },
 
+  'autres.edu_sn': {
+    display: 'edu_sn',
+    database: 'autres',
+    primaryKey: 'ID',
+    searchable: [
+      'ID',
+      'CNI',
+      'PRENOM',
+      'NOM',
+      'DATE_NAISSANCE',
+      'LIEU_NAISSANCE',
+      'controldoublon2',
+      'controldoublon',
+      'SEXE',
+      'EMAIL',
+      'EMAIL2',
+      'TELEPHONE1',
+      'TELEPHONE2',
+      'ADRESSE_RESIDENCE',
+      'DIPLOME_ACADEMIQUE',
+      'DISCIPLINE_DIPLOME_ACADEMIQUE',
+      'DIPLOME_PROFESSIONNEL',
+      'SPECIALITE_DIPLOME_PROFESSIONNEL',
+      'ORDRE_ENSEIGNEMENT_CHOISI',
+      'OPTIONSPECIALITE',
+      'EXPERIENCE_ENSEIGNEMENT',
+      'LIBELLE_DERNIER_POSTE',
+      'IA_DERNIER_POSTE',
+      'IEF_DERNIER_POSTE',
+      'IA_DEPOT',
+      'IEF_DEPOT',
+      'DATE_INSCRIPTION',
+      'EXPERIMENTE',
+      'AUTRE_DIPL_ACAD',
+      'etat_doublon'
+    ],
+    linkedFields: ['CNI', 'TELEPHONE1', 'TELEPHONE2', 'EMAIL', 'EMAIL2'],
+    preview: [
+      'PRENOM',
+      'NOM',
+      'CNI',
+      'TELEPHONE1',
+      'TELEPHONE2',
+      'EMAIL',
+      'ORDRE_ENSEIGNEMENT_CHOISI'
+    ],
+    filters: {
+      DATE_NAISSANCE: 'date',
+      DATE_INSCRIPTION: 'date',
+      SEXE: 'enum',
+      IA_DEPOT: 'string',
+      IEF_DEPOT: 'string',
+      ORDRE_ENSEIGNEMENT_CHOISI: 'string',
+      IA_DERNIER_POSTE: 'string',
+      IEF_DERNIER_POSTE: 'string'
+    },
+    theme: 'pro'
+  },
+
   'autres.esolde_new': {
     display: 'esolde_new',
     database: 'autres',

--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -530,7 +530,7 @@ class SearchService {
         // Terme obligatoire (doit être présent)
         for (const field of searchableFields) {
           termConditions.push(`${quoteIdentifier(field)} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       } else if (term.type === 'field') {
         // Recherche par champ spécifique
@@ -542,20 +542,20 @@ class SearchService {
         if (matchingFields.length > 0) {
           for (const field of matchingFields) {
             termConditions.push(`${quoteIdentifier(field)} LIKE ?`);
-            params.push(`${term.value}%`);
+            params.push(`%${term.value}%`);
           }
         } else {
           const directField = searchableFieldMap.get(term.field);
           if (directField) {
             termConditions.push(`${quoteIdentifier(directField)} LIKE ?`);
-            params.push(`${term.value}%`);
+            params.push(`%${term.value}%`);
           }
         }
       } else if (term.type === 'normal') {
         // Recherche normale dans tous les champs
         for (const field of searchableFields) {
           termConditions.push(`${quoteIdentifier(field)} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       }
 
@@ -592,7 +592,7 @@ class SearchService {
       const excludeConditions = [];
       for (const field of searchableFields) {
         excludeConditions.push(`${quoteIdentifier(field)} NOT LIKE ?`);
-        params.push(`${term.value}%`);
+        params.push(`%${term.value}%`);
       }
       if (excludeConditions.length > 0) {
         sql += ` AND (${excludeConditions.join(' AND ')})`;


### PR DESCRIPTION
## Summary
- allow unified search to use substring matching so all configured tables, including Petrosen, return results when the query is contained within fields
- register the `autres.edu_sn` catalog entry with its searchable columns, preview fields, and filters so the table is included in unified search

## Testing
- not run (npm install fails with 403 when fetching @elastic/elasticsearch)


------
https://chatgpt.com/codex/tasks/task_e_68e3df0eea5883269d39bb0943a03d48