### PR TITLE
Add auto-discovery for autres.edu_sn search integration

### DIFF
--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -514,6 +514,23 @@ export default {
     theme: 'pro'
   },
 
+  'autres.edu_sn': {
+    display: 'edu_sn',
+    database: 'autres',
+    autoDiscover: {
+      search: ['prenom', 'nom', 'nin', 'cni', 'telephone', 'email', 'fonction'],
+      preview: ['prenom', 'nom', 'cni', 'telephone'],
+      linked: ['cni', 'telephone'],
+      filters: {
+        cni: 'string',
+        nin: 'string',
+        telephone: 'string',
+        fonction: 'string'
+      }
+    },
+    theme: 'pro'
+  },
+
   'autres.esolde_new': {
     display: 'esolde_new',
     database: 'autres',


### PR DESCRIPTION
## Summary
- add automatic field discovery in the search service so catalog entries can infer searchable, preview and linked fields when needed
- register the autres.edu_sn table in the catalog with auto-discovery hints so CNI and phone matches trigger follow-up searches

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e5cde8248326b3a7956cd23fdba0