### PR TITLE
Allow repeating unified search queries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2003,15 +2003,6 @@ const App: React.FC = () => {
     const requestedPage = 1;
     const requestedLimit = 20;
 
-    if (
-      lastQueryRef.current &&
-      lastQueryRef.current.query === trimmedQuery &&
-      lastQueryRef.current.page === requestedPage &&
-      lastQueryRef.current.limit === requestedLimit
-    ) {
-      return;
-    }
-
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }


### PR DESCRIPTION
## Summary
- remove the guard that prevented running a unified search twice with the same parameters
- ensure the result list refreshes so freshly ingested records appear immediately at the top

## Testing
- npm install *(fails: 403 Forbidden while downloading @elastic/elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68e52abfe8188326b15474ade52b2d47