### PR TITLE
Restore boolean normalization for USE_ELASTICSEARCH flag

### DIFF
--- a/server/config/environment.js
+++ b/server/config/environment.js
@@ -5,6 +5,25 @@ const DEFAULT_DEV_ORIGINS = ['http://localhost:5173'];
 let cachedSecret;
 let cachedPayloadEncryptionKey;
 
+const normalizeBooleanEnv = value => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(normalized)) {
+      return true;
+    }
+
+    if (['0', 'false', 'no', 'n', 'off'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return undefined;
+};
+
 const sanitizeList = (value = '') =>
   value
     .split(',')
@@ -12,11 +31,15 @@ const sanitizeList = (value = '') =>
     .filter(Boolean);
 
 const ensureSearchConfiguration = () => {
-  if (typeof process.env.USE_ELASTICSEARCH === 'undefined') {
+  const normalizedFlag = normalizeBooleanEnv(process.env.USE_ELASTICSEARCH);
+
+  if (typeof normalizedFlag === 'undefined') {
     process.env.USE_ELASTICSEARCH = 'true';
     console.warn(
       '⚠️ USE_ELASTICSEARCH non défini. Activation par défaut d\'Elasticsearch pour accélérer les recherches.'
     );
+  } else {
+    process.env.USE_ELASTICSEARCH = normalizedFlag ? 'true' : 'false';
   }
 
   if (process.env.USE_ELASTICSEARCH === 'true' && !process.env.ELASTICSEARCH_URL) {


### PR DESCRIPTION
## Summary
- add a helper to normalize USE_ELASTICSEARCH environment values
- ensure ensureSearchConfiguration reuses normalized values so common truthy strings stay enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4df163fec8326863e3fa13e5416b9