### PR TITLE
Improve Elasticsearch resilience and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,16 @@ Pour résoudre le problème :
 
 - Vérifiez que l'URL définie par `ELASTICSEARCH_URL` pointe vers une instance Elasticsearch accessible (par défaut `http://localhost:9200`).
 - Assurez-vous que l'instance est démarrée et accepte les connexions (testez avec `curl $ELASTICSEARCH_URL`).
-- Par défaut, les vérifications de santé attendent jusqu'à 5 secondes (`ELASTICSEARCH_HEALTHCHECK_TIMEOUT_MS=5000`).
-  Augmentez cette valeur si votre cluster met plus de temps à répondre pendant son démarrage.
+- Par défaut, les vérifications de santé attendent jusqu'à 3 secondes (`ELASTICSEARCH_HEALTHCHECK_TIMEOUT_MS=3000`).
+  Ajustez cette valeur si votre cluster met plus de temps à répondre pendant son démarrage.
+- `ELASTICSEARCH_REQUEST_TIMEOUT_MS` (3 secondes par défaut) borne la durée d'une requête Elasticsearch côté client afin
+  de retomber rapidement sur le moteur SQL si le cluster ne répond pas.
+- `ELASTICSEARCH_SEARCH_TIMEOUT_MS` permet de spécifier un délai différent pour les requêtes de recherche (sinon la valeur
+  de `ELASTICSEARCH_REQUEST_TIMEOUT_MS` est utilisée).
+- `ELASTICSEARCH_ABORT_TIMEOUT_MS` ajoute une sécurité côté Node.js : si ce délai est dépassé la requête est explicitement
+  annulée pour rendre la main à l'API.
+- `ELASTICSEARCH_MAX_RETRIES` contrôle le nombre de tentatives supplémentaires côté client (`1` par défaut). Réduisez-le
+  à `0` si vous voulez basculer immédiatement sur le moteur SQL lors d'une indisponibilité.
 - Si Elasticsearch est volontairement inactif, laissez `USE_ELASTICSEARCH=false` dans votre configuration pour éviter le message de bascule.
 
 Une fois la connexion rétablie, redémarrez le serveur Node.js pour réactiver automatiquement la recherche Elasticsearch.

--- a/server/config/elasticsearch.js
+++ b/server/config/elasticsearch.js
@@ -1,7 +1,20 @@
 import { Client } from '@elastic/elasticsearch';
 
+const node = process.env.ELASTICSEARCH_URL || 'http://localhost:9200';
+
+const maxRetriesEnv = Number(process.env.ELASTICSEARCH_MAX_RETRIES);
+const requestTimeoutEnv = Number(process.env.ELASTICSEARCH_REQUEST_TIMEOUT_MS);
+
+const maxRetries = Number.isFinite(maxRetriesEnv) && maxRetriesEnv >= 0 ? maxRetriesEnv : 1;
+const requestTimeout =
+  Number.isFinite(requestTimeoutEnv) && requestTimeoutEnv > 0 ? requestTimeoutEnv : 3000;
+
 const client = new Client({
-  node: process.env.ELASTICSEARCH_URL || 'http://localhost:9200'
+  node,
+  maxRetries,
+  requestTimeout,
+  sniffOnStart: false,
+  name: 'sora-search-platform'
 });
 
 export default client;


### PR DESCRIPTION
## Summary
- configure the Elasticsearch client with bounded retries and request timeouts
- add request abort handling in the search service to fall back to SQL faster when Elasticsearch stalls
- document the new environment variables that control the timeout and retry behaviour

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in the project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cb5ae04883268b2029c2c003680a