### PR TITLE
Expand linked search field detection

### DIFF
--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -184,20 +184,39 @@ class SearchService {
       }
     }
 
-    // Recherche supplémentaire pour les valeurs CNI, TET ou téléphone trouvées
+    // Recherche supplémentaire pour les valeurs d'identifiants (CNI, NIN, téléphones, etc.) trouvées
     if (depth === 0) {
       const extraValues = new Set();
       const phoneRegex = /^tel(ephone)?\d*$/i;
       const queryNormalized = String(query).trim().toLowerCase();
+      const extraFieldNames = new Set([
+        'CNI',
+        'Numero',
+        'numero',
+        'nin',
+        'NIN',
+        'Telephone1',
+        'Telephone2',
+        'TELEPHONE1',
+        'TELEPHONE2',
+        'Phone',
+        'PHONE',
+        '=',
+        'PHONE '
+      ]);
       for (const res of results) {
         const preview = res.preview || {};
         for (const [key, value] of Object.entries(preview)) {
           const keyLower = key.toLowerCase();
           const valueStr = String(value).trim();
+          const matchesConfiguredFields =
+            extraFieldNames.has(key) ||
+            keyLower === 'cni' ||
+            keyLower === 'tet' ||
+            phoneRegex.test(keyLower);
+
           if (
-            (keyLower === 'cni' ||
-              keyLower === 'tet' ||
-              phoneRegex.test(keyLower)) &&
+            matchesConfiguredFields &&
             valueStr &&
             valueStr.toLowerCase() !== queryNormalized
           ) {


### PR DESCRIPTION
## Summary
- trigger secondary searches when identifier fields such as Numero, NIN, and various phone columns are encountered in search previews
- keep the existing CNI/TET/telephone detection while adding support for the enumerated case-sensitive field names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e62bd4836c8326aa3c2e19074db3c0