### PR TITLE
Fix search preview normalization braces

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -190,29 +190,33 @@ export const normalizePreview = (hit: BaseSearchHit): NormalizedPreviewEntry[] =
         if (typeof parsed === 'string') {
           try {
             parsed = JSON.parse(parsed);
-        } catch {
-          // Ignore parse errors and use raw string value
+          } catch {
+            // Ignore parse errors and use raw string value
+          }
         }
-      }
 
-      if (isRecord(parsed)) {
-        Object.entries(parsed).forEach(([nestedKey, nestedValue]) => {
-          pushEntry(nestedKey, nestedValue);
-        });
+        if (isRecord(parsed)) {
+          Object.entries(parsed).forEach(([nestedKey, nestedValue]) => {
+            pushEntry(nestedKey, nestedValue);
+          });
+          return;
+        }
+
+        if (Array.isArray(parsed)) {
+          pushEntry(
+            key,
+            parsed.map((item) => (isRecord(item) ? JSON.stringify(item) : item))
+          );
+          return;
+        }
+
+        pushEntry(key, parsed);
         return;
       }
 
-      if (Array.isArray(parsed)) {
-        pushEntry(key, parsed.map((item) => (isRecord(item) ? JSON.stringify(item) : item)));
-        return;
-      }
-
-      pushEntry(key, parsed);
-      return;
-    }
-
-    pushEntry(key, value);
-  });
+      pushEntry(key, value);
+    });
+  }
 
   return entries;
 };


### PR DESCRIPTION
## Summary
- fix the data parsing branch in `normalizePreview` so the braces close correctly
- ensure parsed data gets normalized before falling back to pushEntry

## Testing
- npm install *(fails: 403 Forbidden when fetching @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d824c4e4832688499399b3ee48f2