### PR TITLE
Fix SQL search pattern matching for relational tables

### DIFF
--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -379,7 +379,7 @@ class SearchService {
         // Terme obligatoire (doit être présent)
         for (const field of searchableFields) {
           termConditions.push(`${field} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       } else if (term.type === 'field') {
         // Recherche par champ spécifique
@@ -391,17 +391,17 @@ class SearchService {
         if (matchingFields.length > 0) {
           for (const field of matchingFields) {
             termConditions.push(`${field} LIKE ?`);
-            params.push(`${term.value}%`);
+            params.push(`%${term.value}%`);
           }
         } else if (config.searchable.includes(term.field)) {
           termConditions.push(`${term.field} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       } else if (term.type === 'normal') {
         // Recherche normale dans tous les champs
         for (const field of searchableFields) {
           termConditions.push(`${field} LIKE ?`);
-          params.push(`${term.value}%`);
+          params.push(`%${term.value}%`);
         }
       }
 
@@ -438,7 +438,7 @@ class SearchService {
       const excludeConditions = [];
       for (const field of searchableFields) {
         excludeConditions.push(`${field} NOT LIKE ?`);
-        params.push(`${term.value}%`);
+        params.push(`%${term.value}%`);
       }
       if (excludeConditions.length > 0) {
         sql += ` AND (${excludeConditions.join(' AND ')})`;


### PR DESCRIPTION
## Summary
- update the SQL search query builder to use substring matching across all searchable fields
- align exclusion filters with the new pattern matching so results from every database, including `autres`, surface correctly

## Testing
- npm run lint *(fails: missing eslint-plugin-react-hooks package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e63659fc288326b95486a9487232df