### PR TITLE
Refactor Elasticsearch-driven search page

### DIFF
--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -29,6 +29,115 @@ const getElasticService = () => {
   return elasticService;
 };
 
+const FOLLOWUP_FIELD_NAMES = [
+  'cni',
+  'nin',
+  'telephone',
+  'telephone1',
+  'telephone2',
+  'numero',
+  'phone'
+];
+
+const FOLLOWUP_FIELDS = new Set(
+  FOLLOWUP_FIELD_NAMES.flatMap((name) => [name, name.toUpperCase()]).map((name) => name.toLowerCase())
+);
+
+const MAX_FOLLOWUP_QUERIES = 5;
+const MIN_FOLLOWUP_LENGTH = 3;
+
+const normalizeFollowupValues = (value) => {
+  const normalized = new Set();
+  const visit = (candidate) => {
+    if (candidate === null || candidate === undefined) {
+      return;
+    }
+
+    if (Array.isArray(candidate)) {
+      candidate.forEach(visit);
+      return;
+    }
+
+    if (typeof candidate === 'object') {
+      return;
+    }
+
+    const text = String(candidate).trim();
+    if (text.length < MIN_FOLLOWUP_LENGTH) {
+      return;
+    }
+
+    normalized.add(text);
+
+    const digits = text.replace(/\D+/g, '');
+    if (digits.length >= 6) {
+      normalized.add(digits);
+    }
+  };
+
+  visit(value);
+  return Array.from(normalized);
+};
+
+const extractFollowupValuesFromHit = (hit) => {
+  const values = new Set();
+  const collect = (record) => {
+    if (!record || typeof record !== 'object') {
+      return;
+    }
+
+    Object.entries(record).forEach(([key, rawValue]) => {
+      if (!key) {
+        return;
+      }
+
+      if (!FOLLOWUP_FIELDS.has(key.toLowerCase())) {
+        return;
+      }
+
+      normalizeFollowupValues(rawValue).forEach((normalized) => {
+        values.add(normalized);
+      });
+    });
+  };
+
+  collect(hit?.record);
+  collect(hit?.preview);
+
+  return Array.from(values);
+};
+
+const buildHitIdentity = (hit) => {
+  if (!hit) {
+    return null;
+  }
+
+  const table = String(hit.table_name || hit.table || '').toLowerCase();
+  const keys = hit.primary_keys && typeof hit.primary_keys === 'object' ? hit.primary_keys : null;
+
+  if (keys) {
+    const sorted = Object.entries(keys)
+      .filter(([_, value]) => value !== undefined && value !== null)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${key}:${value}`)
+      .join('|');
+
+    if (sorted) {
+      return `${table}::${sorted}`;
+    }
+  }
+
+  if (hit.primary_key && hit.primary_value !== undefined && hit.primary_value !== null) {
+    return `${table}::${String(hit.primary_key).toLowerCase()}:${hit.primary_value}`;
+  }
+
+  if (hit.id !== undefined && hit.id !== null) {
+    return `${table}::id:${hit.id}`;
+  }
+
+  return `${table}::${JSON.stringify(hit.preview || hit.record || {})}`;
+};
+
 // Route de recherche principale
 router.post('/', authenticate, async (req, res) => {
   try {
@@ -83,45 +192,105 @@ router.post('/', authenticate, async (req, res) => {
       return res.status(400).json({ error: 'depth doit être >= 1' });
     }
 
-    let results;
     const elastic = getElasticService();
-    const canUseElastic = elastic?.isOperational?.() === true;
-    if (canUseElastic) {
-      const es = await elastic.search(
-        trimmed,
-        parseInt(page),
-        parseInt(limit)
-      );
-      if (elastic?.isOperational?.() === true) {
-        const tablesSearched =
-          Array.isArray(es.tables_searched) && es.tables_searched.length > 0
-            ? es.tables_searched
-            : ['profiles'];
-        results = {
-          total: es.total,
-          page: parseInt(page),
-          limit: parseInt(limit),
-          pages: Math.ceil(es.total / parseInt(limit)),
-          elapsed_ms: es.elapsed_ms,
-          hits: es.hits,
-          tables_searched: tablesSearched
-        };
-      }
+    if (!elastic || elastic.isOperational?.() !== true) {
+      return res.status(503).json({ error: 'Service de recherche indisponible (Elasticsearch).' });
     }
 
-    if (!results) {
-      results = await searchService.search(
-        trimmed,
-        filters,
-        parseInt(page),
-        parseInt(limit),
-        req.user,
-        search_type,
-        { followLinks, maxDepth: parseInt(depth) }
+    const es = await elastic.search(trimmed, parseInt(page), parseInt(limit));
+    const tablesSearched = new Set(
+      Array.isArray(es.tables_searched) && es.tables_searched.length > 0
+        ? es.tables_searched
+        : ['profiles']
+    );
+
+    const results = {
+      total: es.total,
+      page: parseInt(page),
+      limit: parseInt(limit),
+      pages: Math.ceil(es.total / parseInt(limit)),
+      elapsed_ms: es.elapsed_ms,
+      hits: es.hits,
+      tables_searched: Array.from(tablesSearched)
+    };
+
+    const originalHits = Array.isArray(results.hits) ? results.hits : [];
+    const followupCandidates = new Set();
+
+    const normalizedQueryValues = new Set(
+      normalizeFollowupValues(trimmed).map((value) => value.toLowerCase())
+    );
+
+    originalHits.forEach((hit) => {
+      extractFollowupValuesFromHit(hit).forEach((value) => {
+        if (!value || value.length < MIN_FOLLOWUP_LENGTH) {
+          return;
+        }
+        if (normalizedQueryValues.has(value.toLowerCase())) {
+          return;
+        }
+        followupCandidates.add(value);
+      });
+    });
+
+    const followupValues = Array.from(followupCandidates).slice(0, MAX_FOLLOWUP_QUERIES);
+    const existingIdentities = new Set(
+      originalHits.map((hit) => buildHitIdentity(hit)).filter(Boolean)
+    );
+    const relatedQueries = [];
+    const relatedHitsForAccess = [];
+
+    if (followupValues.length > 0) {
+      const followupResults = await Promise.all(
+        followupValues.map(async (value) => {
+          try {
+            const response = await elastic.search(value, 1, Math.max(parseInt(limit), 20));
+            return { value, response };
+          } catch (error) {
+            console.error('Erreur recherche associée:', error.message || error);
+            return { value, response: null };
+          }
+        })
       );
+
+      followupResults.forEach(({ value, response }) => {
+        if (!response || !Array.isArray(response.hits) || response.hits.length === 0) {
+          return;
+        }
+
+        if (Array.isArray(response.tables_searched)) {
+          response.tables_searched.forEach((table) => tablesSearched.add(table));
+        }
+
+        const filteredHits = response.hits.filter((hit) => {
+          const identity = buildHitIdentity(hit);
+          if (!identity) {
+            return true;
+          }
+          if (existingIdentities.has(identity)) {
+            return false;
+          }
+          existingIdentities.add(identity);
+          return true;
+        });
+
+        if (filteredHits.length === 0) {
+          return;
+        }
+
+        const annotatedHits = filteredHits.map((hit) => ({ ...hit, related_to: value }));
+        relatedHitsForAccess.push(...annotatedHits);
+        relatedQueries.push({ value, hits: annotatedHits });
+      });
     }
 
-    searchAccessManager.remember(req.user.id, results.hits || []);
+    if (relatedQueries.length > 0) {
+      results.related_queries = relatedQueries;
+    }
+
+    results.tables_searched = Array.from(tablesSearched);
+
+    searchAccessManager.remember(req.user.id, [...originalHits, ...relatedHitsForAccess]);
 
     const searchTypeValue = typeof search_type === 'string' && search_type ? search_type : 'global';
     const userAgent = req.get('user-agent') || null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,11 @@ interface SearchResult extends RawSearchResult {
   previewEntries: NormalizedPreviewEntry[];
 }
 
+interface RelatedSearchGroup<T> {
+  value: string;
+  hits: T[];
+}
+
 interface SearchResponse {
   total: number;
   page: number;
@@ -145,10 +150,12 @@ interface SearchResponse {
   elapsed_ms: number;
   hits: SearchResult[];
   tables_searched: string[];
+  related_queries?: RelatedSearchGroup<SearchResult>[];
 }
 
-type SearchResponseFromApi = Omit<SearchResponse, 'hits'> & {
+type SearchResponseFromApi = Omit<SearchResponse, 'hits' | 'related_queries'> & {
   hits: RawSearchResult[];
+  related_queries?: RelatedSearchGroup<RawSearchResult>[];
   error?: string;
 };
 
@@ -160,9 +167,22 @@ const mapPreviewEntries = (hits: RawSearchResult[] | undefined): SearchResult[] 
       }))
     : [];
 
+const mapRelatedQueries = (
+  related: RelatedSearchGroup<RawSearchResult>[] | undefined
+): RelatedSearchGroup<SearchResult>[] =>
+  Array.isArray(related)
+    ? related
+        .map((group) => ({
+          value: group.value,
+          hits: mapPreviewEntries(group.hits)
+        }))
+        .filter((group) => group.hits.length > 0)
+    : [];
+
 const normalizeSearchResponse = (data: SearchResponseFromApi): SearchResponse => ({
   ...data,
-  hits: mapPreviewEntries(data.hits)
+  hits: mapPreviewEntries(data.hits),
+  related_queries: mapRelatedQueries(data.related_queries)
 });
 
 const formatScore = (score?: number) => {
@@ -5303,6 +5323,7 @@ useEffect(() => {
                             const formattedScore = formatScore(result.score);
                             const tableLabel = result.table_name || result.table;
                             const databaseLabel = result.database || 'Elasticsearch';
+                            const relatedLabel = typeof result.related_to === 'string' ? result.related_to : null;
 
                             return (
                               <div
@@ -5326,6 +5347,11 @@ useEffect(() => {
                                       {databaseLabel && (
                                         <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-600 dark:bg-gray-700/70 dark:text-gray-300">
                                           {databaseLabel}
+                                        </span>
+                                      )}
+                                      {relatedLabel && (
+                                        <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 font-semibold text-amber-700 dark:bg-amber-900/60 dark:text-amber-200">
+                                          Lié à {relatedLabel}
                                         </span>
                                       )}
                                       {formattedScore && (
@@ -5463,6 +5489,45 @@ useEffect(() => {
                           <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                           Affichage progressif des résultats...
                         </button>
+                      </div>
+                    )}
+                    {Array.isArray(searchResults.related_queries) && searchResults.related_queries.length > 0 && (
+                      <div className="border-t border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/30">
+                        <div className="px-8 py-6">
+                          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                            Résultats liés automatiquement
+                          </h3>
+                          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                            Les identifiants détectés (CNI, NIN, téléphones, numéros, etc.) ont déclenché des recherches complémentaires.
+                          </p>
+                        </div>
+                        <div className="space-y-10 px-8 pb-8">
+                          {searchResults.related_queries.map((related, index) => (
+                            <div
+                              key={`${related.value}-${index}`}
+                              className="bg-white/80 dark:bg-gray-800/70 border border-gray-200 dark:border-gray-700 rounded-2xl p-6 shadow-md"
+                            >
+                              <div className="flex items-center justify-between mb-4">
+                                <div>
+                                  <h4 className="text-md font-semibold text-gray-900 dark:text-gray-100">
+                                    Recherche automatique : {related.value}
+                                  </h4>
+                                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                    Résultats supplémentaires trouvés à partir des données détectées.
+                                  </p>
+                                </div>
+                                <span className="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700 dark:bg-amber-900/60 dark:text-amber-200">
+                                  {related.hits.length} résultat(s)
+                                </span>
+                              </div>
+                              <SearchResultProfiles
+                                hits={related.hits}
+                                query={related.value}
+                                onCreateProfile={openCreateProfile}
+                              />
+                            </div>
+                          ))}
+                        </div>
                       </div>
                     )}
                 </div>

--- a/src/components/SearchResultProfiles.tsx
+++ b/src/components/SearchResultProfiles.tsx
@@ -36,6 +36,7 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
         const tableLabel = hit.table_name || hit.table;
         const databaseLabel = hit.database || 'Elasticsearch';
         const formattedScore = formatScore(hit.score);
+        const relatedLabel = typeof hit.related_to === 'string' ? hit.related_to : null;
 
         return (
           <div key={idx} className="bg-white shadow-lg rounded-2xl overflow-hidden">
@@ -53,6 +54,11 @@ const SearchResultProfiles: React.FC<ProfilesProps> = ({ hits, query, onCreatePr
                     {databaseLabel && (
                       <span className="inline-flex items-center rounded-full bg-blue-900/40 px-2 py-0.5 font-medium text-blue-50">
                         {databaseLabel}
+                      </span>
+                    )}
+                    {relatedLabel && (
+                      <span className="inline-flex items-center rounded-full bg-amber-500/30 px-2 py-0.5 font-semibold text-white">
+                        Lié à {relatedLabel}
                       </span>
                     )}
                     {formattedScore && (

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -4,6 +4,10 @@ export interface BaseSearchHit {
   database?: string;
   preview?: Record<string, unknown> | null;
   primary_keys?: Record<string, unknown> | null;
+  primary_key?: string | null;
+  primary_value?: unknown;
+  record?: Record<string, unknown> | null;
+  related_to?: string;
   score?: number;
   [key: string]: unknown;
 }
@@ -24,10 +28,15 @@ const FALLBACK_EXCLUDED_FIELDS = new Set([
   'table_name',
   'database',
   'primary_keys',
+  'primary_key',
+  'primary_value',
   'score',
   'previewEntries',
   'linkedFields',
-  'theme'
+  'theme',
+  'record',
+  'raw_values',
+  'related_to'
 ]);
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
@@ -108,24 +117,79 @@ export const normalizePreview = (hit: BaseSearchHit): NormalizedPreviewEntry[] =
     seenKeys.add(normalizedKey);
   };
 
-  const source: Record<string, unknown> = {};
+  const record = isRecord(hit.record) ? (hit.record as Record<string, unknown>) : null;
+
+  if (record) {
+    Object.entries(record).forEach(([key, value]) => {
+      if (key.toLowerCase() === 'id') {
+        return;
+      }
+      pushEntry(key, value);
+    });
+  }
+
   if (isRecord(hit.preview)) {
-    Object.assign(source, hit.preview as Record<string, unknown>);
-  } else {
+    Object.entries(hit.preview as Record<string, unknown>).forEach(([key, value]) => {
+      if (key.toLowerCase() === 'id') {
+        return;
+      }
+      pushEntry(key, value);
+    });
+  }
+
+  if (!record && !isRecord(hit.preview)) {
     Object.entries(hit).forEach(([key, value]) => {
       if (FALLBACK_EXCLUDED_FIELDS.has(key)) {
         return;
       }
-      source[key] = value;
+
+      if (key.toLowerCase() === 'id') {
+        return;
+      }
+
+      if (key === 'data') {
+        let parsed: unknown = value;
+        if (typeof parsed === 'string') {
+          try {
+            parsed = JSON.parse(parsed);
+          } catch {
+            // Keep raw string value on parse error
+          }
+        }
+
+        if (isRecord(parsed)) {
+          Object.entries(parsed).forEach(([nestedKey, nestedValue]) => {
+            pushEntry(nestedKey, nestedValue);
+          });
+          return;
+        }
+
+        if (Array.isArray(parsed)) {
+          pushEntry(key, parsed.map((item) => (isRecord(item) ? JSON.stringify(item) : item)));
+          return;
+        }
+
+        pushEntry(key, parsed);
+        return;
+      }
+
+      pushEntry(key, value);
     });
   }
 
-  Object.entries(source).forEach(([key, value]) => {
-    if (key === 'data') {
-      let parsed: unknown = value;
-      if (typeof parsed === 'string') {
-        try {
-          parsed = JSON.parse(parsed);
+  if (record || isRecord(hit.preview)) {
+    Object.entries(hit).forEach(([key, value]) => {
+      if (FALLBACK_EXCLUDED_FIELDS.has(key)) {
+        return;
+      }
+      if (key.toLowerCase() === 'id') {
+        return;
+      }
+      if (key === 'data') {
+        let parsed: unknown = value;
+        if (typeof parsed === 'string') {
+          try {
+            parsed = JSON.parse(parsed);
         } catch {
           // Ignore parse errors and use raw string value
         }


### PR DESCRIPTION
## Summary
- enforce Elasticsearch as the sole search backend, trigger automatic follow-up queries on key identifiers, and attach related result groups
- persist full record payloads in Elasticsearch documents so every field (except IDs) can be rendered directly from search results
- refresh the search UI to render all fields per hit, highlight related values, and surface grouped automatic results for detected identifiers

## Testing
- npm run build *(fails: Vite binary unavailable before installing dependencies)*
- npm install *(fails: registry blocks @elastic/elasticsearch download in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d470bf748326bb9668fed547ad44