### PR TITLE
Fix Elasticsearch abort options usage

### DIFF
--- a/server/services/ElasticSearchService.js
+++ b/server/services/ElasticSearchService.js
@@ -839,7 +839,10 @@ class ElasticSearchService {
           'full_text',
           'raw_values'
         ],
-        query: { bool: boolQuery },
+        query: { bool: boolQuery }
+      };
+
+      const transportOptions = {
         requestTimeout: this.searchRequestTimeout
       };
 
@@ -854,11 +857,11 @@ class ElasticSearchService {
         if (typeof abortTimer.unref === 'function') {
           abortTimer.unref();
         }
-        searchOptions.signal = controller.signal;
+        transportOptions.signal = controller.signal;
       }
 
       try {
-        const response = await client.search(searchOptions);
+        const response = await client.search(searchOptions, transportOptions);
         hits = response.hits;
         took = response.took;
       } finally {


### PR DESCRIPTION
## Summary
- pass search request timeout and abort signal via Elasticsearch transport options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ce8d85e48326a88d7a8399cf24c4