### PR TITLE
Increase upload limit to 200MB

### DIFF
--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -30,7 +30,7 @@ const storage = multer.diskStorage({
 const upload = multer({
   storage: storage,
   limits: {
-    fileSize: 50 * 1024 * 1024 // 50MB
+    fileSize: 200 * 1024 * 1024 // 200MB
   },
   fileFilter: (req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();


### PR DESCRIPTION
## Summary
- increase the multer file size limit for CSV uploads to 200MB

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f1db65808326bcd1d60f20370d73