### PR TITLE
Optimize SQL search fallback for table queries

### DIFF
--- a/server/services/SearchService.js
+++ b/server/services/SearchService.js
@@ -333,7 +333,7 @@ class SearchService {
   async searchInTable(tableName, config, searchTerms, filters) {
     const results = [];
     const primaryKey = await this.getPrimaryKey(tableName, config);
-    
+
     // Vérifier si la table existe
     try {
       await database.query(`SELECT 1 FROM ${tableName} LIMIT 1`);
@@ -342,23 +342,105 @@ class SearchService {
       return results;
     }
 
-    const selectFields = '*';
     const searchableFields = config.searchable || [];
 
     if (searchableFields.length === 0) {
       return results;
     }
 
-    let sql = `SELECT ${selectFields} FROM ${tableName} WHERE `;
+    const perTableLimit = 50;
+    const fetchedRows = new Map();
+    const shouldRunContains = this.shouldRunContainsSearch(searchTerms);
+    const matchModes = shouldRunContains ? ['prefix', 'contains'] : ['prefix'];
+
+    for (const mode of matchModes) {
+      const remaining = perTableLimit - fetchedRows.size;
+      if (remaining <= 0) {
+        break;
+      }
+
+      const queryDefinition = this.buildSearchQuery(
+        tableName,
+        searchableFields,
+        searchTerms,
+        mode,
+        remaining
+      );
+
+      if (!queryDefinition) {
+        continue;
+      }
+
+      try {
+        const rows = await database.query(queryDefinition.sql, queryDefinition.params);
+        for (const row of rows) {
+          const pkValue = row[primaryKey];
+          if (pkValue === undefined || pkValue === null) {
+            continue;
+          }
+          const key = String(pkValue);
+          if (!fetchedRows.has(key)) {
+            fetchedRows.set(key, row);
+          }
+        }
+      } catch (error) {
+        console.error(`❌ Erreur SQL table ${tableName}:`, error.message);
+      }
+
+      if (mode === 'prefix' && fetchedRows.size >= perTableLimit) {
+        break;
+      }
+    }
+
+    for (const row of fetchedRows.values()) {
+      const preview = this.buildPreview(row);
+      results.push({
+        table: config.display,
+        database: config.database,
+        preview: preview,
+        primary_keys: { [primaryKey]: row[primaryKey] },
+        score: this.calculateRelevanceScore(row, searchTerms, searchableFields),
+        linkedFields: config.linkedFields || []
+      });
+    }
+
+    return results;
+  }
+
+  shouldRunContainsSearch(searchTerms) {
+    return searchTerms.some(term =>
+      term && ['normal', 'required', 'field'].includes(term.type)
+    );
+  }
+
+  buildSearchQuery(tableName, searchableFields, searchTerms, matchMode, limit) {
+    const whereClause = this.buildWhereClause(searchTerms, searchableFields, matchMode);
+
+    if (!whereClause) {
+      return null;
+    }
+
+    const limitValue = Math.max(1, limit || 1);
+    const sql = `SELECT * FROM ${tableName} WHERE ${whereClause.conditions} LIMIT ${limitValue}`;
+
+    return {
+      sql,
+      params: whereClause.params
+    };
+  }
+
+  buildWhereClause(searchTerms, searchableFields, matchMode) {
     const params = [];
-    let conditions = [];
+    const conditions = [];
     let currentGroup = [];
-    let operator = 'AND'; // Opérateur par défaut
+    let operator = 'AND';
 
     for (const term of searchTerms) {
-      if (term.type === 'exclude') continue; // Traité séparément
+      if (term.type === 'exclude') {
+        continue;
+      }
+
       if (term.type === 'operator') {
-        // Changer l'opérateur pour les prochains termes
         if (currentGroup.length > 0) {
           conditions.push(`(${currentGroup.join(' OR ')})`);
           currentGroup = [];
@@ -367,56 +449,24 @@ class SearchService {
         continue;
       }
 
-      const termConditions = [];
+      const termConditions = this.buildTermConditions(
+        term,
+        searchableFields,
+        matchMode,
+        params
+      );
 
-      if (term.type === 'exact') {
-        // Recherche exacte
-        for (const field of searchableFields) {
-          termConditions.push(`${field} = ?`);
-          params.push(term.value);
-        }
-      } else if (term.type === 'required') {
-        // Terme obligatoire (doit être présent)
-        for (const field of searchableFields) {
-          termConditions.push(`${field} LIKE ?`);
-          params.push(`${term.value}%`);
-        }
-      } else if (term.type === 'field') {
-        // Recherche par champ spécifique
-        const matchingFields = searchableFields.filter(field =>
-          field.toLowerCase().includes(term.field) ||
-          term.field.includes(field.toLowerCase())
-        );
-
-        if (matchingFields.length > 0) {
-          for (const field of matchingFields) {
-            termConditions.push(`${field} LIKE ?`);
-            params.push(`${term.value}%`);
-          }
-        } else if (config.searchable.includes(term.field)) {
-          termConditions.push(`${term.field} LIKE ?`);
-          params.push(`${term.value}%`);
-        }
-      } else if (term.type === 'normal') {
-        // Recherche normale dans tous les champs
-        for (const field of searchableFields) {
-          termConditions.push(`${field} LIKE ?`);
-          params.push(`${term.value}%`);
-        }
+      if (termConditions.length === 0) {
+        continue;
       }
 
-      if (termConditions.length > 0) {
-        if (term.type === 'required') {
-          // Les termes obligatoires sont ajoutés directement
-          conditions.push(`(${termConditions.join(' OR ')})`);
-        } else {
-          // Les autres termes sont groupés selon l'opérateur
-          currentGroup.push(`(${termConditions.join(' OR ')})`);
-        }
+      if (term.type === 'required') {
+        conditions.push(`(${termConditions.join(' OR ')})`);
+      } else {
+        currentGroup.push(`(${termConditions.join(' OR ')})`);
       }
     }
-    
-    // Ajouter le dernier groupe
+
     if (currentGroup.length > 0) {
       if (operator === 'OR') {
         conditions.push(`(${currentGroup.join(' OR ')})`);
@@ -426,46 +476,94 @@ class SearchService {
     }
 
     if (conditions.length === 0) {
-      return results;
+      return null;
     }
 
-    // Joindre les conditions avec AND par défaut
-    sql += conditions.join(' AND ');
+    const excludeTerms = searchTerms.filter(term => term.type === 'exclude');
+    const excludeClauses = [];
 
-    // Gestion des exclusions
-    const excludeTerms = searchTerms.filter(t => t.type === 'exclude');
     for (const term of excludeTerms) {
-      const excludeConditions = [];
+      const pattern = this.buildLikePattern(term.value, matchMode);
+      if (!pattern) continue;
+
+      const fieldConditions = [];
       for (const field of searchableFields) {
-        excludeConditions.push(`${field} NOT LIKE ?`);
-        params.push(`${term.value}%`);
+        fieldConditions.push(`${field} NOT LIKE ?`);
+        params.push(pattern);
       }
-      if (excludeConditions.length > 0) {
-        sql += ` AND (${excludeConditions.join(' AND ')})`;
+
+      if (fieldConditions.length > 0) {
+        excludeClauses.push(`(${fieldConditions.join(' AND ')})`);
       }
     }
 
-    sql += ' LIMIT 50'; // Limite par table
+    const allConditions = [...conditions, ...excludeClauses];
 
-    try {
-      const rows = await database.query(sql, params);
+    return {
+      conditions: allConditions.join(' AND '),
+      params
+    };
+  }
 
-      for (const row of rows) {
-        const preview = this.buildPreview(row);
-        results.push({
-          table: config.display,
-          database: config.database,
-          preview: preview,
-          primary_keys: { [primaryKey]: row[primaryKey] },
-          score: this.calculateRelevanceScore(row, searchTerms, searchableFields),
-          linkedFields: config.linkedFields || []
-        });
+  buildTermConditions(term, searchableFields, matchMode, params) {
+    const termConditions = [];
+
+    if (term.type === 'exact') {
+      for (const field of searchableFields) {
+        termConditions.push(`${field} = ?`);
+        params.push(term.value);
       }
-    } catch (error) {
-      console.error(`❌ Erreur SQL table ${tableName}:`, error.message);
+      return termConditions;
     }
 
-    return results;
+    const pattern = this.buildLikePattern(term.value, matchMode);
+    if (!pattern) {
+      return termConditions;
+    }
+
+    const pushConditionForField = field => {
+      termConditions.push(`${field} LIKE ?`);
+      params.push(pattern);
+    };
+
+    if (term.type === 'required' || term.type === 'normal') {
+      for (const field of searchableFields) {
+        pushConditionForField(field);
+      }
+    } else if (term.type === 'field') {
+      const termField = term.field.toLowerCase();
+      const matchingFields = searchableFields.filter(field =>
+        field.toLowerCase().includes(termField) ||
+        termField.includes(field.toLowerCase())
+      );
+
+      if (matchingFields.length > 0) {
+        for (const field of matchingFields) {
+          pushConditionForField(field);
+        }
+      } else if (searchableFields.includes(term.field)) {
+        pushConditionForField(term.field);
+      }
+    }
+
+    return termConditions;
+  }
+
+  buildLikePattern(value, matchMode) {
+    if (value === undefined || value === null) {
+      return null;
+    }
+
+    const safeValue = `${value}`.trim();
+    if (safeValue.length === 0) {
+      return null;
+    }
+
+    if (matchMode === 'contains') {
+      return `%${safeValue}%`;
+    }
+
+    return `${safeValue}%`;
   }
 
   buildPreview(record) {


### PR DESCRIPTION
## Summary
- run fast prefix-based queries first and only fall back to contains matching when needed
- refactor search query construction into reusable helpers shared by both match modes
- normalize field matching logic to avoid redundant contains searches and preserve existing filters

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e63a41526883268a0d6d6b998ca257