### PR TITLE
Afficher tous les champs des résultats sauf l'identifiant

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -28,7 +28,7 @@ const FALLBACK_EXCLUDED_FIELDS = new Set([
   'previewEntries'
 ]);
 
-const EXCLUDED_RESULT_FIELDS = new Set(['id', 'id1']);
+const EXCLUDED_RESULT_FIELDS = new Set(['id']);
 
 const shouldExcludeField = (key: string): boolean => {
   const normalizedKey = key.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- limite l'exclusion des champs des résultats de recherche au seul identifiant `id`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e626b6e2c88326ae82bdc2be8f8a8d