### PR TITLE
Add autres education datasets to search catalog

### DIFF
--- a/server/config/tables-catalog.js
+++ b/server/config/tables-catalog.js
@@ -408,6 +408,7 @@ export default {
     display: 'affaire_etrangere',
     database: 'autres',
     searchable: ['prenom', 'nom', 'cni', 'corps', 'emploi', 'lib_service', 'lib_org_nv1'],
+    linkedFields: ['cni'],
     preview: ['prenom', 'nom', 'cni', 'corps', 'emploi'],
     filters: {
       corps: 'string',
@@ -421,12 +422,45 @@ export default {
     display: 'agent_non_fonctionnaire',
     database: 'autres',
     searchable: ['prenom', 'nom', 'datenaiss', 'cni', 'sexe', 'corps', 'emploi', 'lib_service', 'lib_org_niv1'],
+    linkedFields: ['cni'],
     preview: ['prenom', 'nom', 'cni', 'corps', 'emploi'],
     filters: {
       sexe: 'enum',
       corps: 'string',
       emploi: 'string',
       datenaiss: 'date'
+    },
+    theme: 'pro'
+  },
+
+  'autres.edu_sn': {
+    display: 'edu_sn',
+    database: 'autres',
+    searchable: [
+      'PRENOM',
+      'NOM',
+      'CNI',
+      'TELEPHONE1',
+      'TELEPHONE2',
+      'EMAIL',
+      'EMAIL2',
+      'ADRESSE_RESIDENCE',
+      'DIPLOME_ACADEMIQUE',
+      'DISCIPLINE_DIPLOME_ACADEMIQUE',
+      'DIPLOME_PROFESSIONNEL',
+      'SPECIALITE_DIPLOME_PROFESSIONNEL',
+      'LIBELLE_DERNIER_POSTE',
+      'IA_DEPOT',
+      'IEF_DEPOT'
+    ],
+    linkedFields: ['CNI', 'TELEPHONE1', 'TELEPHONE2'],
+    preview: ['PRENOM', 'NOM', 'CNI', 'TELEPHONE1', 'EMAIL'],
+    filters: {
+      SEXE: 'enum',
+      DATE_NAISSANCE: 'date',
+      IA_DEPOT: 'string',
+      IEF_DEPOT: 'string',
+      ORDRE_ENSEIGNEMENT_CHOISI: 'string'
     },
     theme: 'pro'
   },
@@ -504,6 +538,7 @@ export default {
     display: 'education',
     database: 'autres',
     searchable: ['prenom', 'nom', 'datenaiss', 'lieunaiss', 'cni', 'corps', 'lib_service', 'lib_org_niv1', 'telephone'],
+    linkedFields: ['cni', 'telephone'],
     preview: ['prenom', 'nom', 'cni', 'corps', 'telephone'],
     filters: {
       corps: 'string',
@@ -701,14 +736,15 @@ export default {
     display: 'collections',
     database: 'autres',
     searchable: ['Nom', 'Prenom', 'DateNaissance', 'CNI', 'Telephone', 'Localite'],
-    preview: ['Nom', 'Prenom', 'Telephone', 'Localite'],
+    linkedFields: ['CNI', 'Telephone'],
+    preview: ['Nom', 'Prenom', 'CNI', 'Telephone', 'Localite'],
     filters: {
       DateNaissance: 'date',
       CNI: 'string',
       Telephone: 'string',
       Localite: 'string'
     },
-    theme: 'identite',
+    theme: 'identite'
   },
 
   'autres.identified_numbers': {


### PR DESCRIPTION
## Summary
- add configuration for the autres.edu_sn table so it participates in global search
- mark CNI and telephone fields as linked in autres tables to trigger chained lookups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e7ec5810832694fa96acc6a9aeda