### PR TITLE
Revert "Allow substring matching in SQL search queries"

### DIFF
--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -379,7 +379,7 @@ class SearchService {
         // Terme obligatoire (doit être présent)
         for (const field of searchableFields) {
           termConditions.push(`${field} LIKE ?`);
-          params.push(`%${term.value}%`);
+          params.push(`${term.value}%`);
         }
       } else if (term.type === 'field') {
         // Recherche par champ spécifique
@@ -391,17 +391,17 @@ class SearchService {
         if (matchingFields.length > 0) {
           for (const field of matchingFields) {
             termConditions.push(`${field} LIKE ?`);
-            params.push(`%${term.value}%`);
+            params.push(`${term.value}%`);
           }
         } else if (config.searchable.includes(term.field)) {
           termConditions.push(`${term.field} LIKE ?`);
-          params.push(`%${term.value}%`);
+          params.push(`${term.value}%`);
         }
       } else if (term.type === 'normal') {
         // Recherche normale dans tous les champs
         for (const field of searchableFields) {
           termConditions.push(`${field} LIKE ?`);
-          params.push(`%${term.value}%`);
+          params.push(`${term.value}%`);
         }
       }
 
@@ -438,7 +438,7 @@ class SearchService {
       const excludeConditions = [];
       for (const field of searchableFields) {
         excludeConditions.push(`${field} NOT LIKE ?`);
-        params.push(`%${term.value}%`);
+        params.push(`${term.value}%`);
       }
       if (excludeConditions.length > 0) {
         sql += ` AND (${excludeConditions.join(' AND ')})`;


### PR DESCRIPTION
## Summary
- revert the substring matching change in the SQL search service so searches use prefix matching again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6392d2214832683e1ef9d3e44e86e