### PR TITLE
Normalize USE_ELASTICSEARCH env handling

### DIFF
--- a/server/config/environment.js
+++ b/server/config/environment.js
@@ -11,15 +11,50 @@ const sanitizeList = (value = '') =>
     .map(origin => origin.trim())
     .filter(Boolean);
 
+const truthyValues = new Set(['true', '1', 'yes', 'on']);
+const falsyValues = new Set(['false', '0', 'no', 'off']);
+
+const normalizeBooleanEnv = (value, defaultValue = true) => {
+  if (typeof value === 'undefined' || value === null) {
+    return defaultValue;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+
+  if (truthyValues.has(normalized)) {
+    return true;
+  }
+
+  if (falsyValues.has(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+};
+
 const ensureSearchConfiguration = () => {
-  if (typeof process.env.USE_ELASTICSEARCH === 'undefined') {
-    process.env.USE_ELASTICSEARCH = 'true';
+  const rawValue = process.env.USE_ELASTICSEARCH;
+  const useElastic = normalizeBooleanEnv(rawValue, true);
+
+  if (typeof rawValue === 'undefined') {
     console.warn(
       '⚠️ USE_ELASTICSEARCH non défini. Activation par défaut d\'Elasticsearch pour accélérer les recherches.'
     );
+  } else if (
+    rawValue &&
+    !truthyValues.has(rawValue.trim().toLowerCase()) &&
+    !falsyValues.has(rawValue.trim().toLowerCase())
+  ) {
+    console.warn(
+      `⚠️ Valeur USE_ELASTICSEARCH inconnue ("${rawValue}"). Utilisation de ${
+        useElastic ? 'true' : 'false'
+      } après normalisation.`
+    );
   }
 
-  if (process.env.USE_ELASTICSEARCH === 'true' && !process.env.ELASTICSEARCH_URL) {
+  process.env.USE_ELASTICSEARCH = useElastic ? 'true' : 'false';
+
+  if (useElastic && !process.env.ELASTICSEARCH_URL) {
     process.env.ELASTICSEARCH_URL = 'http://localhost:9200';
     console.warn(
       '⚠️ ELASTICSEARCH_URL non défini. Utilisation de http://localhost:9200 comme valeur par défaut.'


### PR DESCRIPTION
## Summary
- normalize boolean handling of USE_ELASTICSEARCH so truthy values such as TRUE/1 keep Elasticsearch enabled
- warn when an unknown value is provided and continue with the normalized fallback
- keep default URL bootstrap when Elasticsearch stays enabled

## Testing
- npm run lint *(fails: missing optional dependency eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cf1576d8832680c7538d169a4818